### PR TITLE
fix: Add React Error Boundaries to prevent full app crashes (#88)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,6 +6,7 @@ import { UserProvider } from './context/UserContext';
 import { WorkflowProvider } from './context/WorkflowContext';
 import { WorkshopDemoLanding } from './pages/WorkshopDemoLanding';
 import { TraceDataViewerDemo } from './pages/TraceDataViewerDemo';
+import { ErrorBoundary, RootErrorFallback } from './components/ErrorBoundary';
 import { Toaster } from 'sonner';
 
 // Create a client
@@ -13,26 +14,28 @@ const queryClient = new QueryClient();
 
 function App() {
   return (
-    <QueryClientProvider client={queryClient}>
-      <UserProvider>
-        <WorkshopProvider>
-          <WorkflowProvider>
-            <Router>
-              <Routes>
-                <Route path="/" element={<WorkshopDemoLanding />} />
-                <Route path="/trace-viewer-demo" element={<TraceDataViewerDemo />} />
-              </Routes>
-            </Router>
-            <Toaster 
-              position="top-right" 
-              expand={true}
-              richColors={true}
-              closeButton={true}
-            />
-          </WorkflowProvider>
-        </WorkshopProvider>
-      </UserProvider>
-    </QueryClientProvider>
+    <ErrorBoundary fallback={(props) => <RootErrorFallback {...props} />}>
+      <QueryClientProvider client={queryClient}>
+        <UserProvider>
+          <WorkshopProvider>
+            <WorkflowProvider>
+              <Router>
+                <Routes>
+                  <Route path="/" element={<WorkshopDemoLanding />} />
+                  <Route path="/trace-viewer-demo" element={<TraceDataViewerDemo />} />
+                </Routes>
+              </Router>
+              <Toaster
+                position="top-right"
+                expand={true}
+                richColors={true}
+                closeButton={true}
+              />
+            </WorkflowProvider>
+          </WorkshopProvider>
+        </UserProvider>
+      </QueryClientProvider>
+    </ErrorBoundary>
   );
 }
 

--- a/client/src/components/ErrorBoundary.test.tsx
+++ b/client/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ErrorBoundary, RootErrorFallback, PageErrorFallback } from './ErrorBoundary';
+
+// Suppress React error boundary console.error noise in test output
+beforeEach(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+function ThrowingComponent({ message }: { message?: string }) {
+  throw new Error(message ?? 'test render error');
+}
+
+function GoodComponent() {
+  return <div>All good</div>;
+}
+
+describe('ErrorBoundary', () => {
+  it('renders children when there is no error', () => {
+    render(
+      <ErrorBoundary>
+        <GoodComponent />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('All good')).toBeInTheDocument();
+  });
+
+  it('renders default fallback when a child throws', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('Page error')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
+  });
+
+  it('renders custom fallback element', () => {
+    render(
+      <ErrorBoundary fallback={<div>Custom fallback</div>}>
+        <ThrowingComponent />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('Custom fallback')).toBeInTheDocument();
+  });
+
+  it('renders custom fallback function with error and reset', () => {
+    render(
+      <ErrorBoundary
+        fallback={({ error, reset }) => (
+          <div>
+            <span>Error: {error.message}</span>
+            <button onClick={reset}>Reset</button>
+          </div>
+        )}
+      >
+        <ThrowingComponent message="kaboom" />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('Error: kaboom')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Reset' })).toBeInTheDocument();
+  });
+
+  it('calls onError callback when an error is caught', () => {
+    const onError = vi.fn();
+    render(
+      <ErrorBoundary onError={onError}>
+        <ThrowingComponent message="callback test" />
+      </ErrorBoundary>,
+    );
+    expect(onError).toHaveBeenCalledOnce();
+    expect(onError.mock.calls[0][0]).toBeInstanceOf(Error);
+    expect(onError.mock.calls[0][0].message).toBe('callback test');
+  });
+
+  it('recovers from error when reset is triggered', async () => {
+    const user = userEvent.setup();
+    let shouldThrow = true;
+
+    function MaybeThrows() {
+      if (shouldThrow) throw new Error('conditional error');
+      return <div>Recovered</div>;
+    }
+
+    render(
+      <ErrorBoundary>
+        <MaybeThrows />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('Page error')).toBeInTheDocument();
+
+    // Fix the error condition, then click "Try again"
+    shouldThrow = false;
+    await user.click(screen.getByRole('button', { name: /try again/i }));
+
+    expect(screen.getByText('Recovered')).toBeInTheDocument();
+  });
+});
+
+describe('RootErrorFallback', () => {
+  it('renders full-page recovery UI', () => {
+    const reset = vi.fn();
+    render(<RootErrorFallback error={new Error('root error')} reset={reset} />);
+
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /reload page/i })).toBeInTheDocument();
+  });
+
+  it('calls reset when Try again is clicked', async () => {
+    const user = userEvent.setup();
+    const reset = vi.fn();
+    render(<RootErrorFallback error={new Error('root error')} reset={reset} />);
+
+    await user.click(screen.getByRole('button', { name: /try again/i }));
+    expect(reset).toHaveBeenCalledOnce();
+  });
+});
+
+describe('PageErrorFallback', () => {
+  it('renders inline recovery UI', () => {
+    const reset = vi.fn();
+    render(<PageErrorFallback error={new Error('page error')} reset={reset} />);
+
+    expect(screen.getByText('Page error')).toBeInTheDocument();
+    expect(
+      screen.getByText(/This section encountered an error/),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
+  });
+
+  it('calls reset when Try again is clicked', async () => {
+    const user = userEvent.setup();
+    const reset = vi.fn();
+    render(<PageErrorFallback error={new Error('page error')} reset={reset} />);
+
+    await user.click(screen.getByRole('button', { name: /try again/i }));
+    expect(reset).toHaveBeenCalledOnce();
+  });
+});

--- a/client/src/components/ErrorBoundary.tsx
+++ b/client/src/components/ErrorBoundary.tsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import { AlertCircle, RefreshCw } from 'lucide-react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+  /** Fallback UI to render on error. Receives error and reset function. */
+  fallback?: React.ReactNode | ((props: { error: Error; reset: () => void }) => React.ReactNode);
+  /** Called when an error is caught. Useful for telemetry/logging. */
+  onError?: (error: Error, errorInfo: React.ErrorInfo) => void;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+/**
+ * React Error Boundary — catches unhandled render errors in child components
+ * and displays a recovery UI instead of crashing the entire app.
+ *
+ * Must be a class component per React API requirements.
+ */
+export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
+    this.props.onError?.(error, errorInfo);
+  }
+
+  reset = (): void => {
+    this.setState({ error: null });
+  };
+
+  render(): React.ReactNode {
+    if (this.state.error) {
+      if (this.props.fallback) {
+        if (typeof this.props.fallback === 'function') {
+          return this.props.fallback({ error: this.state.error, reset: this.reset });
+        }
+        return this.props.fallback;
+      }
+
+      return <DefaultErrorFallback error={this.state.error} reset={this.reset} />;
+    }
+
+    return this.props.children;
+  }
+}
+
+/** Full-page fallback for the root-level boundary. */
+export function RootErrorFallback({ error, reset }: { error: Error; reset: () => void }) {
+  return (
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center p-6">
+      <Card className="max-w-lg w-full border-l-4 border-red-500">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <AlertCircle className="h-5 w-5 text-red-600" />
+            Something went wrong
+            <Badge className="ml-auto bg-red-50 text-red-600 border-red-200">Error</Badge>
+          </CardTitle>
+          <CardDescription>
+            The application encountered an unexpected error.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-sm text-gray-600">
+            You can try recovering by clicking the button below. If the problem persists, refresh the page.
+          </p>
+          {import.meta.env.DEV && (
+            <pre className="text-xs text-red-700 bg-red-50 border border-red-200 rounded p-3 overflow-auto max-h-40">
+              {error.message}
+              {error.stack && `\n\n${error.stack}`}
+            </pre>
+          )}
+          <div className="flex gap-3">
+            <Button onClick={reset} variant="default">
+              <RefreshCw className="h-4 w-4 mr-2" />
+              Try again
+            </Button>
+            <Button onClick={() => window.location.reload()} variant="outline">
+              Reload page
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+/** Inline fallback for page-level boundaries (keeps sidebar/header visible). */
+export function PageErrorFallback({ error, reset }: { error: Error; reset: () => void }) {
+  return (
+    <div className="flex items-center justify-center p-6 h-full">
+      <Card className="max-w-md w-full border-l-4 border-amber-500">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <AlertCircle className="h-5 w-5 text-amber-600" />
+            Page error
+            <Badge className="ml-auto bg-amber-50 text-amber-600 border-amber-200">Error</Badge>
+          </CardTitle>
+          <CardDescription>
+            This section encountered an error, but you can keep using the rest of the app.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {import.meta.env.DEV && (
+            <pre className="text-xs text-red-700 bg-red-50 border border-red-200 rounded p-3 overflow-auto max-h-32">
+              {error.message}
+            </pre>
+          )}
+          <div className="flex gap-3">
+            <Button onClick={reset} size="sm" variant="default">
+              <RefreshCw className="h-4 w-4 mr-2" />
+              Try again
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function DefaultErrorFallback({ error, reset }: { error: Error; reset: () => void }) {
+  return <PageErrorFallback error={error} reset={reset} />;
+}

--- a/client/src/pages/WorkshopDemoLanding.tsx
+++ b/client/src/pages/WorkshopDemoLanding.tsx
@@ -41,6 +41,7 @@ import { AnnotationPendingPage } from '@/components/AnnotationPendingPage';
 import { FacilitatorScreenShare } from '@/components/FacilitatorScreenShare';
 import { PhasePausedView } from '@/components/PhasePausedView';
 import { GeneralDashboard } from '@/components/GeneralDashboard';
+import { ErrorBoundary, PageErrorFallback } from '@/components/ErrorBoundary';
 
 
 
@@ -639,9 +640,17 @@ export function WorkshopDemoLanding() {
                 </div>
               );
             }
-            
-            // Render the appropriate component
-            return renderCurrentView();
+
+            // Render the appropriate component inside a page-level error boundary
+            // so a crash in any page keeps the sidebar/header functional
+            return (
+              <ErrorBoundary
+                key={currentView}
+                fallback={(props) => <PageErrorFallback {...props} />}
+              >
+                {renderCurrentView()}
+              </ErrorBoundary>
+            );
           })()}
         </div>
       </div>


### PR DESCRIPTION
Wrap the app with a layered error boundary strategy so unhandled render errors show a recovery UI instead of a blank white screen:
- Root-level boundary in App.tsx catches fatal errors across the entire tree
- Page-level boundary in WorkshopDemoLanding wraps each view so crashes are isolated and the sidebar/header remain functional
- Reusable ErrorBoundary component supports custom fallbacks and onError callback

## Summary

<!-- Brief description of what this PR does -->

## Related Spec

<!-- Which spec(s) does this PR implement or affect? -->
- Spec: `SPEC_NAME` (from `/specs/`)

## Changes

<!-- List the key changes made -->
-

## Testing

<!-- How was this tested? -->
- [ ] Tests tagged with `@pytest.mark.spec("SPEC_NAME")` or equivalent
- [ ] `just test-server` passes
- [ ] `just ui-test-unit` passes
- [ ] `just ui-lint` passes
- [ ] E2E tests pass (if applicable)

## Checklist

- [ ] Read the relevant spec before implementing
- [ ] No changes to `/specs/` without approval
- [ ] No new database migrations without approval
- [ ] Coverage map updated if new tests added (`uv run spec-coverage-analyzer`)
