### PR TITLE
Fix rubric delete not updating UI immediately

### DIFF
--- a/client/src/pages/RubricCreationDemo.tsx
+++ b/client/src/pages/RubricCreationDemo.tsx
@@ -344,8 +344,15 @@ export function RubricCreationDemo() {
       // Immediately update local state to remove the deleted question
       setQuestions(prevQuestions => prevQuestions.filter(q => q.id !== id));
       
-      // Also invalidate queries to ensure consistency
+      // Set editing flag to prevent useEffect from overwriting our local state
+      // when the query is invalidated and refetched
+      setIsEditingExisting(true);
+      
+      // Invalidate queries to ensure backend is in sync
       queryClient.invalidateQueries({ queryKey: ['rubric', workshopId] });
+      
+      // Reset editing flag after a short delay to allow future syncs
+      setTimeout(() => setIsEditingExisting(false), 1000);
       
       toast.success('Question deleted successfully');
     } catch (error) {


### PR DESCRIPTION
When deleting a rubric question, the UI was not updating immediately. The user had to refresh the page to see the deletion.

**Root Cause**: After deleting, we invalidated the query which triggered a refetch. The useEffect that syncs rubric data was overwriting our local state because `isEditingExisting` was false.

**Fix**: Set `isEditingExisting` flag to true during delete to prevent the useEffect from overwriting local state, then reset after a short delay.