### PR TITLE
fix: remove hardcoded localhost URLs to use Vite proxy

### DIFF
--- a/client/src/pages/RubricCreationDemo.tsx
+++ b/client/src/pages/RubricCreationDemo.tsx
@@ -305,7 +305,7 @@ export function RubricCreationDemo() {
       };
       
       const method = rubric ? 'PUT' : 'POST';
-      const url = `http://localhost:8000/workshops/${workshopId}/rubric`;
+      const url = `/workshops/${workshopId}/rubric`;
       
       console.log('Starting fetch:', method, url);
       fetch(url, {
@@ -348,8 +348,8 @@ export function RubricCreationDemo() {
       // This provides instant UI feedback
       setQuestions(prevQuestions => prevQuestions.filter(q => q.id !== id));
       
-      // Call the delete endpoint directly (bypass slow Vite proxy)
-      const response = await fetch(`http://localhost:8000/workshops/${workshopId}/rubric/questions/${id}`, {
+      // Call the delete endpoint
+      const response = await fetch(`/workshops/${workshopId}/rubric/questions/${id}`, {
         method: 'DELETE',
         headers: {
           'Content-Type': 'application/json',

--- a/client/src/pages/WelcomePage.tsx
+++ b/client/src/pages/WelcomePage.tsx
@@ -152,7 +152,7 @@ export function WelcomePage() {
 
               <Button asChild className="w-full">
                 <a
-                  href="http://localhost:8000/docs"
+                  href="/docs"
                   target="_blank"
                   rel="noopener noreferrer"
                 >
@@ -463,7 +463,7 @@ export function WelcomePage() {
           <p className="text-muted-foreground">
             Ready to build something amazing? Check out the{" "}
             <a
-              href="http://localhost:8000/docs"
+              href="/docs"
               target="_blank"
               rel="noopener noreferrer"
               className="text-blue-600 hover:underline"


### PR DESCRIPTION
## Summary
Remove hardcoded `http://localhost:8000` URLs that cause CORS errors when deployed to Databricks Apps.

## Changes
- **RubricCreationDemo.tsx**: Use relative `/workshops/...` paths instead of `http://localhost:8000/...`
- **WelcomePage.tsx**: Use relative `/docs` path for API documentation links

## Why
When deployed to Databricks Apps, the frontend is served from a different domain (databricksapps.com). Hardcoded localhost URLs:
1. Don't work because there's no localhost:8000 server
2. Get blocked by CORS policy

Using relative paths ensures requests go through:
- **Development**: Vite's proxy (configured in vite.config.ts)
- **Production**: Same-origin server on Databricks Apps