### PR TITLE
Judge tuning per-question persistence, compact toggles, reset annotation

### DIFF
--- a/client/src/components/AnnotationStartPage.tsx
+++ b/client/src/components/AnnotationStartPage.tsx
@@ -213,35 +213,16 @@ export const AnnotationStartPage: React.FC<AnnotationStartPageProps> = ({ onStar
           </RadioGroup>
           
           {/* Randomization Toggle */}
-          <div className="mt-6 pt-4 border-t border-amber-200">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-3">
-                <Shuffle className="w-5 h-5 text-amber-600" />
-                <div>
-                  <Label htmlFor="annotation-randomize-toggle" className="font-medium cursor-pointer">
-                    Randomize Trace Order
-                  </Label>
-                  <div className="text-sm text-slate-600">
-                    Each SME sees traces in a different random order
-                  </div>
-                </div>
-              </div>
-              <Switch
-                id="annotation-randomize-toggle"
-                checked={randomizeTraces}
-                onCheckedChange={setRandomizeTraces}
-              />
-            </div>
-            {!randomizeTraces && (
-              <div className="text-xs text-slate-500 mt-2 ml-8">
-                Default: All SMEs will see traces in the same chronological order
-              </div>
-            )}
-            {randomizeTraces && (
-              <div className="text-xs text-amber-700 mt-2 ml-8">
-                ✓ Randomization enabled: Each SME will see traces in their own unique order
-              </div>
-            )}
+          <div className="mt-4 pt-3 border-t border-amber-200 flex items-center justify-between">
+            <Label htmlFor="annotation-randomize-toggle" className="text-sm text-slate-600 cursor-pointer flex items-center gap-2">
+              <Shuffle className="w-4 h-4 text-amber-600" />
+              Randomize trace order
+            </Label>
+            <Switch
+              id="annotation-randomize-toggle"
+              checked={randomizeTraces}
+              onCheckedChange={setRandomizeTraces}
+            />
           </div>
           
           <div className="mt-4 p-3 bg-purple-100 rounded-lg">

--- a/client/src/components/DiscoveryStartPage.tsx
+++ b/client/src/components/DiscoveryStartPage.tsx
@@ -210,35 +210,16 @@ export const DiscoveryStartPage: React.FC<DiscoveryStartPageProps> = ({ onStartD
           )}
 
           {/* Randomization Toggle */}
-          <div className="mt-6 pt-4 border-t border-amber-200">
-            <div className="flex items-center justify-between p-3 rounded-lg bg-white/50">
-              <div className="flex items-center gap-3">
-                <Shuffle className="w-5 h-5 text-amber-600" />
-                <div>
-                  <Label htmlFor="randomize-toggle" className="font-medium cursor-pointer">
-                    Randomize Trace Order
-                  </Label>
-                  <div className="text-sm text-slate-600">
-                    Each participant sees traces in a different random order
-                  </div>
-                </div>
-              </div>
-              <Switch
-                id="randomize-toggle"
-                checked={randomizeTraces}
-                onCheckedChange={setRandomizeTraces}
-              />
-            </div>
-            {!randomizeTraces && (
-              <div className="text-xs text-slate-500 mt-2 ml-8">
-                Default: All participants will see traces in the same chronological order
-              </div>
-            )}
-            {randomizeTraces && (
-              <div className="text-xs text-amber-700 mt-2 ml-8">
-                ✓ Randomization enabled: Each user will see traces in their own unique order
-              </div>
-            )}
+          <div className="mt-4 pt-3 border-t border-amber-200 flex items-center justify-between">
+            <Label htmlFor="randomize-toggle" className="text-sm text-slate-600 cursor-pointer flex items-center gap-2">
+              <Shuffle className="w-4 h-4 text-amber-600" />
+              Randomize trace order
+            </Label>
+            <Switch
+              id="randomize-toggle"
+              checked={randomizeTraces}
+              onCheckedChange={setRandomizeTraces}
+            />
           </div>
 
           {/* Show current selection info */}

--- a/client/src/components/FacilitatorDashboard.tsx
+++ b/client/src/components/FacilitatorDashboard.tsx
@@ -285,6 +285,7 @@ export const FacilitatorDashboard: React.FC<FacilitatorDashboardProps> = ({ onNa
   const [isAddingTraces, setIsAddingTraces] = React.useState(false);
   const [isReorderingTraces, setIsReorderingTraces] = React.useState(false);
   const [isResettingDiscovery, setIsResettingDiscovery] = React.useState(false);
+  const [isResettingAnnotation, setIsResettingAnnotation] = React.useState(false);
   
   // Judge name state - used for MLflow feedback entries
   const [judgeName, setJudgeName] = React.useState<string>(workshop?.judge_name || 'workshop_judge');
@@ -463,6 +464,39 @@ export const FacilitatorDashboard: React.FC<FacilitatorDashboardProps> = ({ onNa
       toast.error(`Failed to reset discovery: ${error.message}`);
     } finally {
       setIsResettingDiscovery(false);
+    }
+  };
+
+  const handleResetAnnotation = async () => {
+    if (!workshopId) return;
+    
+    setIsResettingAnnotation(true);
+    try {
+      const response = await fetch(`/workshops/${workshopId}/reset-annotation`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+
+      if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.detail || 'Failed to reset annotation');
+      }
+
+      // Invalidate annotation-related caches
+      queryClient.invalidateQueries({ queryKey: ['workshop', workshopId] });
+      queryClient.invalidateQueries({ queryKey: ['annotations', workshopId] });
+      queryClient.invalidateQueries({ queryKey: ['all-traces', workshopId] });
+      
+      toast.success('Annotation reset! All SME progress cleared. Select your trace configuration.');
+      
+      // Force page reload to reflect phase change
+      window.location.reload();
+    } catch (error: any) {
+      toast.error(`Failed to reset annotation: ${error.message}`);
+    } finally {
+      setIsResettingAnnotation(false);
     }
   };
 
@@ -1069,6 +1103,58 @@ export const FacilitatorDashboard: React.FC<FacilitatorDashboardProps> = ({ onNa
                     <div className="flex justify-center">
                       <PhaseControlButton phase="annotation" />
                     </div>
+                  </div>
+
+                  {/* Reset Annotation */}
+                  <div className="border border-purple-200 rounded-lg p-4 bg-purple-50">
+                    <div className="flex items-center gap-2 mb-3">
+                      <RotateCcw className="w-5 h-5 text-purple-600" />
+                      <div className="text-left">
+                        <div className="font-medium text-purple-800">Reset Annotation</div>
+                        <div className="text-xs text-purple-600">Go back to reconfigure trace selection</div>
+                      </div>
+                    </div>
+                    <AlertDialog>
+                      <AlertDialogTrigger asChild>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          disabled={isResettingAnnotation}
+                          className="w-full border-purple-300 text-purple-700 hover:bg-purple-100"
+                        >
+                          {isResettingAnnotation ? (
+                            <>
+                              <div className="w-3 h-3 border border-purple-300 border-t-purple-600 rounded-full animate-spin mr-2" />
+                              Resetting...
+                            </>
+                          ) : (
+                            <>
+                              <RotateCcw className="w-3 h-3 mr-2" />
+                              Reset & Reconfigure
+                            </>
+                          )}
+                        </Button>
+                      </AlertDialogTrigger>
+                      <AlertDialogContent>
+                        <AlertDialogHeader>
+                          <AlertDialogTitle>Reset Annotation Phase?</AlertDialogTitle>
+                          <AlertDialogDescription>
+                            This will reset the annotation phase so you can reconfigure the trace selection and settings.
+                            <br /><br />
+                            <strong>All SME annotations will be cleared.</strong> SMEs will need to start their annotations from the beginning.
+                          </AlertDialogDescription>
+                        </AlertDialogHeader>
+                        <AlertDialogFooter>
+                          <AlertDialogCancel>Cancel</AlertDialogCancel>
+                          <AlertDialogAction 
+                            onClick={handleResetAnnotation}
+                            className="bg-purple-600 hover:bg-purple-700"
+                          >
+                            Reset Annotation
+                          </AlertDialogAction>
+                        </AlertDialogFooter>
+                      </AlertDialogContent>
+                    </AlertDialog>
                   </div>
                 </>
               )}

--- a/server/services/database_service.py
+++ b/server/services/database_service.py
@@ -2529,3 +2529,57 @@ class DatabaseService:
       active_annotation_trace_ids=workshop.active_annotation_trace_ids or [],
       created_at=workshop.created_at,
     )
+
+  def reset_workshop_to_annotation(self, workshop_id: str) -> Optional[Workshop]:
+    """Reset a workshop back to the annotation start page (before annotation was started).
+    
+    This allows changing the annotation configuration (e.g., trace selection, randomization).
+    The phase stays as ANNOTATION but annotation_started is set to False,
+    which causes the UI to show the Annotation Start Page.
+    
+    IMPORTANT: This clears all annotation-related data so SMEs start fresh:
+    - All annotations submitted by SMEs
+    
+    Traces are kept, but SMEs will start fresh from the beginning.
+    
+    Returns the updated workshop or None if not found.
+    """
+    workshop = self.db.query(WorkshopDB).filter(WorkshopDB.id == workshop_id).first()
+    if not workshop:
+      return None
+    
+    # Clear all annotation-related data so SMEs start fresh
+    # Clear annotations submitted by SMEs
+    self.db.query(AnnotationDB).filter(
+      AnnotationDB.workshop_id == workshop_id
+    ).delete(synchronize_session=False)
+    
+    # Keep phase as ANNOTATION but mark annotation as NOT started
+    # This causes the UI to show the Annotation Start Page
+    workshop.current_phase = WorkshopPhase.ANNOTATION
+    workshop.annotation_started = False
+    
+    # Keep completed phases up to discovery (annotation not yet complete)
+    completed = workshop.completed_phases or []
+    workshop.completed_phases = [p for p in completed if p in ['intake', 'discovery']]
+    
+    # Clear active annotation trace list so new selection can be made
+    workshop.active_annotation_trace_ids = None
+    
+    self.db.commit()
+    self.db.refresh(workshop)
+    
+    return Workshop(
+      id=workshop.id,
+      name=workshop.name,
+      description=workshop.description,
+      facilitator_id=workshop.facilitator_id,
+      status=workshop.status,
+      current_phase=workshop.current_phase,
+      completed_phases=workshop.completed_phases or [],
+      discovery_started=workshop.discovery_started or False,
+      annotation_started=workshop.annotation_started or False,
+      active_discovery_trace_ids=workshop.active_discovery_trace_ids or [],
+      active_annotation_trace_ids=workshop.active_annotation_trace_ids or [],
+      created_at=workshop.created_at,
+    )


### PR DESCRIPTION
## Summary
This PR improves the Judge Tuning experience, compacts UI toggles, and adds annotation reset functionality.

## Changes

### Judge Tuning Improvements
- **Per-question evaluation persistence**: Judge scores are now saved per rubric question in localStorage
- When switching between judges (rubric questions), evaluation results are preserved and automatically restored
- Evaluations persist for 24 hours before expiring
- Fixed judge score matching to correctly display results in the evaluation table
- Explicit `judge_type` passed from frontend to backend for accurate MLflow evaluation (binary vs likert)

### UI Improvements
- **Compacted randomization toggles** in Discovery and Annotation start pages
- Removed verbose descriptions - now single-line with icon, label, and switch
- Simplified Judge Tuning UI to dropdown-only rubric question selection

### Reset Annotation Feature
- Added **'Reset Annotation' button** for facilitators in the annotation phase dashboard
- Allows facilitators to go back to annotation configuration page to reconfigure traces
- Clears all SME annotations when reset (with confirmation dialog)
- Backend endpoint: `POST /workshops/{id}/reset-annotation`
- Database method: `reset_workshop_to_annotation()`

### Backend Changes
- Added `judge_type` parameter to `AlignmentRequest` model
- Improved evaluation score handling for different judge types
- New database service method for annotation reset