### PR TITLE
chore: clear MLFLOW_EXPERIMENT_ID to empty string

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -44,6 +44,6 @@
   "environment": {
     "MLFLOW_CLAUDE_TRACING_ENABLED": "true",
     "MLFLOW_TRACKING_URI": "databricks",
-    "MLFLOW_EXPERIMENT_ID": "2517718719903786"
+    "MLFLOW_EXPERIMENT_ID": ""
   }
 }


### PR DESCRIPTION
Clear the MLFLOW_EXPERIMENT_ID in .claude/settings.json to avoid using a specific experiment ID.