### PR TITLE
Smart JSON formatting for arbitrary trace schemas

### DIFF
--- a/client/src/components/TraceViewer.tsx
+++ b/client/src/components/TraceViewer.tsx
@@ -6,6 +6,11 @@
  *
  * Supports optional JSONPath extraction for cleaner display when configured
  * by facilitators via workshop settings.
+ * 
+ * Smart JSON rendering: automatically detects and formats any JSON schema:
+ * - Markdown strings are rendered as formatted markdown
+ * - Nested objects/arrays are shown as collapsible pretty JSON
+ * - URLs are rendered as clickable links
  */
 
 import React, { useState, useMemo } from 'react';
@@ -25,8 +30,8 @@ import {
   Database,
   RefreshCw,
   Link,
-  Brain,
-  Info
+  Code,
+  Hash
 } from "lucide-react";
 import { toast } from 'sonner';
 import { useInvalidateTraces, useWorkshop } from '@/hooks/useWorkshopApi';
@@ -34,59 +39,394 @@ import { useMLflowConfig } from '@/hooks/useWorkshopApi';
 import { useWorkshopContext } from '@/context/WorkshopContext';
 import { useJsonPathExtraction } from '@/hooks/useJsonPathExtraction';
 
-// Interface for parsed structured output
-interface ParsedStructuredOutput {
-  answer: string;
-  annotations?: {
-    url_citations?: Array<{
-      url: string;
-      title: string;
-      type?: string;
-    }>;
-    [key: string]: any;
-  };
-  state?: any;
-  trajectory?: any;
-  [key: string]: any;
-}
+// ============================================================================
+// SMART JSON RENDERER - Handles arbitrary JSON schemas
+// ============================================================================
 
-// Collapsible JSON section component
-const CollapsibleJsonSection: React.FC<{
-  title: string;
-  icon: React.ReactNode;
-  data: any;
-  defaultExpanded?: boolean;
-  colorClass?: string;
-}> = ({ title, icon, data, defaultExpanded = false, colorClass = 'text-gray-600' }) => {
-  const [expanded, setExpanded] = useState(defaultExpanded);
+/**
+ * Detect if a string looks like markdown content
+ */
+const isMarkdownContent = (str: string): boolean => {
+  if (!str || typeof str !== 'string') return false;
   
-  if (!data || (typeof data === 'object' && Object.keys(data).length === 0)) {
-    return null;
+  // Check for common markdown patterns
+  const markdownPatterns = [
+    /^#{1,6}\s+/m,           // Headers: # Header
+    /\*\*[^*]+\*\*/,         // Bold: **text**
+    /\*[^*]+\*/,             // Italic: *text*
+    /^\s*[-*+]\s+/m,         // Unordered lists: - item
+    /^\s*\d+\.\s+/m,         // Ordered lists: 1. item
+    /\[.+\]\(.+\)/,          // Links: [text](url)
+    /```[\s\S]*```/,         // Code blocks: ```code```
+    /`[^`]+`/,               // Inline code: `code`
+    /^\s*>\s+/m,             // Blockquotes: > quote
+    /\|.+\|/,                // Tables: | cell |
+    /\n\n/,                  // Multiple paragraphs
+  ];
+  
+  // If the string has multiple markdown patterns, it's likely markdown
+  const matchCount = markdownPatterns.filter(pattern => pattern.test(str)).length;
+  return matchCount >= 2 || str.length > 200; // Long text or multiple patterns
+};
+
+/**
+ * Check if a string is a URL
+ */
+const isUrl = (str: string): boolean => {
+  if (!str || typeof str !== 'string') return false;
+  try {
+    const url = new URL(str);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
   }
+};
+
+/**
+ * Check if a string looks like JSON
+ */
+const isJsonString = (str: string): boolean => {
+  if (!str || typeof str !== 'string') return false;
+  const trimmed = str.trim();
+  return (trimmed.startsWith('{') && trimmed.endsWith('}')) ||
+         (trimmed.startsWith('[') && trimmed.endsWith(']'));
+};
+
+/**
+ * Try to parse a string as JSON
+ */
+const tryParseJson = (str: string): { success: boolean; data: any } => {
+  try {
+    const data = JSON.parse(str);
+    return { success: true, data };
+  } catch {
+    return { success: false, data: null };
+  }
+};
+
+/**
+ * Format a field name for display (convert camelCase/snake_case to Title Case)
+ */
+const formatFieldName = (name: string): string => {
+  return name
+    .replace(/_/g, ' ')
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/\b\w/g, c => c.toUpperCase());
+};
+
+/**
+ * Collapsible section for any content
+ */
+const CollapsibleSection: React.FC<{
+  title: string;
+  defaultExpanded?: boolean;
+  children: React.ReactNode;
+  badge?: string;
+}> = ({ title, defaultExpanded = false, children, badge }) => {
+  const [expanded, setExpanded] = useState(defaultExpanded);
 
   return (
-    <div className="border rounded-lg overflow-hidden">
+    <div className="border rounded-lg overflow-hidden bg-white">
       <Button
         variant="ghost"
         onClick={() => setExpanded(!expanded)}
-        className={`w-full flex items-center justify-between p-3 h-auto ${colorClass} hover:bg-gray-50`}
+        className="w-full flex items-center justify-between p-3 h-auto text-gray-700 hover:bg-gray-50"
       >
         <div className="flex items-center gap-2">
-          {icon}
+          <Code className="h-4 w-4 text-gray-500" />
           <span className="font-medium text-sm">{title}</span>
+          {badge && (
+            <span className="text-xs bg-gray-100 text-gray-600 px-1.5 py-0.5 rounded">
+              {badge}
+            </span>
+          )}
         </div>
         {expanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
       </Button>
       {expanded && (
         <div className="border-t bg-gray-50 p-3 max-h-96 overflow-auto">
-          <pre className="text-xs text-gray-700 whitespace-pre-wrap font-mono">
-            {JSON.stringify(data, null, 2)}
-          </pre>
+          {children}
         </div>
       )}
     </div>
   );
 };
+
+/**
+ * Smart renderer for any value - recursively handles objects, arrays, strings
+ */
+const SmartValueRenderer: React.FC<{
+  value: any;
+  fieldName?: string;
+  depth?: number;
+  defaultExpanded?: boolean;
+}> = ({ value, fieldName, depth = 0, defaultExpanded = false }) => {
+  // Handle null/undefined
+  if (value === null || value === undefined) {
+    return <span className="text-gray-400 italic">null</span>;
+  }
+
+  // Handle booleans
+  if (typeof value === 'boolean') {
+    return (
+      <span className={value ? 'text-green-600' : 'text-red-600'}>
+        {value.toString()}
+      </span>
+    );
+  }
+
+  // Handle numbers
+  if (typeof value === 'number') {
+    return <span className="text-blue-600">{value}</span>;
+  }
+
+  // Handle strings
+  if (typeof value === 'string') {
+    // Check if it's a URL
+    if (isUrl(value)) {
+      return (
+        <a
+          href={value}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-blue-600 hover:underline flex items-center gap-1 break-all"
+        >
+          <ExternalLink className="h-3 w-3 flex-shrink-0" />
+          {value}
+        </a>
+      );
+    }
+
+    // Check if it's embedded JSON
+    if (isJsonString(value)) {
+      const { success, data } = tryParseJson(value);
+      if (success) {
+        return (
+          <CollapsibleSection 
+            title={fieldName ? formatFieldName(fieldName) : 'JSON Data'} 
+            badge="JSON"
+            defaultExpanded={defaultExpanded}
+          >
+            <SmartValueRenderer value={data} depth={depth + 1} />
+          </CollapsibleSection>
+        );
+      }
+    }
+
+    // Check if it's markdown
+    if (isMarkdownContent(value)) {
+      return (
+        <div className="prose prose-sm max-w-none text-gray-800">
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>
+            {value}
+          </ReactMarkdown>
+        </div>
+      );
+    }
+
+    // Plain string
+    return <span className="text-gray-800 whitespace-pre-wrap">{value}</span>;
+  }
+
+  // Handle arrays
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return <span className="text-gray-400 italic">[]</span>;
+    }
+
+    // Check if it's an array of simple values
+    const isSimpleArray = value.every(v => 
+      typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean'
+    );
+
+    if (isSimpleArray && value.length <= 5) {
+      return (
+        <div className="flex flex-wrap gap-1">
+          {value.map((item, idx) => (
+            <span key={idx} className="bg-gray-100 px-2 py-0.5 rounded text-sm">
+              <SmartValueRenderer value={item} depth={depth + 1} />
+            </span>
+          ))}
+        </div>
+      );
+    }
+
+    // Complex array - show as collapsible
+    return (
+      <CollapsibleSection 
+        title={fieldName ? formatFieldName(fieldName) : 'Array'} 
+        badge={`${value.length} items`}
+        defaultExpanded={defaultExpanded || depth === 0}
+      >
+        <div className="space-y-2">
+          {value.map((item, idx) => (
+            <div key={idx} className="border-l-2 border-gray-200 pl-3">
+              <div className="text-xs text-gray-500 mb-1">Item {idx + 1}</div>
+              <SmartValueRenderer value={item} depth={depth + 1} />
+            </div>
+          ))}
+        </div>
+      </CollapsibleSection>
+    );
+  }
+
+  // Handle objects
+  if (typeof value === 'object') {
+    const entries = Object.entries(value);
+    
+    if (entries.length === 0) {
+      return <span className="text-gray-400 italic">{'{}'}</span>;
+    }
+
+    // Identify "main content" fields that should be rendered prominently
+    const mainContentKeys = ['answer', 'response', 'result', 'output', 'content', 'text', 'message'];
+    const mainEntry = entries.find(([key]) => mainContentKeys.includes(key.toLowerCase()));
+    const otherEntries = entries.filter(([key]) => !mainContentKeys.includes(key.toLowerCase()));
+
+    // If we're at the top level and there's a main content field, show it prominently
+    if (depth === 0 && mainEntry) {
+      return (
+        <div className="space-y-4">
+          {/* Main content rendered prominently */}
+          <div>
+            <SmartValueRenderer value={mainEntry[1]} fieldName={mainEntry[0]} depth={depth + 1} defaultExpanded />
+          </div>
+          
+          {/* Other fields as collapsible sections */}
+          {otherEntries.length > 0 && (
+            <div className="space-y-2 mt-4 pt-4 border-t">
+              <div className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-2">
+                Additional Data
+              </div>
+              {otherEntries.map(([key, val]) => (
+                <SmartObjectField key={key} fieldKey={key} value={val} depth={depth + 1} />
+              ))}
+            </div>
+          )}
+        </div>
+      );
+    }
+
+    // For nested objects, show all fields
+    return (
+      <div className="space-y-2">
+        {entries.map(([key, val]) => (
+          <SmartObjectField key={key} fieldKey={key} value={val} depth={depth + 1} />
+        ))}
+      </div>
+    );
+  }
+
+  // Fallback - stringify
+  return <span className="text-gray-600">{String(value)}</span>;
+};
+
+/**
+ * Render a single object field with smart formatting
+ */
+const SmartObjectField: React.FC<{
+  fieldKey: string;
+  value: any;
+  depth: number;
+}> = ({ fieldKey, value, depth }) => {
+  const [expanded, setExpanded] = useState(false);
+  
+  // Determine if this field should be collapsible
+  const isComplexValue = typeof value === 'object' && value !== null;
+  const isLongString = typeof value === 'string' && value.length > 200;
+  const shouldCollapse = isComplexValue || isLongString;
+
+  // Check if string value is markdown or JSON
+  const isMarkdown = typeof value === 'string' && isMarkdownContent(value);
+  const valueIsJson = typeof value === 'string' && isJsonString(value);
+
+  if (shouldCollapse) {
+    const badge = Array.isArray(value) 
+      ? `${value.length} items` 
+      : isMarkdown 
+        ? 'Markdown' 
+        : valueIsJson 
+          ? 'JSON' 
+          : typeof value === 'object' 
+            ? `${Object.keys(value).length} fields` 
+            : undefined;
+
+    return (
+      <div className="border rounded-lg overflow-hidden bg-white">
+        <Button
+          variant="ghost"
+          onClick={() => setExpanded(!expanded)}
+          className="w-full flex items-center justify-between p-2 h-auto text-gray-700 hover:bg-gray-50"
+        >
+          <div className="flex items-center gap-2">
+            <Hash className="h-3 w-3 text-gray-400" />
+            <span className="font-medium text-sm">{formatFieldName(fieldKey)}</span>
+            {badge && (
+              <span className="text-xs bg-gray-100 text-gray-500 px-1.5 py-0.5 rounded">
+                {badge}
+              </span>
+            )}
+          </div>
+          {expanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+        </Button>
+        {expanded && (
+          <div className="border-t bg-gray-50 p-3 max-h-96 overflow-auto">
+            <SmartValueRenderer value={value} fieldName={fieldKey} depth={depth} />
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // Simple value - show inline
+  return (
+    <div className="flex items-start gap-2 py-1">
+      <span className="text-sm font-medium text-gray-600 min-w-0 flex-shrink-0">
+        {formatFieldName(fieldKey)}:
+      </span>
+      <div className="flex-1 min-w-0">
+        <SmartValueRenderer value={value} depth={depth} />
+      </div>
+    </div>
+  );
+};
+
+/**
+ * Main smart JSON renderer - entry point for rendering any JSON data
+ */
+const SmartJsonRenderer: React.FC<{
+  data: string;
+  fallbackRenderer?: (data: string) => React.ReactNode;
+}> = ({ data, fallbackRenderer }) => {
+  // Try to parse as JSON
+  const { success, data: parsed } = tryParseJson(data);
+  
+  if (success) {
+    return <SmartValueRenderer value={parsed} depth={0} defaultExpanded />;
+  }
+  
+  // Not JSON - check if it's markdown
+  if (isMarkdownContent(data)) {
+    return (
+      <div className="prose prose-sm max-w-none text-gray-800">
+        <ReactMarkdown remarkPlugins={[remarkGfm]}>
+          {data}
+        </ReactMarkdown>
+      </div>
+    );
+  }
+  
+  // Use fallback or show as plain text
+  if (fallbackRenderer) {
+    return <>{fallbackRenderer(data)}</>;
+  }
+  
+  return <span className="text-gray-800 whitespace-pre-wrap">{data}</span>;
+};
+
+// ============================================================================
+// LEGACY COMPONENTS (kept for backward compatibility)
+// ============================================================================
 
 // Citations display component
 const CitationsDisplay: React.FC<{
@@ -138,6 +478,10 @@ const CitationsDisplay: React.FC<{
   );
 };
 
+// ============================================================================
+// TRACE VIEWER COMPONENT
+// ============================================================================
+
 export interface TraceData {
   id: string;
   input: string;
@@ -181,115 +525,27 @@ export const TraceViewer: React.FC<TraceViewerProps> = ({
   const effectiveOutputJsonPath = outputJsonPath ?? workshop?.output_jsonpath;
 
   // Apply JSONPath extraction to input and output
-  const rawDisplayInput = useJsonPathExtraction(trace.input, effectiveInputJsonPath);
-  const rawDisplayOutput = useJsonPathExtraction(trace.output, effectiveOutputJsonPath);
+  const displayInput = useJsonPathExtraction(trace.input, effectiveInputJsonPath);
+  const displayOutput = useJsonPathExtraction(trace.output, effectiveOutputJsonPath);
 
-  // Parse structured input for smart rendering
-  const parsedInput = useMemo((): { isStructured: boolean; userMessage: string; context: any; state: any; rawText: string } => {
+  // Check if input/output are JSON for badge display
+  const isInputJson = useMemo(() => {
     try {
-      const parsed = JSON.parse(rawDisplayInput);
-      
-      if (typeof parsed === 'object' && parsed !== null) {
-        // Pattern 1: {"args": [[{"role": "user", "content": "...", "type": "message"}]], "context": {}, "state": {}}
-        if ('args' in parsed && Array.isArray(parsed.args)) {
-          const messages = parsed.args.flat().filter((m: any) => m && typeof m === 'object');
-          const userMessages = messages
-            .filter((m: any) => m.role === 'user' || m.type === 'message')
-            .map((m: any) => m.content || m.text || '')
-            .filter(Boolean);
-          
-          if (userMessages.length > 0) {
-            return {
-              isStructured: true,
-              userMessage: userMessages.join('\n\n'),
-              context: parsed.context,
-              state: parsed.state,
-              rawText: rawDisplayInput
-            };
-          }
-        }
-        
-        // Pattern 2: {"messages": [{"role": "user", "content": "..."}], ...}
-        if ('messages' in parsed && Array.isArray(parsed.messages)) {
-          const userMessages = parsed.messages
-            .filter((m: any) => m.role === 'user')
-            .map((m: any) => m.content || '')
-            .filter(Boolean);
-          
-          if (userMessages.length > 0) {
-            return {
-              isStructured: true,
-              userMessage: userMessages.join('\n\n'),
-              context: parsed.context,
-              state: parsed.state,
-              rawText: rawDisplayInput
-            };
-          }
-        }
-        
-        // Pattern 3: {"input": "...", ...} or {"query": "...", ...} or {"question": "...", ...}
-        const inputContent = parsed.input || parsed.query || parsed.question || parsed.prompt;
-        if (typeof inputContent === 'string') {
-          return {
-            isStructured: true,
-            userMessage: inputContent,
-            context: parsed.context,
-            state: parsed.state,
-            rawText: rawDisplayInput
-          };
-        }
-      }
-      
-      return { isStructured: false, userMessage: rawDisplayInput, context: null, state: null, rawText: rawDisplayInput };
+      JSON.parse(displayInput);
+      return true;
     } catch {
-      return { isStructured: false, userMessage: rawDisplayInput, context: null, state: null, rawText: rawDisplayInput };
+      return false;
     }
-  }, [rawDisplayInput]);
+  }, [displayInput]);
 
-  // Get the main display text for input
-  const displayInput = parsedInput.userMessage;
-
-  // Parse structured output for smart rendering
-  const parsedOutput = useMemo((): { isStructured: boolean; data: ParsedStructuredOutput | null; rawText: string } => {
+  const isOutputJson = useMemo(() => {
     try {
-      const parsed = JSON.parse(rawDisplayOutput);
-      
-      // Check if it's a structured agent response with answer field
-      if (typeof parsed === 'object' && parsed !== null) {
-        // Common patterns for agent responses
-        if ('answer' in parsed || 'response' in parsed || 'result' in parsed || 'output' in parsed) {
-          const answer = parsed.answer || parsed.response || parsed.result || parsed.output || '';
-          return {
-            isStructured: true,
-            data: {
-              answer: typeof answer === 'string' ? answer : JSON.stringify(answer, null, 2),
-              annotations: parsed.annotations,
-              state: parsed.state,
-              trajectory: parsed.trajectory,
-              // Capture any other fields
-              ...Object.fromEntries(
-                Object.entries(parsed).filter(([key]) => 
-                  !['answer', 'response', 'result', 'output', 'annotations', 'state', 'trajectory'].includes(key)
-                )
-              )
-            },
-            rawText: rawDisplayOutput
-          };
-        }
-      }
-      
-      // Not a structured response, just return raw
-      return { isStructured: false, data: null, rawText: rawDisplayOutput };
+      JSON.parse(displayOutput);
+      return true;
     } catch {
-      // Not JSON, return as plain text
-      return { isStructured: false, data: null, rawText: rawDisplayOutput };
+      return false;
     }
-  }, [rawDisplayOutput]);
-
-  // Get the main display text (answer for structured, raw for plain)
-  const displayOutput = parsedOutput.isStructured && parsedOutput.data 
-    ? parsedOutput.data.answer 
-    : parsedOutput.rawText;
+  }, [displayOutput]);
 
   const handleRefresh = () => {
     invalidateTraces();
@@ -435,40 +691,15 @@ export const TraceViewer: React.FC<TraceViewerProps> = ({
           <div className="flex items-center gap-2">
             <User className="h-4 w-4 text-blue-600" />
             <span className="font-medium text-blue-800">Input</span>
-            {parsedInput.isStructured && (
+            {isInputJson && (
               <span className="text-xs bg-blue-100 text-blue-700 px-2 py-0.5 rounded">
-                Structured Request
+                Structured
               </span>
             )}
           </div>
           <div className="bg-blue-50 border-l-4 border-blue-400 p-4 rounded-r-lg">
-            <div className="text-gray-800 leading-relaxed prose prose-sm max-w-none">
-              <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                {displayInput}
-              </ReactMarkdown>
-            </div>
+            <SmartJsonRenderer data={displayInput} />
           </div>
-
-          {/* Structured Input Metadata Sections */}
-          {parsedInput.isStructured && (parsedInput.context || parsedInput.state) && (
-            <div className="space-y-2 mt-2">
-              {/* Context */}
-              <CollapsibleJsonSection
-                title="Request Context"
-                icon={<Info className="h-4 w-4" />}
-                data={parsedInput.context}
-                colorClass="text-blue-600"
-              />
-
-              {/* State */}
-              <CollapsibleJsonSection
-                title="Request State"
-                icon={<Database className="h-4 w-4" />}
-                data={parsedInput.state}
-                colorClass="text-blue-500"
-              />
-            </div>
-          )}
         </div>
 
         {/* Output */}
@@ -476,77 +707,15 @@ export const TraceViewer: React.FC<TraceViewerProps> = ({
           <div className="flex items-center gap-2">
             <Bot className="h-4 w-4 text-green-600" />
             <span className="font-medium text-green-800">Output</span>
-            {parsedOutput.isStructured && (
+            {isOutputJson && (
               <span className="text-xs bg-green-100 text-green-700 px-2 py-0.5 rounded">
-                Structured Response
+                Structured
               </span>
             )}
           </div>
-          
-          {/* Main Answer/Response */}
           <div className="bg-green-50 border-l-4 border-green-400 p-4 rounded-r-lg">
-            <div className="text-gray-800 leading-relaxed prose prose-sm max-w-none">
-              <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                {displayOutput}
-              </ReactMarkdown>
-            </div>
+            <SmartJsonRenderer data={displayOutput} />
           </div>
-
-          {/* Structured Output Metadata Sections */}
-          {parsedOutput.isStructured && parsedOutput.data && (
-            <div className="space-y-2 mt-4">
-              {/* Citations */}
-              {parsedOutput.data.annotations?.url_citations && (
-                <CitationsDisplay citations={parsedOutput.data.annotations.url_citations} />
-              )}
-
-              {/* Trajectory/Reasoning */}
-              <CollapsibleJsonSection
-                title="Agent Reasoning & Trajectory"
-                icon={<Brain className="h-4 w-4" />}
-                data={parsedOutput.data.trajectory}
-                colorClass="text-purple-600"
-              />
-
-              {/* State */}
-              <CollapsibleJsonSection
-                title="State Information"
-                icon={<Info className="h-4 w-4" />}
-                data={parsedOutput.data.state}
-                colorClass="text-amber-600"
-              />
-
-              {/* Other annotations (non-citation) */}
-              {parsedOutput.data.annotations && 
-               Object.keys(parsedOutput.data.annotations).filter(k => k !== 'url_citations').length > 0 && (
-                <CollapsibleJsonSection
-                  title="Additional Annotations"
-                  icon={<FileText className="h-4 w-4" />}
-                  data={Object.fromEntries(
-                    Object.entries(parsedOutput.data.annotations).filter(([k]) => k !== 'url_citations')
-                  )}
-                  colorClass="text-gray-600"
-                />
-              )}
-
-              {/* Any other fields */}
-              {(() => {
-                const otherFields = Object.fromEntries(
-                  Object.entries(parsedOutput.data).filter(([key]) => 
-                    !['answer', 'annotations', 'state', 'trajectory'].includes(key)
-                  )
-                );
-                return Object.keys(otherFields).length > 0 ? (
-                  <CollapsibleJsonSection
-                    title="Additional Data"
-                    icon={<Database className="h-4 w-4" />}
-                    data={otherFields}
-                    colorClass="text-gray-500"
-                  />
-                ) : null;
-              })()}
-            </div>
-          )}
         </div>
       </CardContent>
     </Card>


### PR DESCRIPTION
## Summary
The TraceViewer now intelligently handles **any JSON schema** without requiring predefined field names.

## How it works

### Automatic Detection
- **Markdown strings**: Detected by patterns (headers, lists, code blocks, etc.) and rendered with proper formatting
- **URLs**: Automatically detected and rendered as clickable links
- **Nested JSON**: Objects and arrays are shown as collapsible sections with pretty-printed JSON
- **Plain strings**: Rendered as-is

### Smart Content Promotion
Fields commonly containing main content (`answer`, `response`, `result`, `content`, `text`, `message`, `output`) are rendered prominently at the top, while all other fields are shown in collapsible sections below.

### Recursive Rendering
The renderer handles deeply nested structures - if a string field contains JSON, it's automatically parsed and rendered with the same smart formatting.

## Example
For input like:
```json
{"args": [[{"role": "user", "content": "What is TCO?"}]], "context": {}, "state": {}}
```

The viewer will:
1. Show the user message prominently: "What is TCO?"
2. Show "args", "context", "state" as collapsible sections

For output like:
```json
{"answer": "## TCO Analysis\n\n...", "trajectory": {...}, "state": {...}}
```

The viewer will:
1. Render the markdown answer with proper formatting
2. Show trajectory/state as collapsible pretty JSON sections