### PR TITLE
chore: add GitHub PR and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,33 @@
+---
+name: Documentation
+about: Propose new documentation or improvements to existing docs
+title: '[Docs] '
+labels: documentation
+---
+
+## What needs documenting?
+
+<!-- Describe the topic, feature, or workflow that needs documentation -->
+
+## Related Specs
+
+<!-- Which spec(s) does this relate to? Docs complement specs but focus on user-facing guidance rather than implementation details -->
+- Spec: `SPEC_NAME` (if applicable)
+
+## Suggested Location
+
+<!-- Where should this documentation live? -->
+- [ ] `/doc/` (user-facing guides and release notes)
+- [ ] README.md
+- [ ] CONTRIBUTING.md
+- [ ] `/specs/` (if defining new behavior - requires approval)
+- [ ] `.claude/skills/` (agent-specific guidance)
+- [ ] Other:
+
+## Context
+
+<!-- Why is this documentation needed? What problem does it solve? -->
+
+## Additional Notes
+
+<!-- Any examples, references, or details that would help write this documentation -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Summary
+
+<!-- Brief description of what this PR does -->
+
+## Related Spec
+
+<!-- Which spec(s) does this PR implement or affect? -->
+- Spec: `SPEC_NAME` (from `/specs/`)
+
+## Changes
+
+<!-- List the key changes made -->
+-
+
+## Testing
+
+<!-- How was this tested? -->
+- [ ] Tests tagged with `@pytest.mark.spec("SPEC_NAME")` or equivalent
+- [ ] `just test-server` passes
+- [ ] `just ui-test-unit` passes
+- [ ] `just ui-lint` passes
+- [ ] E2E tests pass (if applicable)
+
+## Checklist
+
+- [ ] Read the relevant spec before implementing
+- [ ] No changes to `/specs/` without approval
+- [ ] No new database migrations without approval
+- [ ] Coverage map updated if new tests added (`uv run spec-coverage-analyzer`)


### PR DESCRIPTION
Add templates to standardize contributions:
- PR template aligned with spec-driven workflow
- Documentation issue template for /doc/ changes