### PR TITLE
Add unit tests for multiple rubric questions and judge types

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -6,10 +6,10 @@ on:
 
 jobs:
   e2e-test:
-    runs-on: 
+    runs-on:
       group: databricks-solutions-protected-runner-group
       labels: linux-ubuntu-latest
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -47,9 +47,14 @@ jobs:
         run: |
           # Set up environment
           export ENVIRONMENT=development
-          
+
           # Run e2e tests using just
           uv run just e2e headless 1
+        env:
+          CI: true
+
+      - name: Run Python unit tests
+        run: uv run just test-server
         env:
           CI: true
 

--- a/client/src/components/JudgeTypeSelector.test.tsx
+++ b/client/src/components/JudgeTypeSelector.test.tsx
@@ -1,0 +1,253 @@
+// @spec JUDGE_EVALUATION_SPEC
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { JudgeTypeSelector, defaultPromptTemplates, binaryLabelPresets } from './JudgeTypeSelector';
+
+describe('@spec:JUDGE_EVALUATION_SPEC JudgeTypeSelector', () => {
+  describe('Rendering', () => {
+    it('renders all three judge type cards', () => {
+      render(
+        <JudgeTypeSelector
+          selectedType="likert"
+          onTypeChange={() => {}}
+        />
+      );
+
+      expect(screen.getByText('Likert Scale Judge')).toBeInTheDocument();
+      expect(screen.getByText('Binary Judge')).toBeInTheDocument();
+      expect(screen.getByText('Free-form Feedback')).toBeInTheDocument();
+    });
+
+    it('displays descriptions for each judge type', () => {
+      render(
+        <JudgeTypeSelector
+          selectedType="likert"
+          onTypeChange={() => {}}
+        />
+      );
+
+      expect(screen.getByText('Rubric-based scoring with 1-5 scale ratings')).toBeInTheDocument();
+      expect(screen.getByText('Simple pass/fail or yes/no evaluation')).toBeInTheDocument();
+      expect(screen.getByText('Open-ended qualitative analysis')).toBeInTheDocument();
+    });
+
+    it('shows features for Likert judge', () => {
+      render(
+        <JudgeTypeSelector
+          selectedType="likert"
+          onTypeChange={() => {}}
+        />
+      );
+
+      expect(screen.getByText('1-5 Likert scale ratings')).toBeInTheDocument();
+      expect(screen.getByText('Multiple evaluation criteria')).toBeInTheDocument();
+      expect(screen.getByText('Detailed rubric alignment')).toBeInTheDocument();
+    });
+
+    it('shows features for Binary judge', () => {
+      render(
+        <JudgeTypeSelector
+          selectedType="binary"
+          onTypeChange={() => {}}
+        />
+      );
+
+      expect(screen.getByText('Pass/Fail decisions')).toBeInTheDocument();
+      expect(screen.getByText('Custom label support')).toBeInTheDocument();
+      expect(screen.getByText('High-speed evaluation')).toBeInTheDocument();
+    });
+
+    it('shows features for Free-form judge', () => {
+      render(
+        <JudgeTypeSelector
+          selectedType="freeform"
+          onTypeChange={() => {}}
+        />
+      );
+
+      expect(screen.getByText('Detailed text feedback')).toBeInTheDocument();
+      expect(screen.getByText('Qualitative insights')).toBeInTheDocument();
+      expect(screen.getByText('Flexible format')).toBeInTheDocument();
+    });
+
+    it('shows use cases for each judge type', () => {
+      render(
+        <JudgeTypeSelector
+          selectedType="likert"
+          onTypeChange={() => {}}
+        />
+      );
+
+      // Likert use cases
+      expect(screen.getByText('Quality evaluation')).toBeInTheDocument();
+
+      // Binary use cases
+      expect(screen.getByText('Safety checks')).toBeInTheDocument();
+
+      // Freeform use cases
+      expect(screen.getByText('Improvement suggestions')).toBeInTheDocument();
+    });
+  });
+
+  describe('Selection behavior', () => {
+    it('calls onTypeChange when clicking Likert card', () => {
+      const onTypeChange = vi.fn();
+      render(
+        <JudgeTypeSelector
+          selectedType="binary"
+          onTypeChange={onTypeChange}
+        />
+      );
+
+      fireEvent.click(screen.getByText('Likert Scale Judge'));
+      expect(onTypeChange).toHaveBeenCalledWith('likert');
+    });
+
+    it('calls onTypeChange when clicking Binary card', () => {
+      const onTypeChange = vi.fn();
+      render(
+        <JudgeTypeSelector
+          selectedType="likert"
+          onTypeChange={onTypeChange}
+        />
+      );
+
+      fireEvent.click(screen.getByText('Binary Judge'));
+      expect(onTypeChange).toHaveBeenCalledWith('binary');
+    });
+
+    it('calls onTypeChange when clicking Free-form card', () => {
+      const onTypeChange = vi.fn();
+      render(
+        <JudgeTypeSelector
+          selectedType="likert"
+          onTypeChange={onTypeChange}
+        />
+      );
+
+      fireEvent.click(screen.getByText('Free-form Feedback'));
+      expect(onTypeChange).toHaveBeenCalledWith('freeform');
+    });
+
+    it('highlights selected type with checkmark', () => {
+      const { container } = render(
+        <JudgeTypeSelector
+          selectedType="binary"
+          onTypeChange={() => {}}
+        />
+      );
+
+      // The selected card should have ring-2 ring-primary class
+      const binaryCard = screen.getByText('Binary Judge').closest('div[class*="cursor-pointer"]');
+      expect(binaryCard).toHaveClass('ring-2');
+    });
+  });
+
+  describe('Disabled state', () => {
+    it('does not call onTypeChange when disabled', () => {
+      const onTypeChange = vi.fn();
+      render(
+        <JudgeTypeSelector
+          selectedType="likert"
+          onTypeChange={onTypeChange}
+          disabled={true}
+        />
+      );
+
+      fireEvent.click(screen.getByText('Binary Judge'));
+      expect(onTypeChange).not.toHaveBeenCalled();
+    });
+
+    it('applies opacity styling when disabled', () => {
+      const { container } = render(
+        <JudgeTypeSelector
+          selectedType="likert"
+          onTypeChange={() => {}}
+          disabled={true}
+        />
+      );
+
+      const cards = container.querySelectorAll('[class*="cursor-not-allowed"]');
+      expect(cards.length).toBe(3);
+    });
+  });
+});
+
+describe('@spec:JUDGE_EVALUATION_SPEC defaultPromptTemplates', () => {
+  describe('Likert template', () => {
+    it('includes 1-5 scale rating instructions', () => {
+      expect(defaultPromptTemplates.likert).toContain('1-5');
+      expect(defaultPromptTemplates.likert).toContain('1 = Poor');
+      expect(defaultPromptTemplates.likert).toContain('5 = Excellent');
+    });
+
+    it('includes rubric placeholder', () => {
+      expect(defaultPromptTemplates.likert).toContain('{rubric}');
+    });
+
+    it('includes input and output placeholders', () => {
+      expect(defaultPromptTemplates.likert).toContain('{input}');
+      expect(defaultPromptTemplates.likert).toContain('{output}');
+    });
+  });
+
+  describe('Binary template', () => {
+    it('includes 0/1 rating instructions', () => {
+      expect(defaultPromptTemplates.binary).toContain('0:');
+      expect(defaultPromptTemplates.binary).toContain('1:');
+      expect(defaultPromptTemplates.binary).toContain('PASS');
+      expect(defaultPromptTemplates.binary).toContain('FAIL');
+    });
+
+    it('includes criteria placeholder', () => {
+      expect(defaultPromptTemplates.binary).toContain('{criteria}');
+    });
+
+    it('includes example format', () => {
+      expect(defaultPromptTemplates.binary).toContain('Example format');
+    });
+  });
+
+  describe('Freeform template', () => {
+    it('includes qualitative feedback instructions', () => {
+      expect(defaultPromptTemplates.freeform).toContain('Strengths');
+      expect(defaultPromptTemplates.freeform).toContain('Areas for improvement');
+      expect(defaultPromptTemplates.freeform).toContain('suggestions');
+    });
+
+    it('includes focus placeholder', () => {
+      expect(defaultPromptTemplates.freeform).toContain('{focus}');
+    });
+  });
+});
+
+describe('@spec:JUDGE_EVALUATION_SPEC binaryLabelPresets', () => {
+  it('has pass_fail preset', () => {
+    expect(binaryLabelPresets.pass_fail).toEqual({ pass: 'Pass', fail: 'Fail' });
+  });
+
+  it('has yes_no preset', () => {
+    expect(binaryLabelPresets.yes_no).toEqual({ pass: 'Yes', fail: 'No' });
+  });
+
+  it('has accept_reject preset', () => {
+    expect(binaryLabelPresets.accept_reject).toEqual({ pass: 'Accept', fail: 'Reject' });
+  });
+
+  it('has safe_unsafe preset', () => {
+    expect(binaryLabelPresets.safe_unsafe).toEqual({ pass: 'Safe', fail: 'Unsafe' });
+  });
+
+  it('has compliant_violation preset', () => {
+    expect(binaryLabelPresets.compliant_violation).toEqual({ pass: 'Compliant', fail: 'Violation' });
+  });
+
+  it('all presets have pass and fail keys', () => {
+    Object.values(binaryLabelPresets).forEach(preset => {
+      expect(preset).toHaveProperty('pass');
+      expect(preset).toHaveProperty('fail');
+      expect(typeof preset.pass).toBe('string');
+      expect(typeof preset.fail).toBe('string');
+    });
+  });
+});

--- a/client/src/components/Pagination.test.tsx
+++ b/client/src/components/Pagination.test.tsx
@@ -1,41 +1,566 @@
-import { describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+// @spec UI_COMPONENTS_SPEC
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Pagination } from './Pagination';
 
-describe('Pagination', () => {
-  it('renders null when totalPages <= 1', () => {
-    const { container } = render(
-      <Pagination
-        currentPage={1}
-        totalPages={1}
-        totalItems={0}
-        itemsPerPage={10}
-        onPageChange={() => {}}
-      />
-    );
-    expect(container.firstChild).toBeNull();
+describe('@spec:UI_COMPONENTS_SPEC Pagination', () => {
+  describe('Basic rendering', () => {
+    it('renders null when totalPages <= 1', () => {
+      const { container } = render(
+        <Pagination
+          currentPage={1}
+          totalPages={1}
+          totalItems={0}
+          itemsPerPage={10}
+          onPageChange={() => {}}
+        />
+      );
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('renders pagination controls when totalPages > 1', () => {
+      render(
+        <Pagination
+          currentPage={1}
+          totalPages={5}
+          totalItems={50}
+          itemsPerPage={10}
+          onPageChange={() => {}}
+        />
+      );
+      expect(screen.getByTitle('First page (Home)')).toBeInTheDocument();
+      expect(screen.getByTitle('Previous page (←)')).toBeInTheDocument();
+      expect(screen.getByTitle('Next page (→)')).toBeInTheDocument();
+      expect(screen.getByTitle('Last page (End)')).toBeInTheDocument();
+    });
   });
 
-  it('shows item range and calls onPageChange on next click', async () => {
-    const user = userEvent.setup();
-    const onPageChange = vi.fn();
+  describe('Page info display', () => {
+    it('shows correct item range and total', () => {
+      render(
+        <Pagination
+          currentPage={2}
+          totalPages={5}
+          totalItems={42}
+          itemsPerPage={10}
+          onPageChange={() => {}}
+        />
+      );
+      expect(screen.getByText('Showing 11 to 20 of 42 results')).toBeInTheDocument();
+    });
 
-    render(
-      <Pagination
-        currentPage={2}
-        totalPages={5}
-        totalItems={42}
-        itemsPerPage={10}
-        onPageChange={onPageChange}
-      />
-    );
+    it('shows correct range on first page', () => {
+      render(
+        <Pagination
+          currentPage={1}
+          totalPages={5}
+          totalItems={42}
+          itemsPerPage={10}
+          onPageChange={() => {}}
+        />
+      );
+      expect(screen.getByText('Showing 1 to 10 of 42 results')).toBeInTheDocument();
+    });
 
-    expect(screen.getByText('Showing 11 to 20 of 42 results')).toBeInTheDocument();
+    it('shows correct range on last page with partial items', () => {
+      render(
+        <Pagination
+          currentPage={5}
+          totalPages={5}
+          totalItems={42}
+          itemsPerPage={10}
+          onPageChange={() => {}}
+        />
+      );
+      expect(screen.getByText('Showing 41 to 42 of 42 results')).toBeInTheDocument();
+    });
+  });
 
-    await user.click(screen.getByTitle('Next page (→)'));
-    expect(onPageChange).toHaveBeenCalledWith(3);
+  describe('Navigation buttons', () => {
+    it('calls onPageChange on next click', async () => {
+      const user = userEvent.setup();
+      const onPageChange = vi.fn();
+
+      render(
+        <Pagination
+          currentPage={2}
+          totalPages={5}
+          totalItems={42}
+          itemsPerPage={10}
+          onPageChange={onPageChange}
+        />
+      );
+
+      await user.click(screen.getByTitle('Next page (→)'));
+      expect(onPageChange).toHaveBeenCalledWith(3);
+    });
+
+    it('calls onPageChange on previous click', async () => {
+      const user = userEvent.setup();
+      const onPageChange = vi.fn();
+
+      render(
+        <Pagination
+          currentPage={2}
+          totalPages={5}
+          totalItems={42}
+          itemsPerPage={10}
+          onPageChange={onPageChange}
+        />
+      );
+
+      await user.click(screen.getByTitle('Previous page (←)'));
+      expect(onPageChange).toHaveBeenCalledWith(1);
+    });
+
+    it('calls onPageChange on first page click', async () => {
+      const user = userEvent.setup();
+      const onPageChange = vi.fn();
+
+      render(
+        <Pagination
+          currentPage={3}
+          totalPages={5}
+          totalItems={42}
+          itemsPerPage={10}
+          onPageChange={onPageChange}
+        />
+      );
+
+      await user.click(screen.getByTitle('First page (Home)'));
+      expect(onPageChange).toHaveBeenCalledWith(1);
+    });
+
+    it('calls onPageChange on last page click', async () => {
+      const user = userEvent.setup();
+      const onPageChange = vi.fn();
+
+      render(
+        <Pagination
+          currentPage={3}
+          totalPages={5}
+          totalItems={42}
+          itemsPerPage={10}
+          onPageChange={onPageChange}
+        />
+      );
+
+      await user.click(screen.getByTitle('Last page (End)'));
+      expect(onPageChange).toHaveBeenCalledWith(5);
+    });
+
+    it('disables previous/first buttons on first page', () => {
+      render(
+        <Pagination
+          currentPage={1}
+          totalPages={5}
+          totalItems={42}
+          itemsPerPage={10}
+          onPageChange={() => {}}
+        />
+      );
+
+      expect(screen.getByTitle('First page (Home)')).toBeDisabled();
+      expect(screen.getByTitle('Previous page (←)')).toBeDisabled();
+      expect(screen.getByTitle('Next page (→)')).not.toBeDisabled();
+      expect(screen.getByTitle('Last page (End)')).not.toBeDisabled();
+    });
+
+    it('disables next/last buttons on last page', () => {
+      render(
+        <Pagination
+          currentPage={5}
+          totalPages={5}
+          totalItems={42}
+          itemsPerPage={10}
+          onPageChange={() => {}}
+        />
+      );
+
+      expect(screen.getByTitle('First page (Home)')).not.toBeDisabled();
+      expect(screen.getByTitle('Previous page (←)')).not.toBeDisabled();
+      expect(screen.getByTitle('Next page (→)')).toBeDisabled();
+      expect(screen.getByTitle('Last page (End)')).toBeDisabled();
+    });
+  });
+
+  describe('Page number buttons', () => {
+    it('highlights current page', () => {
+      render(
+        <Pagination
+          currentPage={3}
+          totalPages={5}
+          totalItems={42}
+          itemsPerPage={10}
+          onPageChange={() => {}}
+        />
+      );
+
+      const pageButton = screen.getByTitle('Go to page 3');
+      // Check that it has the default variant (not outline)
+      expect(pageButton).toBeInTheDocument();
+    });
+
+    it('navigates to clicked page number', async () => {
+      const user = userEvent.setup();
+      const onPageChange = vi.fn();
+
+      render(
+        <Pagination
+          currentPage={2}
+          totalPages={5}
+          totalItems={42}
+          itemsPerPage={10}
+          onPageChange={onPageChange}
+        />
+      );
+
+      await user.click(screen.getByTitle('Go to page 4'));
+      expect(onPageChange).toHaveBeenCalledWith(4);
+    });
+
+    it('shows ellipsis for large page counts', () => {
+      render(
+        <Pagination
+          currentPage={5}
+          totalPages={10}
+          totalItems={100}
+          itemsPerPage={10}
+          onPageChange={() => {}}
+        />
+      );
+
+      // Should show ellipsis when far from start or end
+      const ellipses = screen.getAllByText('...');
+      expect(ellipses.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('Items per page selector', () => {
+    it('does not show selector by default', () => {
+      render(
+        <Pagination
+          currentPage={1}
+          totalPages={5}
+          totalItems={50}
+          itemsPerPage={10}
+          onPageChange={() => {}}
+        />
+      );
+
+      expect(screen.queryByText('Show')).not.toBeInTheDocument();
+    });
+
+    it('shows selector when showItemsPerPageSelector is true', () => {
+      const onItemsPerPageChange = vi.fn();
+
+      render(
+        <Pagination
+          currentPage={1}
+          totalPages={5}
+          totalItems={50}
+          itemsPerPage={10}
+          onPageChange={() => {}}
+          onItemsPerPageChange={onItemsPerPageChange}
+          showItemsPerPageSelector={true}
+        />
+      );
+
+      expect(screen.getByText('Show')).toBeInTheDocument();
+      expect(screen.getByText('per page')).toBeInTheDocument();
+    });
+
+    it('calls onItemsPerPageChange when selection changes', async () => {
+      const user = userEvent.setup();
+      const onItemsPerPageChange = vi.fn();
+
+      render(
+        <Pagination
+          currentPage={1}
+          totalPages={5}
+          totalItems={50}
+          itemsPerPage={10}
+          onPageChange={() => {}}
+          onItemsPerPageChange={onItemsPerPageChange}
+          showItemsPerPageSelector={true}
+        />
+      );
+
+      const select = screen.getByRole('combobox');
+      await user.selectOptions(select, '25');
+      expect(onItemsPerPageChange).toHaveBeenCalledWith(25);
+    });
+
+    it('shows correct options (10, 25, 50, 100)', () => {
+      const onItemsPerPageChange = vi.fn();
+
+      render(
+        <Pagination
+          currentPage={1}
+          totalPages={5}
+          totalItems={50}
+          itemsPerPage={10}
+          onPageChange={() => {}}
+          onItemsPerPageChange={onItemsPerPageChange}
+          showItemsPerPageSelector={true}
+        />
+      );
+
+      expect(screen.getByRole('option', { name: '10' })).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: '25' })).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: '50' })).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: '100' })).toBeInTheDocument();
+    });
+  });
+
+  describe('Quick jump feature', () => {
+    it('does not show quick jump by default', () => {
+      render(
+        <Pagination
+          currentPage={1}
+          totalPages={5}
+          totalItems={50}
+          itemsPerPage={10}
+          onPageChange={() => {}}
+        />
+      );
+
+      expect(screen.queryByText('Go to page:')).not.toBeInTheDocument();
+    });
+
+    it('shows quick jump when showQuickJump is true', () => {
+      render(
+        <Pagination
+          currentPage={1}
+          totalPages={5}
+          totalItems={50}
+          itemsPerPage={10}
+          onPageChange={() => {}}
+          showQuickJump={true}
+        />
+      );
+
+      expect(screen.getByText('Go to page:')).toBeInTheDocument();
+      expect(screen.getByRole('spinbutton')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Go' })).toBeInTheDocument();
+    });
+
+    it('navigates to valid page when Go is clicked', async () => {
+      const user = userEvent.setup();
+      const onPageChange = vi.fn();
+
+      render(
+        <Pagination
+          currentPage={1}
+          totalPages={5}
+          totalItems={50}
+          itemsPerPage={10}
+          onPageChange={onPageChange}
+          showQuickJump={true}
+        />
+      );
+
+      const input = screen.getByRole('spinbutton');
+      await user.type(input, '3');
+      await user.click(screen.getByRole('button', { name: 'Go' }));
+
+      expect(onPageChange).toHaveBeenCalledWith(3);
+    });
+
+    it('navigates when Enter is pressed in quick jump input', async () => {
+      const user = userEvent.setup();
+      const onPageChange = vi.fn();
+
+      render(
+        <Pagination
+          currentPage={1}
+          totalPages={5}
+          totalItems={50}
+          itemsPerPage={10}
+          onPageChange={onPageChange}
+          showQuickJump={true}
+        />
+      );
+
+      const input = screen.getByRole('spinbutton');
+      await user.type(input, '4');
+      await user.keyboard('{Enter}');
+
+      expect(onPageChange).toHaveBeenCalledWith(4);
+    });
+
+    it('disables Go button for invalid page numbers', () => {
+      render(
+        <Pagination
+          currentPage={1}
+          totalPages={5}
+          totalItems={50}
+          itemsPerPage={10}
+          onPageChange={() => {}}
+          showQuickJump={true}
+        />
+      );
+
+      // Go button should be disabled when input is empty
+      expect(screen.getByRole('button', { name: 'Go' })).toBeDisabled();
+    });
+  });
+
+  describe('Keyboard shortcuts', () => {
+    it('does not show keyboard hints by default', () => {
+      render(
+        <Pagination
+          currentPage={1}
+          totalPages={5}
+          totalItems={50}
+          itemsPerPage={10}
+          onPageChange={() => {}}
+        />
+      );
+
+      expect(screen.queryByText(/Use.*arrows/)).not.toBeInTheDocument();
+    });
+
+    it('shows keyboard hints when showKeyboardShortcuts is true', () => {
+      render(
+        <Pagination
+          currentPage={1}
+          totalPages={5}
+          totalItems={50}
+          itemsPerPage={10}
+          onPageChange={() => {}}
+          showKeyboardShortcuts={true}
+        />
+      );
+
+      expect(screen.getByText(/Use.*arrows.*Home.*End.*navigation/)).toBeInTheDocument();
+    });
+
+    it('navigates to next page with ArrowRight', async () => {
+      const onPageChange = vi.fn();
+
+      render(
+        <Pagination
+          currentPage={2}
+          totalPages={5}
+          totalItems={50}
+          itemsPerPage={10}
+          onPageChange={onPageChange}
+          showKeyboardShortcuts={true}
+        />
+      );
+
+      fireEvent.keyDown(document, { key: 'ArrowRight' });
+      expect(onPageChange).toHaveBeenCalledWith(3);
+    });
+
+    it('navigates to previous page with ArrowLeft', async () => {
+      const onPageChange = vi.fn();
+
+      render(
+        <Pagination
+          currentPage={3}
+          totalPages={5}
+          totalItems={50}
+          itemsPerPage={10}
+          onPageChange={onPageChange}
+          showKeyboardShortcuts={true}
+        />
+      );
+
+      fireEvent.keyDown(document, { key: 'ArrowLeft' });
+      expect(onPageChange).toHaveBeenCalledWith(2);
+    });
+
+    it('navigates to first page with Home key', async () => {
+      const onPageChange = vi.fn();
+
+      render(
+        <Pagination
+          currentPage={3}
+          totalPages={5}
+          totalItems={50}
+          itemsPerPage={10}
+          onPageChange={onPageChange}
+          showKeyboardShortcuts={true}
+        />
+      );
+
+      fireEvent.keyDown(document, { key: 'Home' });
+      expect(onPageChange).toHaveBeenCalledWith(1);
+    });
+
+    it('navigates to last page with End key', async () => {
+      const onPageChange = vi.fn();
+
+      render(
+        <Pagination
+          currentPage={2}
+          totalPages={5}
+          totalItems={50}
+          itemsPerPage={10}
+          onPageChange={onPageChange}
+          showKeyboardShortcuts={true}
+        />
+      );
+
+      fireEvent.keyDown(document, { key: 'End' });
+      expect(onPageChange).toHaveBeenCalledWith(5);
+    });
+
+    it('does not navigate on ArrowRight when on last page', async () => {
+      const onPageChange = vi.fn();
+
+      render(
+        <Pagination
+          currentPage={5}
+          totalPages={5}
+          totalItems={50}
+          itemsPerPage={10}
+          onPageChange={onPageChange}
+          showKeyboardShortcuts={true}
+        />
+      );
+
+      fireEvent.keyDown(document, { key: 'ArrowRight' });
+      expect(onPageChange).not.toHaveBeenCalled();
+    });
+
+    it('does not navigate on ArrowLeft when on first page', async () => {
+      const onPageChange = vi.fn();
+
+      render(
+        <Pagination
+          currentPage={1}
+          totalPages={5}
+          totalItems={50}
+          itemsPerPage={10}
+          onPageChange={onPageChange}
+          showKeyboardShortcuts={true}
+        />
+      );
+
+      fireEvent.keyDown(document, { key: 'ArrowLeft' });
+      expect(onPageChange).not.toHaveBeenCalled();
+    });
+
+    it('does not handle keyboard when showKeyboardShortcuts is false', async () => {
+      const onPageChange = vi.fn();
+
+      render(
+        <Pagination
+          currentPage={2}
+          totalPages={5}
+          totalItems={50}
+          itemsPerPage={10}
+          onPageChange={onPageChange}
+          showKeyboardShortcuts={false}
+        />
+      );
+
+      fireEvent.keyDown(document, { key: 'ArrowRight' });
+      expect(onPageChange).not.toHaveBeenCalled();
+    });
   });
 });
-
-

--- a/client/src/components/TraceDataViewer.test.tsx
+++ b/client/src/components/TraceDataViewer.test.tsx
@@ -1,0 +1,608 @@
+// @spec UI_COMPONENTS_SPEC
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TraceDataViewer } from './TraceDataViewer';
+
+// Mock clipboard API
+const mockClipboardWrite = vi.fn();
+Object.assign(navigator, {
+  clipboard: {
+    writeText: mockClipboardWrite,
+  },
+});
+
+// Mock URL.createObjectURL and revokeObjectURL for download tests
+const mockCreateObjectURL = vi.fn(() => 'blob:mock-url');
+const mockRevokeObjectURL = vi.fn();
+Object.assign(window, {
+  URL: {
+    createObjectURL: mockCreateObjectURL,
+    revokeObjectURL: mockRevokeObjectURL,
+  },
+});
+
+describe('@spec:UI_COMPONENTS_SPEC TraceDataViewer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Basic rendering', () => {
+    it('renders with valid JSON output', () => {
+      render(
+        <TraceDataViewer
+          trace={{
+            id: 'test-1',
+            input: '{"query": "Hello"}',
+            output: '{"response": "World"}',
+          }}
+        />
+      );
+
+      expect(screen.getByText('Trace Data Viewer')).toBeInTheDocument();
+      expect(screen.getByText('Input')).toBeInTheDocument();
+      expect(screen.getByText('Output')).toBeInTheDocument();
+    });
+
+    it('renders error state for invalid JSON output', () => {
+      render(
+        <TraceDataViewer
+          trace={{
+            id: 'test-1',
+            input: '{"query": "Hello"}',
+            output: 'not valid json',
+          }}
+        />
+      );
+
+      expect(screen.getByText('Unable to parse trace output')).toBeInTheDocument();
+    });
+
+    it('displays MLflow trace ID badge when provided', () => {
+      render(
+        <TraceDataViewer
+          trace={{
+            id: 'test-1',
+            input: '{"query": "Hello"}',
+            output: '{"response": "World"}',
+            mlflow_trace_id: 'mlflow-12345678-abcd',
+          }}
+        />
+      );
+
+      expect(screen.getByText('MLflow: mlflow-1...')).toBeInTheDocument();
+    });
+
+    it('shows context section when showContext is true and context exists', () => {
+      render(
+        <TraceDataViewer
+          trace={{
+            id: 'test-1',
+            input: '{"query": "Hello"}',
+            output: '{"response": "World"}',
+            context: { source: 'test', metadata: { key: 'value' } },
+          }}
+          showContext={true}
+        />
+      );
+
+      expect(screen.getByText('Context')).toBeInTheDocument();
+    });
+
+    it('hides context section when showContext is false', () => {
+      render(
+        <TraceDataViewer
+          trace={{
+            id: 'test-1',
+            input: '{"query": "Hello"}',
+            output: '{"response": "World"}',
+            context: { source: 'test' },
+          }}
+          showContext={false}
+        />
+      );
+
+      expect(screen.queryByText('Context')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('LLM content extraction - OpenAI format', () => {
+    it('extracts content from OpenAI chat completion format', () => {
+      const openAIResponse = JSON.stringify({
+        id: 'chatcmpl-123',
+        object: 'chat.completion',
+        model: 'gpt-4',
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: 'Hello, I am an AI assistant.',
+            },
+            finish_reason: 'stop',
+          },
+        ],
+      });
+
+      render(
+        <TraceDataViewer
+          trace={{
+            id: 'test-1',
+            input: '{"messages": [{"role": "user", "content": "Hello"}]}',
+            output: openAIResponse,
+          }}
+        />
+      );
+
+      // Should show Response tab (LLM content detected)
+      expect(screen.getByText('Response')).toBeInTheDocument();
+      expect(screen.getByText('Hello, I am an AI assistant.')).toBeInTheDocument();
+    });
+
+    it('extracts content from text completion format', () => {
+      const textCompletion = JSON.stringify({
+        choices: [
+          {
+            text: 'This is a text completion response.',
+            finish_reason: 'stop',
+          },
+        ],
+      });
+
+      render(
+        <TraceDataViewer
+          trace={{
+            id: 'test-1',
+            input: '{"prompt": "Hello"}',
+            output: textCompletion,
+          }}
+        />
+      );
+
+      expect(screen.getByText('This is a text completion response.')).toBeInTheDocument();
+    });
+  });
+
+  describe('LLM content extraction - Anthropic format', () => {
+    it('extracts content from Anthropic Claude format', () => {
+      const anthropicResponse = JSON.stringify({
+        id: 'msg-123',
+        type: 'message',
+        role: 'assistant',
+        content: [
+          {
+            type: 'text',
+            text: 'Hello from Claude!',
+          },
+        ],
+        model: 'claude-3',
+        stop_reason: 'end_turn',
+      });
+
+      render(
+        <TraceDataViewer
+          trace={{
+            id: 'test-1',
+            input: '{"messages": []}',
+            output: anthropicResponse,
+          }}
+        />
+      );
+
+      expect(screen.getByText('Hello from Claude!')).toBeInTheDocument();
+    });
+
+    it('concatenates multiple text blocks', () => {
+      const multiBlockResponse = JSON.stringify({
+        content: [
+          { type: 'text', text: 'First paragraph.' },
+          { type: 'text', text: 'Second paragraph.' },
+        ],
+      });
+
+      render(
+        <TraceDataViewer
+          trace={{
+            id: 'test-1',
+            input: '{}',
+            output: multiBlockResponse,
+          }}
+        />
+      );
+
+      // Both paragraphs should be joined
+      expect(screen.getByText(/First paragraph/)).toBeInTheDocument();
+      expect(screen.getByText(/Second paragraph/)).toBeInTheDocument();
+    });
+  });
+
+  describe('LLM content extraction - Judge format', () => {
+    it('extracts rationale from judge evaluation output', () => {
+      const judgeResponse = JSON.stringify({
+        choices: [
+          {
+            result: 4,
+            rationale: 'The response is accurate and helpful.',
+          },
+        ],
+      });
+
+      render(
+        <TraceDataViewer
+          trace={{
+            id: 'test-1',
+            input: '{}',
+            output: judgeResponse,
+          }}
+        />
+      );
+
+      expect(screen.getByText(/Rating: 4/)).toBeInTheDocument();
+      expect(screen.getByText(/The response is accurate and helpful./)).toBeInTheDocument();
+    });
+
+    it('extracts JSON-encoded judge result from message content', () => {
+      const judgeInMessage = JSON.stringify({
+        choices: [
+          {
+            message: {
+              content: JSON.stringify({
+                result: 1,
+                rationale: 'Excellent response!',
+              }),
+            },
+          },
+        ],
+      });
+
+      render(
+        <TraceDataViewer
+          trace={{
+            id: 'test-1',
+            input: '{}',
+            output: judgeInMessage,
+          }}
+        />
+      );
+
+      expect(screen.getByText(/Rating: 1/)).toBeInTheDocument();
+      expect(screen.getByText(/Excellent response!/)).toBeInTheDocument();
+    });
+  });
+
+  describe('Data table format (SQL results)', () => {
+    it('renders result array as table when clicking Data Table tab', async () => {
+      const user = userEvent.setup();
+      const sqlResult = JSON.stringify({
+        result: [
+          { name: 'Alice', age: 30 },
+          { name: 'Bob', age: 25 },
+        ],
+      });
+
+      render(
+        <TraceDataViewer
+          trace={{
+            id: 'test-1',
+            input: '{}',
+            output: sqlResult,
+          }}
+        />
+      );
+
+      // Data Table tab should be present
+      expect(screen.getByText('Data Table')).toBeInTheDocument();
+
+      // Click on Data Table tab to see content
+      await user.click(screen.getByText('Data Table'));
+
+      // Now the table content should be visible
+      expect(screen.getByText('2 rows × 2 columns')).toBeInTheDocument();
+      expect(screen.getByText('Alice')).toBeInTheDocument();
+      expect(screen.getByText('Bob')).toBeInTheDocument();
+    });
+
+    it('shows Download CSV button when Data Table tab is active', async () => {
+      const user = userEvent.setup();
+      const sqlResult = JSON.stringify({
+        result: [{ name: 'Alice', age: 30 }],
+      });
+
+      render(
+        <TraceDataViewer
+          trace={{
+            id: 'test-1',
+            input: '{}',
+            output: sqlResult,
+          }}
+        />
+      );
+
+      // Click Data Table tab to activate it
+      await user.click(screen.getByText('Data Table'));
+
+      expect(screen.getByText('Download CSV')).toBeInTheDocument();
+    });
+  });
+
+  describe('SQL query formatting', () => {
+    it('displays SQL query with formatting', () => {
+      const sqlOutput = JSON.stringify({
+        result: [{ count: 10 }],
+        query_text: 'SELECT COUNT(*) FROM users WHERE active = 1',
+      });
+
+      render(
+        <TraceDataViewer
+          trace={{
+            id: 'test-1',
+            input: '{}',
+            output: sqlOutput,
+          }}
+        />
+      );
+
+      expect(screen.getByText('SQL Query')).toBeInTheDocument();
+      // Query should be displayed (formatted with line breaks)
+      expect(screen.getByText(/SELECT/)).toBeInTheDocument();
+    });
+
+    it('shows Download SQL button when query_text exists', () => {
+      const sqlOutput = JSON.stringify({
+        result: [],
+        query_text: 'SELECT * FROM users',
+      });
+
+      render(
+        <TraceDataViewer
+          trace={{
+            id: 'test-1',
+            input: '{}',
+            output: sqlOutput,
+          }}
+        />
+      );
+
+      expect(screen.getByText('Download SQL')).toBeInTheDocument();
+    });
+  });
+
+  describe('Copy to clipboard', () => {
+    it('has Copy buttons for input and output sections', () => {
+      render(
+        <TraceDataViewer
+          trace={{
+            id: 'test-1',
+            input: '{"query": "test"}',
+            output: '{"result": "ok"}',
+          }}
+        />
+      );
+
+      // Find Copy buttons - there should be at least one for input
+      const copyButtons = screen.getAllByText('Copy');
+      expect(copyButtons.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('Tab switching', () => {
+    it('switches between Response and Raw JSON tabs for LLM content', async () => {
+      const user = userEvent.setup();
+      const openAIResponse = JSON.stringify({
+        choices: [
+          {
+            message: {
+              content: 'Test response',
+            },
+          },
+        ],
+      });
+
+      render(
+        <TraceDataViewer
+          trace={{
+            id: 'test-1',
+            input: '{}',
+            output: openAIResponse,
+          }}
+        />
+      );
+
+      // Initially on Response tab
+      expect(screen.getByText('Test response')).toBeInTheDocument();
+
+      // Click Raw JSON tab
+      await user.click(screen.getByText('Raw JSON'));
+
+      // Should show raw JSON structure
+      expect(screen.getByText(/choices/)).toBeInTheDocument();
+    });
+
+    it('switches between Data Table and Raw JSON tabs for SQL results', async () => {
+      const user = userEvent.setup();
+      const sqlResult = JSON.stringify({
+        result: [{ name: 'Alice' }],
+      });
+
+      render(
+        <TraceDataViewer
+          trace={{
+            id: 'test-1',
+            input: '{}',
+            output: sqlResult,
+          }}
+        />
+      );
+
+      // Click Data Table tab first to see table content
+      await user.click(screen.getByText('Data Table'));
+      expect(screen.getByText('Alice')).toBeInTheDocument();
+
+      // Click Raw JSON tab
+      await user.click(screen.getByText('Raw JSON'));
+
+      // Should show raw JSON (the result key)
+      expect(screen.getByText(/result/)).toBeInTheDocument();
+    });
+  });
+
+  describe('Fallback display', () => {
+    it('shows raw JSON when no LLM content or table data detected', () => {
+      const plainJson = JSON.stringify({
+        custom: 'data',
+        nested: { key: 'value' },
+      });
+
+      render(
+        <TraceDataViewer
+          trace={{
+            id: 'test-1',
+            input: '{}',
+            output: plainJson,
+          }}
+        />
+      );
+
+      // Should render as raw JSON without tabs
+      expect(screen.getByText(/custom/)).toBeInTheDocument();
+      expect(screen.queryByText('Response')).not.toBeInTheDocument();
+      expect(screen.queryByText('Data Table')).not.toBeInTheDocument();
+    });
+
+    it('handles double-stringified JSON', () => {
+      // JSON that's been stringified twice
+      const doubleStringified = JSON.stringify(JSON.stringify({ message: 'hello' }));
+
+      render(
+        <TraceDataViewer
+          trace={{
+            id: 'test-1',
+            input: '{}',
+            output: doubleStringified,
+          }}
+        />
+      );
+
+      // Should parse correctly
+      expect(screen.getByText(/message/)).toBeInTheDocument();
+    });
+  });
+
+  describe('Response metadata', () => {
+    it('shows collapsible metadata section for LLM responses', () => {
+      const responseWithMetadata = JSON.stringify({
+        id: 'chatcmpl-123',
+        model: 'gpt-4',
+        object: 'chat.completion',
+        choices: [
+          {
+            message: { content: 'Hello!' },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: { total_tokens: 50 },
+      });
+
+      render(
+        <TraceDataViewer
+          trace={{
+            id: 'test-1',
+            input: '{}',
+            output: responseWithMetadata,
+          }}
+        />
+      );
+
+      // Should show Response Metadata summary
+      expect(screen.getByText('Response Metadata')).toBeInTheDocument();
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('handles empty result array', () => {
+      const emptyResult = JSON.stringify({
+        result: [],
+      });
+
+      render(
+        <TraceDataViewer
+          trace={{
+            id: 'test-1',
+            input: '{}',
+            output: emptyResult,
+          }}
+        />
+      );
+
+      // Should still render without errors
+      expect(screen.getByText('Trace Data Viewer')).toBeInTheDocument();
+    });
+
+    it('handles messages array format', () => {
+      const messagesFormat = JSON.stringify({
+        messages: [
+          { role: 'user', content: 'Hello' },
+          { role: 'assistant', content: 'Hi there!' },
+        ],
+      });
+
+      render(
+        <TraceDataViewer
+          trace={{
+            id: 'test-1',
+            input: '{}',
+            output: messagesFormat,
+          }}
+        />
+      );
+
+      expect(screen.getByText('Hi there!')).toBeInTheDocument();
+    });
+
+    it('handles Databricks agent response format', () => {
+      const databricksFormat = JSON.stringify({
+        output: [
+          {
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'text', text: 'Databricks response' }],
+          },
+        ],
+      });
+
+      render(
+        <TraceDataViewer
+          trace={{
+            id: 'test-1',
+            input: '{}',
+            output: databricksFormat,
+          }}
+        />
+      );
+
+      expect(screen.getByText('Databricks response')).toBeInTheDocument();
+    });
+
+    it('handles flattened chat completion format', () => {
+      const flattenedFormat = JSON.stringify({
+        id: 'chatcmpl-123',
+        object: 'chat.completion',
+        model: 'gpt-4',
+        role: 'assistant',
+        content: 'Flattened response content',
+        finish_reason: 'stop',
+      });
+
+      render(
+        <TraceDataViewer
+          trace={{
+            id: 'test-1',
+            input: '{}',
+            output: flattenedFormat,
+          }}
+        />
+      );
+
+      expect(screen.getByText('Flattened response content')).toBeInTheDocument();
+    });
+  });
+});

--- a/client/src/hooks/useJsonPathExtraction.test.ts
+++ b/client/src/hooks/useJsonPathExtraction.test.ts
@@ -1,0 +1,154 @@
+// @spec TRACE_DISPLAY_SPEC
+import { describe, expect, it } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useJsonPathExtraction, applyJsonPathExtraction } from './useJsonPathExtraction';
+
+describe('@spec:TRACE_DISPLAY_SPEC useJsonPathExtraction', () => {
+  describe('useJsonPathExtraction hook', () => {
+    it('returns original data when no jsonPath is provided', () => {
+      const data = '{"message": "hello"}';
+      const { result } = renderHook(() => useJsonPathExtraction(data, null));
+      expect(result.current).toBe(data);
+    });
+
+    it('returns original data when jsonPath is empty string', () => {
+      const data = '{"message": "hello"}';
+      const { result } = renderHook(() => useJsonPathExtraction(data, ''));
+      expect(result.current).toBe(data);
+    });
+
+    it('returns original data when jsonPath is whitespace only', () => {
+      const data = '{"message": "hello"}';
+      const { result } = renderHook(() => useJsonPathExtraction(data, '   '));
+      expect(result.current).toBe(data);
+    });
+
+    it('extracts simple value from JSON', () => {
+      const data = '{"message": "hello world"}';
+      const { result } = renderHook(() => useJsonPathExtraction(data, '$.message'));
+      expect(result.current).toBe('hello world');
+    });
+
+    it('extracts nested value', () => {
+      const data = '{"response": {"text": "nested value"}}';
+      const { result } = renderHook(() => useJsonPathExtraction(data, '$.response.text'));
+      expect(result.current).toBe('nested value');
+    });
+
+    it('extracts array element by index', () => {
+      const data = '{"items": ["first", "second", "third"]}';
+      const { result } = renderHook(() => useJsonPathExtraction(data, '$.items[0]'));
+      expect(result.current).toBe('first');
+    });
+
+    it('extracts multiple values with wildcard and joins with newlines', () => {
+      const data = '{"messages": [{"content": "one"}, {"content": "two"}, {"content": "three"}]}';
+      const { result } = renderHook(() => useJsonPathExtraction(data, '$.messages[*].content'));
+      expect(result.current).toBe('one\ntwo\nthree');
+    });
+
+    it('returns original data when JSONPath returns no matches', () => {
+      const data = '{"foo": "bar"}';
+      const { result } = renderHook(() => useJsonPathExtraction(data, '$.nonexistent'));
+      expect(result.current).toBe(data);
+    });
+
+    it('returns original data when JSON is invalid', () => {
+      const data = 'not valid json';
+      const { result } = renderHook(() => useJsonPathExtraction(data, '$.anything'));
+      expect(result.current).toBe(data);
+    });
+
+    it('returns original data when result is null', () => {
+      const data = '{"value": null}';
+      const { result } = renderHook(() => useJsonPathExtraction(data, '$.value'));
+      expect(result.current).toBe(data);
+    });
+
+    it('converts numeric values to strings', () => {
+      const data = '{"count": 42}';
+      const { result } = renderHook(() => useJsonPathExtraction(data, '$.count'));
+      expect(result.current).toBe('42');
+    });
+
+    it('converts boolean values to strings', () => {
+      const data = '{"active": true}';
+      const { result } = renderHook(() => useJsonPathExtraction(data, '$.active'));
+      expect(result.current).toBe('true');
+    });
+
+    it('serializes object values to JSON', () => {
+      const data = '{"nested": {"key": "value"}}';
+      const { result } = renderHook(() => useJsonPathExtraction(data, '$.nested'));
+      expect(result.current).toContain('"key"');
+      expect(result.current).toContain('"value"');
+    });
+
+    it('filters out null values from multiple results', () => {
+      const data = '{"items": ["one", null, "three"]}';
+      const { result } = renderHook(() => useJsonPathExtraction(data, '$.items[*]'));
+      expect(result.current).toBe('one\nthree');
+    });
+  });
+
+  describe('applyJsonPathExtraction function', () => {
+    it('returns success: false when no jsonPath is provided', () => {
+      const data = '{"message": "hello"}';
+      const result = applyJsonPathExtraction(data, null);
+      expect(result.success).toBe(false);
+      expect(result.result).toBe(data);
+    });
+
+    it('returns success: true with extracted value', () => {
+      const data = '{"message": "hello"}';
+      const result = applyJsonPathExtraction(data, '$.message');
+      expect(result.success).toBe(true);
+      expect(result.result).toBe('hello');
+    });
+
+    it('returns success: false when no matches found', () => {
+      const data = '{"foo": "bar"}';
+      const result = applyJsonPathExtraction(data, '$.missing');
+      expect(result.success).toBe(false);
+      expect(result.result).toBe(data);
+    });
+
+    it('returns success: false for invalid JSON', () => {
+      const data = 'invalid json';
+      const result = applyJsonPathExtraction(data, '$.anything');
+      expect(result.success).toBe(false);
+      expect(result.result).toBe(data);
+    });
+
+    it('extracts deeply nested value', () => {
+      const data = '{"a": {"b": {"c": {"d": "deep"}}}}';
+      const result = applyJsonPathExtraction(data, '$.a.b.c.d');
+      expect(result.success).toBe(true);
+      expect(result.result).toBe('deep');
+    });
+
+    it('joins multiple matches with newlines', () => {
+      const data = '{"list": ["alpha", "beta", "gamma"]}';
+      const result = applyJsonPathExtraction(data, '$.list[*]');
+      expect(result.success).toBe(true);
+      expect(result.result).toBe('alpha\nbeta\ngamma');
+    });
+
+    it('handles empty array result as failure', () => {
+      const data = '{"items": []}';
+      const result = applyJsonPathExtraction(data, '$.items[*]');
+      expect(result.success).toBe(false);
+    });
+
+    it('extracts from typical LLM response format', () => {
+      const data = JSON.stringify({
+        choices: [
+          { message: { content: 'Hello from AI!' } }
+        ]
+      });
+      const result = applyJsonPathExtraction(data, '$.choices[0].message.content');
+      expect(result.success).toBe(true);
+      expect(result.result).toBe('Hello from AI!');
+    });
+  });
+});

--- a/client/src/lib/utils.test.ts
+++ b/client/src/lib/utils.test.ts
@@ -1,12 +1,168 @@
+// @spec DESIGN_SYSTEM_SPEC
 import { describe, expect, it } from 'vitest';
 import { cn } from './utils';
 
-// @spec DESIGN_SYSTEM_SPEC
-describe('cn', () => {
-  it('merges classnames and tailwind conflicts', () => {
-    expect(cn('p-2', 'p-4')).toBe('p-4');
-    expect(cn('text-sm', false && 'hidden', undefined, 'text-lg')).toBe('text-lg');
+describe('@spec:DESIGN_SYSTEM_SPEC cn utility', () => {
+  describe('basic class merging', () => {
+    it('combines multiple class strings', () => {
+      expect(cn('foo', 'bar')).toBe('foo bar');
+    });
+
+    it('handles single class', () => {
+      expect(cn('single-class')).toBe('single-class');
+    });
+
+    it('handles empty input', () => {
+      expect(cn()).toBe('');
+    });
+
+    it('handles empty strings', () => {
+      expect(cn('', 'valid-class', '')).toBe('valid-class');
+    });
+  });
+
+  describe('Tailwind CSS conflict resolution', () => {
+    it('resolves padding conflicts (later wins)', () => {
+      expect(cn('p-2', 'p-4')).toBe('p-4');
+    });
+
+    it('resolves margin conflicts', () => {
+      expect(cn('m-2', 'm-8')).toBe('m-8');
+    });
+
+    it('resolves text size conflicts', () => {
+      expect(cn('text-sm', 'text-lg')).toBe('text-lg');
+    });
+
+    it('resolves background color conflicts', () => {
+      expect(cn('bg-red-500', 'bg-blue-500')).toBe('bg-blue-500');
+    });
+
+    it('resolves text color conflicts', () => {
+      expect(cn('text-gray-500', 'text-purple-600')).toBe('text-purple-600');
+    });
+
+    it('allows different utility categories to coexist', () => {
+      const result = cn('p-4', 'm-2', 'text-lg', 'bg-white');
+      expect(result).toContain('p-4');
+      expect(result).toContain('m-2');
+      expect(result).toContain('text-lg');
+      expect(result).toContain('bg-white');
+    });
+
+    it('resolves directional padding conflicts', () => {
+      expect(cn('px-2', 'px-4')).toBe('px-4');
+      expect(cn('py-2', 'py-6')).toBe('py-6');
+    });
+
+    it('keeps non-conflicting directional utilities', () => {
+      const result = cn('px-2', 'py-4');
+      expect(result).toContain('px-2');
+      expect(result).toContain('py-4');
+    });
+  });
+
+  describe('conditional classes', () => {
+    it('filters out falsy values', () => {
+      expect(cn('always', false && 'never')).toBe('always');
+    });
+
+    it('filters out undefined values', () => {
+      expect(cn('always', undefined, 'also')).toBe('always also');
+    });
+
+    it('filters out null values', () => {
+      expect(cn('always', null, 'also')).toBe('always also');
+    });
+
+    it('handles conditional expression with true', () => {
+      const isActive = true;
+      expect(cn('base', isActive && 'active')).toBe('base active');
+    });
+
+    it('handles conditional expression with false', () => {
+      const isActive = false;
+      expect(cn('base', isActive && 'active')).toBe('base');
+    });
+
+    it('handles ternary expressions', () => {
+      const variant = 'primary';
+      expect(cn('btn', variant === 'primary' ? 'btn-primary' : 'btn-secondary')).toBe('btn btn-primary');
+    });
+  });
+
+  describe('array inputs', () => {
+    it('handles array of classes', () => {
+      expect(cn(['class-a', 'class-b'])).toBe('class-a class-b');
+    });
+
+    it('handles mixed array and string inputs', () => {
+      expect(cn('single', ['array-a', 'array-b'])).toBe('single array-a array-b');
+    });
+
+    it('filters falsy values from arrays', () => {
+      expect(cn(['valid', false && 'invalid', null, undefined, 'also-valid'])).toBe('valid also-valid');
+    });
+  });
+
+  describe('object inputs (clsx-style)', () => {
+    it('handles object with boolean values', () => {
+      expect(cn({ active: true, disabled: false })).toBe('active');
+    });
+
+    it('handles object with all true values', () => {
+      expect(cn({ 'class-a': true, 'class-b': true })).toBe('class-a class-b');
+    });
+
+    it('handles empty object', () => {
+      expect(cn({})).toBe('');
+    });
+
+    it('combines object and string inputs', () => {
+      const result = cn('base', { active: true, hidden: false });
+      expect(result).toBe('base active');
+    });
+  });
+
+  describe('design system usage patterns', () => {
+    it('handles button variant pattern', () => {
+      const variant = 'primary';
+      const size = 'lg';
+      const result = cn(
+        'inline-flex items-center justify-center rounded-md font-medium',
+        variant === 'primary' && 'bg-primary text-primary-foreground hover:bg-primary/90',
+        variant === 'secondary' && 'bg-secondary text-secondary-foreground',
+        size === 'lg' && 'h-11 px-8',
+        size === 'sm' && 'h-9 px-3'
+      );
+      expect(result).toContain('bg-primary');
+      expect(result).toContain('h-11');
+      expect(result).not.toContain('bg-secondary');
+    });
+
+    it('handles disabled state override', () => {
+      const isDisabled = true;
+      const result = cn(
+        'bg-primary text-white',
+        isDisabled && 'bg-gray-300 text-gray-500 cursor-not-allowed'
+      );
+      // When disabled, gray should override primary
+      expect(result).toContain('bg-gray-300');
+    });
+
+    it('handles responsive classes', () => {
+      const result = cn('p-2', 'md:p-4', 'lg:p-6');
+      expect(result).toContain('p-2');
+      expect(result).toContain('md:p-4');
+      expect(result).toContain('lg:p-6');
+    });
+
+    it('handles dark mode classes', () => {
+      const result = cn('bg-white', 'dark:bg-gray-900', 'text-black', 'dark:text-white');
+      expect(result).toContain('bg-white');
+      expect(result).toContain('dark:bg-gray-900');
+      expect(result).toContain('text-black');
+      expect(result).toContain('dark:text-white');
+    });
   });
 });
-
-

--- a/client/src/utils/rubricUtils.test.ts
+++ b/client/src/utils/rubricUtils.test.ts
@@ -1,37 +1,234 @@
 import { describe, expect, it } from 'vitest';
-import { formatRubricQuestions, parseRubricQuestions, QUESTION_DELIMITER } from './rubricUtils';
+import { formatRubricQuestions, parseRubricQuestions, QUESTION_DELIMITER, type RubricQuestion } from './rubricUtils';
 
 // @spec RUBRIC_SPEC
-describe('rubricUtils', () => {
-  it('parses rubric questions using delimiter and first-colon split', () => {
-    const text = [
-      'Clarity: The response is clear.\nAnd can include newlines.',
-      'Tone: Friendly: but only first colon splits title from description',
-      '',
-    ].join(QUESTION_DELIMITER);
+describe('@spec:RUBRIC_SPEC rubricUtils', () => {
+  describe('parseRubricQuestions', () => {
+    it('parses rubric questions using delimiter and first-colon split', () => {
+      const text = [
+        'Clarity: The response is clear.\nAnd can include newlines.',
+        'Tone: Friendly: but only first colon splits title from description',
+        '',
+      ].join(QUESTION_DELIMITER);
 
-    const parsed = parseRubricQuestions(text);
-    expect(parsed).toHaveLength(2);
-    expect(parsed[0].title).toBe('Clarity');
-    expect(parsed[0].description).toContain('include newlines');
-    expect(parsed[1].title).toBe('Tone');
-    expect(parsed[1].description).toBe('Friendly: but only first colon splits title from description');
+      const parsed = parseRubricQuestions(text);
+      expect(parsed).toHaveLength(2);
+      expect(parsed[0].title).toBe('Clarity');
+      expect(parsed[0].description).toContain('include newlines');
+      expect(parsed[1].title).toBe('Tone');
+      expect(parsed[1].description).toBe('Friendly: but only first colon splits title from description');
+    });
+
+    it('returns empty array for empty input', () => {
+      expect(parseRubricQuestions('')).toEqual([]);
+      expect(parseRubricQuestions(null as unknown as string)).toEqual([]);
+      expect(parseRubricQuestions(undefined as unknown as string)).toEqual([]);
+    });
+
+    it('filters out empty question parts', () => {
+      const text = `Question 1: Description${QUESTION_DELIMITER}${QUESTION_DELIMITER}Question 2: Description`;
+      const parsed = parseRubricQuestions(text);
+      expect(parsed).toHaveLength(2);
+    });
+
+    it('handles questions without colons', () => {
+      const text = 'Just a title without description';
+      const parsed = parseRubricQuestions(text);
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].title).toBe('Just a title without description');
+      expect(parsed[0].description).toBe('');
+    });
+
+    it('generates sequential IDs', () => {
+      const text = `Q1: D1${QUESTION_DELIMITER}Q2: D2${QUESTION_DELIMITER}Q3: D3`;
+      const parsed = parseRubricQuestions(text);
+      expect(parsed[0].id).toBe('q_1');
+      expect(parsed[1].id).toBe('q_2');
+      expect(parsed[2].id).toBe('q_3');
+    });
   });
 
-  it('round-trips format -> parse', () => {
-    const questions = [
-      { id: 'q_1', title: 'A', description: 'B' },
-      { id: 'q_2', title: 'C', description: 'D' },
-    ];
-    const formatted = formatRubricQuestions(questions);
-    expect(formatted).toContain(QUESTION_DELIMITER);
+  describe('Judge type parsing', () => {
+    it('defaults to likert when no judge type specified', () => {
+      const text = 'Quality: Is the response high quality?';
+      const parsed = parseRubricQuestions(text);
+      expect(parsed[0].judgeType).toBe('likert');
+    });
 
-    const parsed = parseRubricQuestions(formatted);
-    expect(parsed.map((q) => ({ title: q.title, description: q.description }))).toEqual([
-      { title: 'A', description: 'B' },
-      { title: 'C', description: 'D' },
-    ]);
+    it('parses likert judge type', () => {
+      const text = 'Quality: Is the response high quality?|||JUDGE_TYPE|||likert';
+      const parsed = parseRubricQuestions(text);
+      expect(parsed[0].judgeType).toBe('likert');
+    });
+
+    it('parses binary judge type', () => {
+      const text = 'Safety: Is the response safe?|||JUDGE_TYPE|||binary';
+      const parsed = parseRubricQuestions(text);
+      expect(parsed[0].judgeType).toBe('binary');
+    });
+
+    it('parses freeform judge type', () => {
+      const text = 'Feedback: Provide detailed feedback|||JUDGE_TYPE|||freeform';
+      const parsed = parseRubricQuestions(text);
+      expect(parsed[0].judgeType).toBe('freeform');
+    });
+
+    it('ignores invalid judge type and defaults to likert', () => {
+      const text = 'Question: Description|||JUDGE_TYPE|||invalid_type';
+      const parsed = parseRubricQuestions(text);
+      expect(parsed[0].judgeType).toBe('likert');
+    });
+
+    it('handles whitespace around judge type', () => {
+      const text = 'Question: Description|||JUDGE_TYPE|||  binary  ';
+      const parsed = parseRubricQuestions(text);
+      expect(parsed[0].judgeType).toBe('binary');
+    });
+  });
+
+  describe('Multiple questions with different judge types', () => {
+    it('parses multiple questions with mixed judge types', () => {
+      const text = [
+        'Accuracy: Is the response factually accurate?|||JUDGE_TYPE|||likert',
+        'Safety Check: Is the response safe for all audiences?|||JUDGE_TYPE|||binary',
+        'Improvement Suggestions: What could be improved?|||JUDGE_TYPE|||freeform',
+      ].join(QUESTION_DELIMITER);
+
+      const parsed = parseRubricQuestions(text);
+
+      expect(parsed).toHaveLength(3);
+
+      expect(parsed[0].title).toBe('Accuracy');
+      expect(parsed[0].judgeType).toBe('likert');
+
+      expect(parsed[1].title).toBe('Safety Check');
+      expect(parsed[1].judgeType).toBe('binary');
+
+      expect(parsed[2].title).toBe('Improvement Suggestions');
+      expect(parsed[2].judgeType).toBe('freeform');
+    });
+
+    it('preserves descriptions with judge type metadata', () => {
+      const text = 'Helpfulness: Rate from 1-5 how helpful the response is.\nConsider completeness.|||JUDGE_TYPE|||likert';
+      const parsed = parseRubricQuestions(text);
+
+      expect(parsed[0].title).toBe('Helpfulness');
+      expect(parsed[0].description).toBe('Rate from 1-5 how helpful the response is.\nConsider completeness.');
+      expect(parsed[0].judgeType).toBe('likert');
+    });
+
+    it('handles complex multi-line descriptions with judge types', () => {
+      const text = [
+        'Completeness: Does the response fully answer the question?\n\nLook for:\n- All parts addressed\n- No missing information|||JUDGE_TYPE|||likert',
+        'Hallucination: Does the response contain made-up information?|||JUDGE_TYPE|||binary',
+      ].join(QUESTION_DELIMITER);
+
+      const parsed = parseRubricQuestions(text);
+
+      expect(parsed).toHaveLength(2);
+      expect(parsed[0].description).toContain('Look for:');
+      expect(parsed[0].description).toContain('All parts addressed');
+      expect(parsed[1].judgeType).toBe('binary');
+    });
+  });
+
+  describe('formatRubricQuestions', () => {
+    it('returns empty string for empty array', () => {
+      expect(formatRubricQuestions([])).toBe('');
+      expect(formatRubricQuestions(null as unknown as RubricQuestion[])).toBe('');
+    });
+
+    it('formats single question with judge type', () => {
+      const questions: RubricQuestion[] = [
+        { id: 'q_1', title: 'Quality', description: 'Rate quality', judgeType: 'likert' }
+      ];
+      const formatted = formatRubricQuestions(questions);
+
+      expect(formatted).toContain('Quality: Rate quality');
+      expect(formatted).toContain('|||JUDGE_TYPE|||likert');
+    });
+
+    it('formats multiple questions with delimiters', () => {
+      const questions: RubricQuestion[] = [
+        { id: 'q_1', title: 'A', description: 'B', judgeType: 'likert' },
+        { id: 'q_2', title: 'C', description: 'D', judgeType: 'binary' },
+      ];
+      const formatted = formatRubricQuestions(questions);
+
+      expect(formatted).toContain(QUESTION_DELIMITER);
+      expect(formatted).toContain('|||JUDGE_TYPE|||likert');
+      expect(formatted).toContain('|||JUDGE_TYPE|||binary');
+    });
+  });
+
+  describe('Round-trip consistency', () => {
+    it('round-trips format -> parse with judge types preserved', () => {
+      const questions: RubricQuestion[] = [
+        { id: 'q_1', title: 'Accuracy', description: 'Check accuracy', judgeType: 'likert' },
+        { id: 'q_2', title: 'Safety', description: 'Check safety', judgeType: 'binary' },
+        { id: 'q_3', title: 'Feedback', description: 'Provide feedback', judgeType: 'freeform' },
+      ];
+
+      const formatted = formatRubricQuestions(questions);
+      const parsed = parseRubricQuestions(formatted);
+
+      expect(parsed).toHaveLength(3);
+
+      // Check content is preserved
+      expect(parsed[0].title).toBe('Accuracy');
+      expect(parsed[0].description).toBe('Check accuracy');
+      expect(parsed[0].judgeType).toBe('likert');
+
+      expect(parsed[1].title).toBe('Safety');
+      expect(parsed[1].description).toBe('Check safety');
+      expect(parsed[1].judgeType).toBe('binary');
+
+      expect(parsed[2].title).toBe('Feedback');
+      expect(parsed[2].description).toBe('Provide feedback');
+      expect(parsed[2].judgeType).toBe('freeform');
+    });
+
+    it('round-trips with multi-line descriptions', () => {
+      const questions: RubricQuestion[] = [
+        {
+          id: 'q_1',
+          title: 'Completeness',
+          description: 'Check if response is complete.\n\nConsider:\n- All parts\n- No gaps',
+          judgeType: 'likert'
+        },
+      ];
+
+      const formatted = formatRubricQuestions(questions);
+      const parsed = parseRubricQuestions(formatted);
+
+      expect(parsed[0].description).toContain('Check if response is complete.');
+      expect(parsed[0].description).toContain('Consider:');
+      expect(parsed[0].description).toContain('All parts');
+    });
+
+    it('round-trips empty descriptions', () => {
+      const questions: RubricQuestion[] = [
+        { id: 'q_1', title: 'Simple Check', description: '', judgeType: 'binary' },
+      ];
+
+      const formatted = formatRubricQuestions(questions);
+      const parsed = parseRubricQuestions(formatted);
+
+      expect(parsed[0].title).toBe('Simple Check');
+      expect(parsed[0].description).toBe('');
+      expect(parsed[0].judgeType).toBe('binary');
+    });
+  });
+
+  describe('QUESTION_DELIMITER constant', () => {
+    it('exports the correct delimiter', () => {
+      expect(QUESTION_DELIMITER).toBe('|||QUESTION_SEPARATOR|||');
+    });
+
+    it('delimiter is unique and unlikely in user input', () => {
+      // Verify the delimiter contains special characters that are unlikely in natural text
+      expect(QUESTION_DELIMITER).toContain('|||');
+      expect(QUESTION_DELIMITER.length).toBeGreaterThan(10);
+    });
   });
 });
-
-

--- a/client/src/utils/traceUtils.test.ts
+++ b/client/src/utils/traceUtils.test.ts
@@ -1,31 +1,160 @@
+// @spec DATASETS_SPEC
 import { describe, expect, it } from 'vitest';
 import { convertTraceToTraceData } from './traceUtils';
 
-// @spec DATASETS_SPEC
-describe('traceUtils', () => {
-  it('converts API trace fields and normalizes falsy optionals to undefined', () => {
-    const out = convertTraceToTraceData({
-      id: 't1',
-      input: 'in',
-      output: 'out',
-      context: null,
-      mlflow_trace_id: '',
-      mlflow_url: undefined,
-      mlflow_host: null,
-      mlflow_experiment_id: 0,
+describe('@spec:DATASETS_SPEC traceUtils', () => {
+  describe('convertTraceToTraceData', () => {
+    it('converts basic API trace fields', () => {
+      const out = convertTraceToTraceData({
+        id: 't1',
+        input: '{"query": "test"}',
+        output: '{"response": "result"}',
+      });
+
+      expect(out).toEqual({
+        id: 't1',
+        input: '{"query": "test"}',
+        output: '{"response": "result"}',
+        context: undefined,
+        mlflow_trace_id: undefined,
+        mlflow_url: undefined,
+        mlflow_host: undefined,
+        mlflow_experiment_id: undefined,
+      });
     });
 
-    expect(out).toEqual({
-      id: 't1',
-      input: 'in',
-      output: 'out',
-      context: undefined,
-      mlflow_trace_id: undefined,
-      mlflow_url: undefined,
-      mlflow_host: undefined,
-      mlflow_experiment_id: undefined,
+    it('normalizes null optional fields to undefined', () => {
+      const out = convertTraceToTraceData({
+        id: 't1',
+        input: 'in',
+        output: 'out',
+        context: null,
+        mlflow_trace_id: null,
+        mlflow_url: null,
+        mlflow_host: null,
+        mlflow_experiment_id: null,
+      });
+
+      expect(out.context).toBeUndefined();
+      expect(out.mlflow_trace_id).toBeUndefined();
+      expect(out.mlflow_url).toBeUndefined();
+      expect(out.mlflow_host).toBeUndefined();
+      expect(out.mlflow_experiment_id).toBeUndefined();
+    });
+
+    it('normalizes empty string optional fields to undefined', () => {
+      const out = convertTraceToTraceData({
+        id: 't1',
+        input: 'in',
+        output: 'out',
+        mlflow_trace_id: '',
+        mlflow_url: '',
+        mlflow_host: '',
+        mlflow_experiment_id: '',
+      });
+
+      expect(out.mlflow_trace_id).toBeUndefined();
+      expect(out.mlflow_url).toBeUndefined();
+      expect(out.mlflow_host).toBeUndefined();
+      expect(out.mlflow_experiment_id).toBeUndefined();
+    });
+
+    it('normalizes zero/falsy optional fields to undefined', () => {
+      const out = convertTraceToTraceData({
+        id: 't1',
+        input: 'in',
+        output: 'out',
+        context: undefined,
+        mlflow_trace_id: '',
+        mlflow_url: undefined,
+        mlflow_host: null,
+        mlflow_experiment_id: 0,
+      });
+
+      expect(out).toEqual({
+        id: 't1',
+        input: 'in',
+        output: 'out',
+        context: undefined,
+        mlflow_trace_id: undefined,
+        mlflow_url: undefined,
+        mlflow_host: undefined,
+        mlflow_experiment_id: undefined,
+      });
+    });
+
+    it('preserves valid MLflow metadata', () => {
+      const out = convertTraceToTraceData({
+        id: 'trace-123',
+        input: '{"messages": []}',
+        output: '{"choices": []}',
+        context: { source: 'test' },
+        mlflow_trace_id: 'mlflow-abc-123',
+        mlflow_url: 'https://mlflow.example.com/trace/abc-123',
+        mlflow_host: 'mlflow.example.com',
+        mlflow_experiment_id: 'exp-456',
+      });
+
+      expect(out.id).toBe('trace-123');
+      expect(out.context).toEqual({ source: 'test' });
+      expect(out.mlflow_trace_id).toBe('mlflow-abc-123');
+      expect(out.mlflow_url).toBe('https://mlflow.example.com/trace/abc-123');
+      expect(out.mlflow_host).toBe('mlflow.example.com');
+      expect(out.mlflow_experiment_id).toBe('exp-456');
+    });
+
+    it('preserves complex JSON input/output', () => {
+      const complexInput = JSON.stringify({
+        messages: [
+          { role: 'user', content: 'Hello' },
+          { role: 'assistant', content: 'Hi there' },
+        ],
+        metadata: { session_id: '123' },
+      });
+
+      const complexOutput = JSON.stringify({
+        choices: [{ message: { content: 'Response text' } }],
+        usage: { total_tokens: 100 },
+      });
+
+      const out = convertTraceToTraceData({
+        id: 't1',
+        input: complexInput,
+        output: complexOutput,
+      });
+
+      expect(out.input).toBe(complexInput);
+      expect(out.output).toBe(complexOutput);
+    });
+
+    it('handles trace with only required fields', () => {
+      const out = convertTraceToTraceData({
+        id: 'minimal-trace',
+        input: 'test input',
+        output: 'test output',
+      });
+
+      expect(out.id).toBe('minimal-trace');
+      expect(out.input).toBe('test input');
+      expect(out.output).toBe('test output');
+    });
+
+    it('handles trace with complex context object', () => {
+      const context = {
+        source: 'mlflow',
+        experiment: { id: 'exp-1', name: 'test-experiment' },
+        run: { id: 'run-1', status: 'FINISHED' },
+        nested: { deep: { value: true } },
+      };
+
+      const out = convertTraceToTraceData({
+        id: 't1',
+        input: 'in',
+        output: 'out',
+        context: context,
+      });
+
+      expect(out.context).toEqual(context);
     });
   });
 });
-
-

--- a/tests/unit/services/test_rubric_parsing.py
+++ b/tests/unit/services/test_rubric_parsing.py
@@ -1,0 +1,236 @@
+"""Unit tests for rubric question parsing functionality.
+
+Tests the _parse_rubric_questions and _reconstruct_rubric_questions methods
+in DatabaseService which handle the QUESTION_DELIMITER format.
+"""
+
+import pytest
+from unittest.mock import MagicMock
+
+from server.services.database_service import DatabaseService
+
+
+@pytest.fixture
+def db_service():
+    """Create a DatabaseService with a mocked session for testing parsing."""
+    mock_session = MagicMock()
+    return DatabaseService(mock_session)
+
+
+@pytest.mark.spec("RUBRIC_SPEC")
+class TestParseRubricQuestions:
+    """Tests for the _parse_rubric_questions method."""
+
+    def test_simple_questions(self, db_service):
+        """Test parsing two simple questions with the standard delimiter."""
+        raw = "Question 1: Description 1|||QUESTION_SEPARATOR|||Question 2: Description 2"
+
+        questions = db_service._parse_rubric_questions(raw)
+
+        assert len(questions) == 2
+        assert questions[0]['title'] == 'Question 1'
+        assert questions[0]['description'] == 'Description 1'
+        assert questions[1]['title'] == 'Question 2'
+        assert questions[1]['description'] == 'Description 2'
+
+    def test_multi_line_description(self, db_service):
+        """Test parsing questions with multi-line descriptions."""
+        raw = """Question 1: Line 1 of description
+Line 2 of description
+
+Line 3 after blank|||QUESTION_SEPARATOR|||Question 2: Single line"""
+
+        questions = db_service._parse_rubric_questions(raw)
+
+        assert len(questions) == 2
+        # First question should have multi-line description preserved
+        assert questions[0]['title'] == 'Question 1'
+        assert 'Line 1 of description' in questions[0]['description']
+        assert 'Line 2 of description' in questions[0]['description']
+        assert 'Line 3 after blank' in questions[0]['description']
+        # Second question should be simple
+        assert questions[1]['title'] == 'Question 2'
+
+    def test_empty_input_returns_empty_list(self, db_service):
+        """Test that empty input returns an empty list."""
+        assert db_service._parse_rubric_questions('') == []
+        assert db_service._parse_rubric_questions(None) == []
+
+    def test_whitespace_only_input_returns_empty_list(self, db_service):
+        """Test that whitespace-only input returns an empty list."""
+        assert db_service._parse_rubric_questions('   ') == []
+        assert db_service._parse_rubric_questions('\n\n') == []
+
+    def test_single_question(self, db_service):
+        """Test parsing a single question without separator."""
+        raw = "Single Question: This is the only question"
+
+        questions = db_service._parse_rubric_questions(raw)
+
+        assert len(questions) == 1
+        assert questions[0]['title'] == 'Single Question'
+        assert questions[0]['description'] == 'This is the only question'
+
+    def test_questions_with_judge_type(self, db_service):
+        """Test parsing questions that include judge type markers."""
+        raw = "Quality: Is it good?|||JUDGE_TYPE|||binary|||QUESTION_SEPARATOR|||Accuracy: Is it accurate?|||JUDGE_TYPE|||likert"
+
+        questions = db_service._parse_rubric_questions(raw)
+
+        assert len(questions) == 2
+        assert questions[0]['title'] == 'Quality'
+        assert questions[0]['judge_type'] == 'binary'
+        assert questions[1]['title'] == 'Accuracy'
+        assert questions[1]['judge_type'] == 'likert'
+
+    def test_default_judge_type_is_likert(self, db_service):
+        """Test that questions without judge type default to likert."""
+        raw = "Simple Question: No judge type specified"
+
+        questions = db_service._parse_rubric_questions(raw)
+
+        assert len(questions) == 1
+        assert questions[0].get('judge_type', 'likert') == 'likert'
+
+    def test_questions_have_ids(self, db_service):
+        """Test that parsed questions have ID fields."""
+        raw = "Q1: Desc 1|||QUESTION_SEPARATOR|||Q2: Desc 2"
+
+        questions = db_service._parse_rubric_questions(raw)
+
+        assert all('id' in q for q in questions)
+        assert questions[0]['id'] == 'q_1'
+        assert questions[1]['id'] == 'q_2'
+
+    def test_whitespace_trimmed(self, db_service):
+        """Test that whitespace is trimmed from parsed values."""
+        raw = "  Question Title  :   Description with spaces   "
+
+        questions = db_service._parse_rubric_questions(raw)
+
+        assert len(questions) == 1
+        # Titles should be trimmed
+        assert questions[0]['title'].strip() == questions[0]['title']
+
+    def test_empty_parts_filtered_out(self, db_service):
+        """Test that empty parts between delimiters are filtered out."""
+        raw = "Q1: D1|||QUESTION_SEPARATOR||||||QUESTION_SEPARATOR|||Q2: D2"
+
+        questions = db_service._parse_rubric_questions(raw)
+
+        # Should only get 2 questions, empty part in middle filtered
+        assert len(questions) == 2
+
+    def test_legacy_delimiter_supported(self, db_service):
+        """Test that legacy --- delimiter is still supported for backward compatibility."""
+        # Based on the code, legacy delimiter '---' is also supported
+        raw = "Q1: D1---Q2: D2"
+
+        questions = db_service._parse_rubric_questions(raw)
+
+        # Should parse correctly with legacy delimiter
+        assert len(questions) >= 1
+
+
+@pytest.mark.spec("RUBRIC_SPEC")
+class TestReconstructRubricQuestions:
+    """Tests for the _reconstruct_rubric_questions method."""
+
+    def test_reconstruct_simple_questions(self, db_service):
+        """Test reconstructing questions back to string format."""
+        questions = [
+            {'id': 'q_1', 'title': 'Question 1', 'description': 'Description 1', 'judge_type': 'likert'},
+            {'id': 'q_2', 'title': 'Question 2', 'description': 'Description 2', 'judge_type': 'likert'},
+        ]
+
+        reconstructed = db_service._reconstruct_rubric_questions(questions)
+
+        assert '|||QUESTION_SEPARATOR|||' in reconstructed
+        assert 'Question 1' in reconstructed
+        assert 'Question 2' in reconstructed
+
+    def test_reconstruct_preserves_judge_type(self, db_service):
+        """Test that reconstructing preserves judge type information."""
+        questions = [
+            {'id': 'q_1', 'title': 'Binary Q', 'description': 'Desc', 'judge_type': 'binary'},
+        ]
+
+        reconstructed = db_service._reconstruct_rubric_questions(questions)
+
+        assert '|||JUDGE_TYPE|||binary' in reconstructed
+
+    def test_reconstruct_updates_ids_sequentially(self, db_service):
+        """Test that reconstructing updates IDs to be sequential."""
+        questions = [
+            {'id': 'old_id_1', 'title': 'Q1', 'description': 'D1', 'judge_type': 'likert'},
+            {'id': 'random_id', 'title': 'Q2', 'description': 'D2', 'judge_type': 'likert'},
+        ]
+
+        db_service._reconstruct_rubric_questions(questions)
+
+        # IDs should be updated to q_1, q_2
+        assert questions[0]['id'] == 'q_1'
+        assert questions[1]['id'] == 'q_2'
+
+    def test_reconstruct_empty_list_returns_empty_string(self, db_service):
+        """Test that empty questions list returns empty string."""
+        result = db_service._reconstruct_rubric_questions([])
+        assert result == ''
+
+
+@pytest.mark.spec("RUBRIC_SPEC")
+class TestRoundTrip:
+    """Tests that parse and reconstruct are consistent."""
+
+    def test_parse_reconstruct_roundtrip(self, db_service):
+        """Test that parsing and reconstructing are consistent (roundtrip)."""
+        original = "Quality: Is the response high quality?|||JUDGE_TYPE|||binary|||QUESTION_SEPARATOR|||Accuracy: Is it factually correct?|||JUDGE_TYPE|||likert"
+
+        # Parse
+        questions = db_service._parse_rubric_questions(original)
+
+        # Reconstruct back
+        reconstructed = db_service._reconstruct_rubric_questions(questions)
+
+        # Parse again
+        questions_again = db_service._parse_rubric_questions(reconstructed)
+
+        # Should have same structure
+        assert len(questions) == len(questions_again)
+        assert questions[0]['title'] == questions_again[0]['title']
+        assert questions[1]['title'] == questions_again[1]['title']
+        assert questions[0]['judge_type'] == questions_again[0]['judge_type']
+        assert questions[1]['judge_type'] == questions_again[1]['judge_type']
+
+
+@pytest.mark.spec("RUBRIC_SPEC")
+class TestBinaryScaleSupport:
+    """Tests for binary scale support in rubrics."""
+
+    def test_binary_judge_type_parsed_correctly(self, db_service):
+        """Test that binary judge type is correctly identified."""
+        raw = "Pass/Fail Check: Does it pass?|||JUDGE_TYPE|||binary"
+
+        questions = db_service._parse_rubric_questions(raw)
+
+        assert len(questions) == 1
+        assert questions[0]['judge_type'] == 'binary'
+
+    def test_likert_judge_type_parsed_correctly(self, db_service):
+        """Test that likert judge type is correctly identified."""
+        raw = "Quality Rating: Rate from 1-5|||JUDGE_TYPE|||likert"
+
+        questions = db_service._parse_rubric_questions(raw)
+
+        assert len(questions) == 1
+        assert questions[0]['judge_type'] == 'likert'
+
+    def test_mixed_judge_types_in_rubric(self, db_service):
+        """Test rubric with both binary and likert questions."""
+        raw = "Safety: Is it safe?|||JUDGE_TYPE|||binary|||QUESTION_SEPARATOR|||Quality: How good is it?|||JUDGE_TYPE|||likert"
+
+        questions = db_service._parse_rubric_questions(raw)
+
+        assert len(questions) == 2
+        assert questions[0]['judge_type'] == 'binary'
+        assert questions[1]['judge_type'] == 'likert'

--- a/tests/unit/test_sqlite_rescue.py
+++ b/tests/unit/test_sqlite_rescue.py
@@ -1,0 +1,200 @@
+"""Unit tests for SQLite Rescue module.
+
+Tests configuration parsing, path validation, and volume path utilities
+for Databricks Apps database persistence.
+"""
+
+import os
+import pytest
+from unittest.mock import patch
+
+from server.sqlite_rescue import (
+    _get_config,
+    _validate_volume_path,
+    _get_volume_root,
+)
+
+
+@pytest.mark.spec("BUILD_AND_DEPLOY_SPEC")
+class TestGetConfig:
+    """Tests for the _get_config function."""
+
+    def test_default_database_url(self):
+        """Test default DATABASE_URL parsing."""
+        with patch.dict(os.environ, {}, clear=True):
+            local_path, volume_path, interval = _get_config()
+            # Default is sqlite:///./workshop.db
+            assert local_path == "./workshop.db"
+            assert volume_path is None
+            assert interval == 10  # Default interval
+
+    def test_sqlite_triple_slash_url(self):
+        """Test sqlite:/// URL format."""
+        with patch.dict(os.environ, {"DATABASE_URL": "sqlite:///./data/app.db"}, clear=True):
+            local_path, volume_path, interval = _get_config()
+            assert local_path == "./data/app.db"
+
+    def test_sqlite_double_slash_url(self):
+        """Test sqlite:// URL format (less common)."""
+        with patch.dict(os.environ, {"DATABASE_URL": "sqlite://./data/app.db"}, clear=True):
+            local_path, volume_path, interval = _get_config()
+            assert local_path == "./data/app.db"
+
+    def test_non_sqlite_url_returns_none(self):
+        """Test that non-SQLite URLs return None for local path."""
+        with patch.dict(os.environ, {"DATABASE_URL": "postgresql://localhost/db"}, clear=True):
+            local_path, volume_path, interval = _get_config()
+            assert local_path is None
+
+    def test_volume_backup_path_direct(self):
+        """Test SQLITE_VOLUME_BACKUP_PATH configuration."""
+        env = {
+            "DATABASE_URL": "sqlite:///./workshop.db",
+            "SQLITE_VOLUME_BACKUP_PATH": "/Volumes/catalog/schema/volume/backup.db",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            local_path, volume_path, interval = _get_config()
+            assert volume_path == "/Volumes/catalog/schema/volume/backup.db"
+
+    def test_volume_path_appends_workshop_db(self):
+        """Test SQLITE_VOLUME_PATH appends /workshop.db."""
+        env = {
+            "DATABASE_URL": "sqlite:///./workshop.db",
+            "SQLITE_VOLUME_PATH": "/Volumes/catalog/schema/volume",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            local_path, volume_path, interval = _get_config()
+            assert volume_path == "/Volumes/catalog/schema/volume/workshop.db"
+
+    def test_volume_path_with_trailing_slash(self):
+        """Test SQLITE_VOLUME_PATH with trailing slash is handled."""
+        env = {
+            "DATABASE_URL": "sqlite:///./workshop.db",
+            "SQLITE_VOLUME_PATH": "/Volumes/catalog/schema/volume/",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            local_path, volume_path, interval = _get_config()
+            assert volume_path == "/Volumes/catalog/schema/volume/workshop.db"
+            assert "//" not in volume_path  # No double slashes
+
+    def test_backup_path_takes_precedence(self):
+        """Test that SQLITE_VOLUME_BACKUP_PATH takes precedence over SQLITE_VOLUME_PATH."""
+        env = {
+            "DATABASE_URL": "sqlite:///./workshop.db",
+            "SQLITE_VOLUME_PATH": "/Volumes/catalog/schema/volume",
+            "SQLITE_VOLUME_BACKUP_PATH": "/Volumes/other/path/custom.db",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            local_path, volume_path, interval = _get_config()
+            assert volume_path == "/Volumes/other/path/custom.db"
+
+    def test_custom_backup_interval(self):
+        """Test custom backup interval configuration."""
+        env = {
+            "DATABASE_URL": "sqlite:///./workshop.db",
+            "SQLITE_BACKUP_INTERVAL_MINUTES": "30",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            local_path, volume_path, interval = _get_config()
+            assert interval == 30
+
+    def test_backup_interval_zero_disables(self):
+        """Test that interval of 0 is allowed (disables backup timer)."""
+        env = {
+            "DATABASE_URL": "sqlite:///./workshop.db",
+            "SQLITE_BACKUP_INTERVAL_MINUTES": "0",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            local_path, volume_path, interval = _get_config()
+            assert interval == 0
+
+
+@pytest.mark.spec("BUILD_AND_DEPLOY_SPEC")
+class TestValidateVolumePath:
+    """Tests for the _validate_volume_path function."""
+
+    def test_valid_volume_path(self):
+        """Test valid Unity Catalog volume path."""
+        path = "/Volumes/my_catalog/my_schema/my_volume/workshop.db"
+        is_valid, error = _validate_volume_path(path)
+        assert is_valid is True
+        assert error == ""
+
+    def test_valid_nested_path(self):
+        """Test valid nested path within volume."""
+        path = "/Volumes/catalog/schema/volume/subdir/nested/file.db"
+        is_valid, error = _validate_volume_path(path)
+        assert is_valid is True
+        assert error == ""
+
+    def test_empty_path_is_invalid(self):
+        """Test that empty path is invalid."""
+        is_valid, error = _validate_volume_path("")
+        assert is_valid is False
+        assert "empty" in error.lower()
+
+    def test_none_path_is_invalid(self):
+        """Test that None path is invalid."""
+        is_valid, error = _validate_volume_path(None)
+        assert is_valid is False
+
+    def test_non_volumes_prefix_is_invalid(self):
+        """Test that paths not starting with /Volumes/ are invalid."""
+        path = "/dbfs/mnt/my_volume/file.db"
+        is_valid, error = _validate_volume_path(path)
+        assert is_valid is False
+        assert "/Volumes/" in error
+
+    def test_incomplete_volume_path_is_invalid(self):
+        """Test that incomplete volume path is invalid."""
+        # Missing filename component
+        path = "/Volumes/catalog/schema"
+        is_valid, error = _validate_volume_path(path)
+        assert is_valid is False
+        assert "Invalid Unity Catalog volume path" in error
+
+    def test_just_volumes_root_is_invalid(self):
+        """Test that just /Volumes/ is invalid."""
+        path = "/Volumes/"
+        is_valid, error = _validate_volume_path(path)
+        assert is_valid is False
+
+    def test_case_sensitive_volumes_prefix(self):
+        """Test that /Volumes/ prefix is case-sensitive."""
+        path = "/volumes/catalog/schema/volume/file.db"
+        is_valid, error = _validate_volume_path(path)
+        assert is_valid is False  # lowercase 'v' should fail
+
+
+@pytest.mark.spec("BUILD_AND_DEPLOY_SPEC")
+class TestGetVolumeRoot:
+    """Tests for the _get_volume_root function."""
+
+    def test_extracts_volume_root(self):
+        """Test extracting volume root from full path."""
+        path = "/Volumes/my_catalog/my_schema/my_volume/workshop.db"
+        root = _get_volume_root(path)
+        assert root == "/Volumes/my_catalog/my_schema/my_volume"
+
+    def test_extracts_root_from_nested_path(self):
+        """Test extracting volume root from deeply nested path."""
+        path = "/Volumes/catalog/schema/volume/a/b/c/file.db"
+        root = _get_volume_root(path)
+        assert root == "/Volumes/catalog/schema/volume"
+
+    def test_returns_none_for_short_path(self):
+        """Test that short paths return None."""
+        path = "/Volumes/catalog"
+        root = _get_volume_root(path)
+        assert root is None
+
+    def test_returns_none_for_empty_path(self):
+        """Test that empty path returns None."""
+        root = _get_volume_root("")
+        assert root is None
+
+    def test_exact_volume_path_returns_self(self):
+        """Test that exact volume path returns itself."""
+        path = "/Volumes/catalog/schema/volume"
+        root = _get_volume_root(path)
+        assert root == path

--- a/tests/unit/utils/test_jsonpath_utils.py
+++ b/tests/unit/utils/test_jsonpath_utils.py
@@ -5,6 +5,7 @@ import pytest
 from server.utils.jsonpath_utils import apply_jsonpath, validate_jsonpath
 
 
+@pytest.mark.spec("TRACE_DISPLAY_SPEC")
 class TestApplyJsonPath:
     """Tests for the apply_jsonpath function."""
 
@@ -124,6 +125,7 @@ class TestApplyJsonPath:
         assert result == "hello"
 
 
+@pytest.mark.spec("TRACE_DISPLAY_SPEC")
 class TestValidateJsonPath:
     """Tests for the validate_jsonpath function."""
 


### PR DESCRIPTION
## Summary
- Add comprehensive unit tests for multiple rubric questions with different judge types (Likert, Binary, Freeform)
- Add JudgeTypeSelector component tests for the judge tuning page
- Expand existing test coverage across multiple specs
- Add Python unit tests to CI workflow (runs after E2E tests)

## Test Coverage Added

| Test File | Tests | Spec |
|-----------|-------|------|
| JudgeTypeSelector.test.tsx | 26 | JUDGE_EVALUATION_SPEC |
| rubricUtils.test.ts | 22 | RUBRIC_SPEC |
| TraceDataViewer.test.tsx | 25 | UI_COMPONENTS_SPEC |
| Pagination.test.tsx | 32 | UI_COMPONENTS_SPEC |
| useJsonPathExtraction.test.ts | 22 | TRACE_DISPLAY_SPEC |
| utils.test.ts | 29 | DESIGN_SYSTEM_SPEC |
| test_rubric_parsing.py | 19 | RUBRIC_SPEC |
| test_sqlite_rescue.py | 23 | BUILD_AND_DEPLOY_SPEC |

**Total:** 125 Python tests, 173 frontend tests

## Test plan
- [x] All Python unit tests pass (`just test-server`)
- [x] All frontend unit tests pass (`just ui-test-unit`)
- [ ] CI pipeline runs E2E tests followed by Python unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)