### PR TITLE
fix: Truncate workshop description to single line

### DIFF
--- a/client/src/components/WorkshopHeader.tsx
+++ b/client/src/components/WorkshopHeader.tsx
@@ -75,7 +75,7 @@ export const WorkshopHeader: React.FC<WorkshopHeaderProps> = ({
           </div>
           
           {showDescription && workshop.description && (
-            <p className="text-sm text-muted-foreground mt-1 max-w-2xl">
+            <p className="text-sm text-muted-foreground mt-1 max-w-2xl line-clamp-1">
               {workshop.description}
             </p>
           )}


### PR DESCRIPTION
## Summary
- Truncates the workshop description in the header to a single line with ellipsis overflow, preventing long descriptions from dominating the page layout.

## Test plan
- [ ] Verify workshop description shows only one line on the Intake page
- [ ] Verify long descriptions show ellipsis ("...") at the end
- [ ] Verify short descriptions still display normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)