### PR TITLE
Lock MLflow to 3.7 and default annotation to 15 traces

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ pandas>=2.1.0
 requests>=2.32.4
 rich>=14.0.0
 click>=8.1.0
-mlflow[databricks,genai]>=3.6.0
+mlflow[databricks,genai]==3.7
 cryptography>=41.0.0
 bcrypt>=4.0.0
 PyYAML>=6.0

--- a/server/routers/workshops.py
+++ b/server/routers/workshops.py
@@ -691,8 +691,8 @@ async def begin_annotation_phase(workshop_id: str, request: dict = {}, db: Sessi
   Each user will see the same set of traces, but in a randomized order unique to them."""
   import random
 
-  # Get the optional trace limit from request (default to 10)
-  trace_limit = request.get('trace_limit', 10)
+  # Get the optional trace limit from request (default to 15)
+  trace_limit = request.get('trace_limit', 15)
 
   db_service = DatabaseService(db)
   workshop = db_service.get_workshop(workshop_id)


### PR DESCRIPTION
There seems to be an issue in MLflow 3.8 - I expect it to get resolved, but there's a ticket, and I saw the same error on requests that previously worked with no issues: `A customer is encountering this error on Traces/Assessments while using MLflow version 3.8.0: Databricks model invocation failed with status 400: {"error_code":"BAD_REQUEST","message":"{\n \"error\": {\n \"message\": \"Unknown parameter: 'response_schema'.\",\n \"type\": \"invalid_request_error\",\n \"param\": \"response_schema\",\n \"code\": \"unknown_parameter\"\n }\n}"} by running`

https://databricks.atlassian.net/browse/ES-1684918

Pinning to MLflow version 3.7 until clear that won't happen.

Also upping to 15 annotation traces by default to ensure Alignment can occur, in cases where there's one or two irrelevant or failure traces.