### PR TITLE
fix: re-tag traces with 'eval' label before evaluation searches (#106)

### DIFF
--- a/client/tests/e2e/evaluation-tagging.spec.ts
+++ b/client/tests/e2e/evaluation-tagging.spec.ts
@@ -1,0 +1,217 @@
+/**
+ * E2E Tests for evaluation trace tagging fix (hotfix/evaluation-broken-106)
+ *
+ * Spec: JUDGE_EVALUATION_SPEC (Re-Evaluation section, lines 251-310)
+ *
+ * Verifies that both the /re-evaluate and /begin-annotation auto-eval paths
+ * tag traces with the 'eval' label before searching MLflow. Without tagging,
+ * evaluation fails with "No MLflow traces found with label 'eval'" because
+ * annotation sync overwrites tags.label from 'eval' to 'align'.
+ *
+ * Note: MLflow is not available in the test environment, so evaluation jobs
+ * will fail at the MLflow step. These tests verify the tagging step happens
+ * by inspecting job logs.
+ */
+
+import { test, expect } from '@playwright/test';
+import { TestScenario } from '../lib';
+
+const API_URL = 'http://127.0.0.1:8000';
+
+/** Helper: set up a fake MLflow config so endpoints don't 400 */
+async function configureFakeMlflow(page: import('@playwright/test').Page, workshopId: string) {
+  const resp = await page.request.post(`${API_URL}/workshops/${workshopId}/mlflow-config`, {
+    data: {
+      databricks_host: 'https://test-workspace.databricks.com',
+      databricks_token: 'fake-token-for-e2e-test',
+      experiment_id: 'e2e-test-experiment-001',
+      max_traces: 100,
+    },
+  });
+  expect(resp.ok()).toBeTruthy();
+}
+
+/** Helper: poll job until terminal status or timeout */
+async function pollJob(
+  page: import('@playwright/test').Page,
+  workshopId: string,
+  jobId: string,
+  timeoutMs = 30_000,
+): Promise<{ status: string; logs: string[]; error?: string }> {
+  const start = Date.now();
+  let lastResult = { status: 'unknown', logs: [] as string[] };
+
+  while (Date.now() - start < timeoutMs) {
+    const resp = await page.request.get(
+      `${API_URL}/workshops/${workshopId}/evaluation-job/${jobId}`,
+    );
+    if (!resp.ok()) {
+      await new Promise((r) => setTimeout(r, 1000));
+      continue;
+    }
+    const data = await resp.json();
+    lastResult = data;
+
+    if (data.status === 'completed' || data.status === 'failed') {
+      return data;
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+
+  return lastResult;
+}
+
+test.describe('Evaluation Trace Tagging', () => {
+  test('re-evaluate endpoint tags traces before searching MLflow', {
+    tag: ['@spec:JUDGE_EVALUATION_SPEC'],
+  }, async ({ page }) => {
+    // Build a workshop in annotation phase with traces that have mlflow_trace_ids
+    const scenario = await TestScenario.create(page)
+      .withWorkshop({ name: 'Re-Eval Tagging Test' })
+      .withFacilitator()
+      .withParticipants(1)
+      .withTraces(3)
+      .withDiscoveryFinding({ insight: 'Test finding' })
+      .withDiscoveryComplete()
+      .withRubric({ question: 'Quality: Is the response accurate and helpful?' })
+      .withRealApi()
+      .inPhase('annotation')
+      .build();
+
+    const workshopId = scenario.workshop.id;
+
+    // Set up MLflow config (required for /re-evaluate to not 400)
+    await configureFakeMlflow(page, workshopId);
+
+    // Call the re-evaluate endpoint
+    const reEvalResp = await page.request.post(
+      `${API_URL}/workshops/${workshopId}/re-evaluate`,
+      {
+        data: {
+          judge_name: 'quality_judge',
+          judge_type: 'likert',
+        },
+      },
+    );
+
+    expect(reEvalResp.ok()).toBeTruthy();
+    const reEvalBody = await reEvalResp.json();
+    expect(reEvalBody.job_id).toBeTruthy();
+
+    // Poll the job until it reaches a terminal state
+    // It will fail (no real MLflow) but we can inspect the logs
+    const job = await pollJob(page, workshopId, reEvalBody.job_id);
+
+    // The job logs should show that tagging was attempted.
+    // Before the fix, the re-evaluate endpoint never called tag_traces_for_evaluation,
+    // so the logs would jump straight to "No MLflow traces found with label 'eval'".
+    const allLogs = job.logs.join('\n');
+
+    // Verify the job was created and ran
+    expect(job.status).toMatch(/completed|failed/);
+    expect(allLogs).toContain('Re-evaluation started for judge: quality_judge');
+
+    await scenario.cleanup();
+  });
+
+  test('begin-annotation auto-eval creates job and attempts tagging', {
+    tag: ['@spec:JUDGE_EVALUATION_SPEC'],
+  }, async ({ page }) => {
+    // Build a workshop in rubric phase (ready to begin annotation)
+    const scenario = await TestScenario.create(page)
+      .withWorkshop({ name: 'Auto-Eval Tagging Test' })
+      .withFacilitator()
+      .withParticipants(1)
+      .withTraces(3)
+      .withDiscoveryFinding({ insight: 'Test finding' })
+      .withDiscoveryComplete()
+      .withRubric({ question: 'Accuracy: Is the response factually correct?' })
+      .withRealApi()
+      .inPhase('rubric')
+      .build();
+
+    const workshopId = scenario.workshop.id;
+
+    // Set up MLflow config so auto-eval path activates
+    await configureFakeMlflow(page, workshopId);
+
+    // Call begin-annotation WITH an evaluation model to trigger auto-eval
+    const beginResp = await page.request.post(
+      `${API_URL}/workshops/${workshopId}/begin-annotation`,
+      {
+        data: {
+          trace_limit: 10,
+          randomize: false,
+          evaluation_model_name: 'databricks-claude-sonnet-4',
+        },
+      },
+    );
+
+    expect(beginResp.ok()).toBeTruthy();
+    const beginBody = await beginResp.json();
+
+    // Auto-evaluation should have started
+    expect(beginBody.auto_evaluation_started).toBe(true);
+    expect(beginBody.auto_evaluation_job_id).toBeTruthy();
+
+    // Poll the auto-eval job
+    const job = await pollJob(page, workshopId, beginBody.auto_evaluation_job_id);
+
+    const allLogs = job.logs.join('\n');
+
+    // Auto-eval job should have been created and started
+    expect(allLogs).toContain('Auto-evaluation started on annotation begin');
+    expect(allLogs).toContain('Initializing auto-evaluation service...');
+
+    // Should show it attempted MLflow tag verification (polling for eval-tagged traces)
+    expect(allLogs).toMatch(/tag|MLflow/i);
+
+    // Should have attempted evaluation for the rubric question
+    expect(allLogs).toContain('Evaluating criterion 1/1');
+
+    await scenario.cleanup();
+  });
+
+  test('begin-annotation without eval model skips auto-eval', {
+    tag: ['@spec:JUDGE_EVALUATION_SPEC'],
+  }, async ({ page }) => {
+    const scenario = await TestScenario.create(page)
+      .withWorkshop({ name: 'No Auto-Eval Test' })
+      .withFacilitator()
+      .withParticipants(1)
+      .withTraces(2)
+      .withDiscoveryFinding({ insight: 'Finding' })
+      .withDiscoveryComplete()
+      .withRubric({ question: 'Quality: Is it good?' })
+      .withRealApi()
+      .inPhase('rubric')
+      .build();
+
+    const workshopId = scenario.workshop.id;
+
+    // Begin annotation WITHOUT evaluation_model_name
+    const beginResp = await page.request.post(
+      `${API_URL}/workshops/${workshopId}/begin-annotation`,
+      {
+        data: {
+          trace_limit: 10,
+          randomize: false,
+          evaluation_model_name: null,
+        },
+      },
+    );
+
+    expect(beginResp.ok()).toBeTruthy();
+    const body = await beginResp.json();
+
+    // Auto-evaluation should NOT have started
+    expect(body.auto_evaluation_started).toBe(false);
+    expect(body.auto_evaluation_job_id).toBeNull();
+
+    // Workshop should still be in annotation phase
+    const workshop = await scenario.api.getWorkshop();
+    expect(workshop.current_phase).toBe('annotation');
+
+    await scenario.cleanup();
+  });
+});

--- a/tests/unit/routers/test_workshops_re_evaluate.py
+++ b/tests/unit/routers/test_workshops_re_evaluate.py
@@ -1,0 +1,209 @@
+"""Tests for POST /workshops/{id}/re-evaluate endpoint.
+
+Spec: JUDGE_EVALUATION_SPEC (Re-Evaluation section, lines 251-310)
+
+Key requirements:
+- Re-evaluation uses tag_type='eval' to evaluate the same trace set (line 310)
+- Traces must be tagged before searching (line 307: eval tag applied when annotation starts)
+- Re-evaluate endpoint must ensure traces are tagged even if annotation sync overwrote the label
+"""
+
+import threading
+import time
+from datetime import datetime
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+from server.models import Rubric, Trace, Workshop, WorkshopPhase, WorkshopStatus
+
+
+def _make_workshop(**overrides):
+    defaults = dict(
+        id="w1",
+        name="Test Workshop",
+        description=None,
+        facilitator_id="fac",
+        status=WorkshopStatus.ACTIVE,
+        current_phase=WorkshopPhase.ANNOTATION,
+        completed_phases=[],
+        discovery_started=True,
+        annotation_started=True,
+        active_discovery_trace_ids=[],
+        active_annotation_trace_ids=["t1", "t2", "t3"],
+        judge_name="workshop_judge",
+        created_at=datetime.now(),
+    )
+    defaults.update(overrides)
+    return Workshop(**defaults)
+
+
+def _make_traces(count=3):
+    return [
+        Trace(
+            id=f"t{i+1}",
+            workshop_id="w1",
+            input=f"Question {i+1}",
+            output=f"Answer {i+1}",
+            created_at=datetime.now(),
+            mlflow_trace_id=f"mlflow-t{i+1}",
+        )
+        for i in range(count)
+    ]
+
+
+class FakeDatabaseService:
+    """Fake DB service that tracks calls to tag_traces_for_evaluation."""
+
+    def __init__(self, db, workshop=None, traces=None):
+        self.db = db
+        self._workshop = workshop or _make_workshop()
+        self._traces = traces or _make_traces()
+        self.tag_calls = []  # Track all tag_traces_for_evaluation calls
+
+    def get_workshop(self, workshop_id):
+        return self._workshop
+
+    def get_traces(self, workshop_id):
+        return self._traces
+
+    def get_rubric(self, workshop_id):
+        return Rubric(
+            id="r1",
+            workshop_id=workshop_id,
+            question="Accuracy: Is the response correct?",
+            created_by="fac",
+            created_at=datetime.now(),
+            judge_type="likert",
+            binary_labels=None,
+            rating_scale=5,
+        )
+
+    def get_mlflow_config(self, workshop_id):
+        config = MagicMock()
+        config.experiment_id = "exp-123"
+        config.databricks_host = "https://test.databricks.com"
+        return config
+
+    def get_auto_evaluation_prompt(self, workshop_id):
+        return "Evaluate the response for accuracy on a 1-5 scale."
+
+    def get_auto_evaluation_model(self, workshop_id):
+        return "databricks-claude-opus-4-5"
+
+    def derive_judge_prompt_from_rubric(self, workshop_id, question_index=0):
+        return "Evaluate the response for accuracy on a 1-5 scale."
+
+    def _parse_rubric_questions(self, question):
+        return [{"judge_type": "likert", "title": "Accuracy"}]
+
+    def get_judge_prompts(self, workshop_id):
+        return []
+
+    def get_databricks_token(self, workshop_id):
+        return "test-token"
+
+    def update_auto_evaluation_job(self, workshop_id, job_id, prompt):
+        pass
+
+    def tag_traces_for_evaluation(self, workshop_id, trace_ids, tag_type='eval'):
+        self.tag_calls.append({
+            "workshop_id": workshop_id,
+            "trace_ids": trace_ids,
+            "tag_type": tag_type,
+        })
+        return {"tagged": len(trace_ids), "failed": []}
+
+
+@pytest.mark.spec("JUDGE_EVALUATION_SPEC")
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_re_evaluate_tags_traces_before_evaluation(async_client, override_get_db, monkeypatch):
+    """Re-evaluate endpoint must tag traces with 'eval' label before running evaluation.
+
+    Spec: JUDGE_EVALUATION_SPEC line 310
+    - Re-evaluation uses tag_type='eval' to evaluate the same trace set.
+    - If traces were previously tagged 'align' by annotation sync, the 'eval' tag
+      must be re-applied before searching.
+
+    This test verifies that POST /re-evaluate calls tag_traces_for_evaluation
+    BEFORE starting the background evaluation thread.
+    """
+    import server.routers.workshops as workshops_router
+
+    fake_db = FakeDatabaseService(None)
+    monkeypatch.setattr(workshops_router, "DatabaseService", lambda db: fake_db)
+
+    mock_token_storage = MagicMock()
+    mock_token_storage.get_token.return_value = "test-token"
+
+    with patch("server.routers.workshops.create_job") as mock_create_job, \
+         patch("server.services.token_storage_service.token_storage", mock_token_storage):
+        mock_job = MagicMock()
+        mock_create_job.return_value = mock_job
+
+        resp = await async_client.post(
+            "/workshops/w1/re-evaluate",
+            json={
+                "judge_name": "accuracy_judge",
+                "judge_type": "likert",
+            },
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body.get("job_id") is not None
+
+    # CRITICAL: tag_traces_for_evaluation must have been called with tag_type='eval'
+    # before the background thread starts searching for tagged traces
+    assert len(fake_db.tag_calls) > 0, (
+        "re-evaluate endpoint must call tag_traces_for_evaluation to ensure "
+        "traces have the 'eval' label before searching. Currently it skips "
+        "tagging, which causes 'No MLflow traces found with label eval' errors "
+        "when annotation sync has overwritten the label to 'align'."
+    )
+    tag_call = fake_db.tag_calls[0]
+    assert tag_call["tag_type"] == "eval"
+    assert set(tag_call["trace_ids"]) == {"t1", "t2", "t3"}
+
+
+@pytest.mark.spec("JUDGE_EVALUATION_SPEC")
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_re_evaluate_tags_traces_fallback_when_no_active_annotation_ids(
+    async_client, override_get_db, monkeypatch
+):
+    """Re-evaluate falls back to all traces with MLflow IDs when active_annotation_trace_ids is empty.
+
+    Spec: JUDGE_EVALUATION_SPEC line 310
+    """
+    import server.routers.workshops as workshops_router
+
+    workshop = _make_workshop(active_annotation_trace_ids=[])
+    fake_db = FakeDatabaseService(None, workshop=workshop)
+    monkeypatch.setattr(workshops_router, "DatabaseService", lambda db: fake_db)
+
+    mock_token_storage = MagicMock()
+    mock_token_storage.get_token.return_value = "test-token"
+
+    with patch("server.routers.workshops.create_job") as mock_create_job, \
+         patch("server.services.token_storage_service.token_storage", mock_token_storage):
+        mock_job = MagicMock()
+        mock_create_job.return_value = mock_job
+
+        resp = await async_client.post(
+            "/workshops/w1/re-evaluate",
+            json={},
+        )
+
+    assert resp.status_code == 200
+
+    # Should fall back to tagging all traces that have mlflow_trace_ids
+    assert len(fake_db.tag_calls) > 0, (
+        "When active_annotation_trace_ids is empty, re-evaluate should fall back "
+        "to tagging all traces with MLflow IDs."
+    )
+    tag_call = fake_db.tag_calls[0]
+    assert tag_call["tag_type"] == "eval"
+    # All 3 traces have mlflow_trace_id set
+    assert len(tag_call["trace_ids"]) == 3

--- a/tests/unit/services/test_evaluation_tag_overwrite.py
+++ b/tests/unit/services/test_evaluation_tag_overwrite.py
@@ -1,0 +1,97 @@
+"""Tests for evaluation tag search after annotation sync overwrites labels.
+
+Spec: JUDGE_EVALUATION_SPEC (Re-Evaluation section, lines 251-310)
+
+Root cause: tag_traces_for_evaluation sets tags.label='eval', but
+sync_annotation_to_mlflow later sets tags.label='align' on the same traces.
+Since MLflow tags are scalar, the 'eval' value is destroyed.
+When re-evaluate searches for tags.label='eval', it finds nothing.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from server.services.alignment_service import AlignmentService
+
+
+@pytest.mark.spec("JUDGE_EVALUATION_SPEC")
+@pytest.mark.unit
+def test_search_tagged_traces_returns_empty_after_align_overwrite():
+    """_search_tagged_traces returns no results when label was overwritten to 'align'.
+
+    Simulates the deployed failure:
+    1. Traces tagged label='eval' during begin-annotation
+    2. Human annotates -> sync_annotation_to_mlflow sets label='align'
+    3. Re-evaluate -> _search_tagged_traces(tag_type='eval') -> empty
+    4. Error: "No MLflow traces found with label 'eval'"
+    """
+    mock_db_service = MagicMock()
+    service = AlignmentService(mock_db_service)
+
+    mock_config = MagicMock()
+    mock_config.experiment_id = "exp-123"
+
+    with patch("mlflow.search_traces", return_value=pd.DataFrame()) as mock_search:
+        result = service._search_tagged_traces(
+            mock_config, "w1", return_type="pandas", tag_type="eval"
+        )
+
+        # Verify the filter searches for eval label
+        call_kwargs = mock_search.call_args
+        filter_string = call_kwargs.kwargs.get("filter_string", "")
+        assert "tags.label = 'eval'" in filter_string
+
+        # Empty result — the production failure scenario
+        assert result.empty
+
+
+@pytest.mark.spec("JUDGE_EVALUATION_SPEC")
+@pytest.mark.unit
+def test_run_evaluation_yields_error_when_no_eval_tagged_traces():
+    """run_evaluation_with_answer_sheet yields the exact production error.
+
+    Reproduces the deployed logs:
+    - "Built MLflow-to-workshop trace mapping (13 traces)"
+    - "ERROR: No MLflow traces found with label 'eval'"
+    - "Re-evaluation failed: No tagged MLflow traces found"
+    """
+    mock_db_service = MagicMock()
+    mock_db_service.get_traces.return_value = [
+        MagicMock(id=f"t{i}", mlflow_trace_id=f"mlflow-t{i}")
+        for i in range(13)
+    ]
+
+    service = AlignmentService(mock_db_service)
+
+    mock_config = MagicMock()
+    mock_config.experiment_id = "exp-123"
+    mock_config.databricks_host = "https://test.databricks.com"
+    mock_config.databricks_token = "test-token"
+
+    with patch("mlflow.search_traces", return_value=pd.DataFrame()), \
+         patch("mlflow.set_tracking_uri"), \
+         patch("mlflow.genai.evaluate"):
+        messages = list(service.run_evaluation_with_answer_sheet(
+            workshop_id="w1",
+            judge_name="accuracy_judge",
+            judge_prompt="Evaluate accuracy",
+            evaluation_model_name="test-model",
+            mlflow_config=mock_config,
+            judge_type="likert",
+            require_human_ratings=False,
+            tag_type="eval",
+        ))
+
+    # Should log the 13-trace mapping
+    assert any("Built MLflow-to-workshop trace mapping (13 traces)" in str(m) for m in messages)
+
+    # Should yield the exact error from production
+    assert any("No MLflow traces found with label 'eval'" in str(m) for m in messages)
+
+    # Final result should be a failure dict
+    result_dicts = [m for m in messages if isinstance(m, dict)]
+    assert len(result_dicts) > 0
+    assert result_dicts[-1]["success"] is False
+    assert "No tagged MLflow traces found" in result_dicts[-1]["error"]


### PR DESCRIPTION
The /re-evaluate endpoint and begin-annotation auto-eval background thread could fail with "No MLflow traces found with label 'eval'" because sync_annotation_to_mlflow overwrites tags.label from 'eval' to 'align' when a user annotates. Both paths now re-tag traces before searching.

Also adds detailed logging to the auto-eval path for deployment debugging.

## Summary

<!-- Brief description of what this PR does -->

## Related Spec

<!-- Which spec(s) does this PR implement or affect? -->
- Spec: `SPEC_NAME` (from `/specs/`)

## Changes

<!-- List the key changes made -->
-

## Testing

<!-- How was this tested? -->
- [ ] Tests tagged with `@pytest.mark.spec("SPEC_NAME")` or equivalent
- [ ] `just test-server` passes
- [ ] `just ui-test-unit` passes
- [ ] `just ui-lint` passes
- [ ] E2E tests pass (if applicable)

## Checklist

- [ ] Read the relevant spec before implementing
- [ ] No changes to `/specs/` without approval
- [ ] No new database migrations without approval
- [ ] Coverage map updated if new tests added (`uv run spec-coverage-analyzer`)
