### PR TITLE
chore: expand ruff linting beyond dead-code checks

### DIFF
--- a/justfile
+++ b/justfile
@@ -301,6 +301,11 @@ ui-lint:
 lint-vulture:
   uv run vulture {{server-dir}}/ vulture_whitelist.py --min-confidence 80
 
+# Run full ruff lint (uses pyproject.toml config)
+[group('dev')]
+lint-ruff *args:
+  uv run ruff check {{server-dir}}/ {{args}}
+
 # Detect dead Python code with ruff F4xx rules
 [group('dev')]
 lint-ruff-deadcode:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,19 +137,37 @@ exclude = [
 
 [tool.ruff.lint]
 select = [
-    "E",   # pycodestyle errors
-    "W",   # pycodestyle warnings
-    "F",   # pyflakes
-    "I",   # isort
-    "B",   # flake8-bugbear
-    "C4",  # flake8-comprehensions
-    "UP",  # pyupgrade
+    "E",    # pycodestyle errors
+    "W",    # pycodestyle warnings
+    "F",    # pyflakes
+    "I",    # isort
+    "B",    # flake8-bugbear
+    "C4",   # flake8-comprehensions
+    "UP",   # pyupgrade
+    "SIM",  # flake8-simplify
+    "RET",  # flake8-return
+    "RUF",  # ruff-specific rules
+    "PERF", # perflint
 ]
 ignore = [
-    "E501",  # line too long (handled by black)
-    "B008",  # do not perform function calls in argument defaults
-    "C901",  # too complex
+    "E501",   # line too long (handled by black/formatter)
+    "B008",   # do not perform function calls in argument defaults
+    "C901",   # too complex
+    "RET504", # unnecessary assignment before return — often aids readability
+    "SIM108", # ternary instead of if/else — often less readable
+    "RUF001", # ambiguous unicode in strings — intentional special characters
+    "RUF002", # ambiguous unicode in docstrings — intentional special characters
+    "RUF013", # implicit-optional — valid but would change many signatures
+    "E402",   # module-import-not-at-top — conditional imports are intentional
+    "SIM102", # collapsible-if — nested ifs often aid readability
+    "SIM105", # suppressible-exception — contextlib.suppress not always clearer
+    "PERF401",# manual-list-comprehension — explicit loops can be clearer
+    "PERF403",# manual-dict-comprehension — explicit loops can be clearer
+    "RUF012", # mutable-class-default — ClassVar annotation not always needed
 ]
+
+[tool.ruff.lint.per-file-ignores]
+"server/services/*" = ["C401"]  # generator-to-set: explicit in service layer
 
 [tool.ruff.lint.isort]
 known-first-party = ["server"]

--- a/server/config.py
+++ b/server/config.py
@@ -4,63 +4,63 @@ import os
 
 
 class ServerConfig:
-  """Server configuration for optimal performance with multiple concurrent users."""
+    """Server configuration for optimal performance with multiple concurrent users."""
 
-  # Server settings
-  HOST: str = os.getenv('HOST', '0.0.0.0')
-  PORT: int = int(os.getenv('PORT', '8000'))
-  WORKERS: int = int(os.getenv('WORKERS', '4'))  # Multiple workers for better concurrency
-  WORKER_CLASS: str = os.getenv('WORKER_CLASS', 'uvicorn.workers.UvicornWorker')
-  # Connection settings
-  MAX_CONNECTIONS: int = int(os.getenv('MAX_CONNECTIONS', '100'))
-  KEEP_ALIVE_TIMEOUT: int = int(os.getenv('KEEP_ALIVE_TIMEOUT', '65'))
-  TIMEOUT_GRACEFUL_SHUTDOWN: int = int(os.getenv('TIMEOUT_GRACEFUL_SHUTDOWN', '30'))
-  # Database settings
-  DB_POOL_SIZE: int = int(os.getenv('DB_POOL_SIZE', '20'))
-  DB_MAX_OVERFLOW: int = int(os.getenv('DB_MAX_OVERFLOW', '30'))
-  DB_POOL_TIMEOUT: int = int(os.getenv('DB_POOL_TIMEOUT', '30'))
-  DB_POOL_RECYCLE: int = int(os.getenv('DB_POOL_RECYCLE', '3600'))
-  # CORS settings - Allow all origins for development
-  CORS_ORIGINS: list = ['*']  # Allow all origins
+    # Server settings
+    HOST: str = os.getenv("HOST", "0.0.0.0")
+    PORT: int = int(os.getenv("PORT", "8000"))
+    WORKERS: int = int(os.getenv("WORKERS", "4"))  # Multiple workers for better concurrency
+    WORKER_CLASS: str = os.getenv("WORKER_CLASS", "uvicorn.workers.UvicornWorker")
+    # Connection settings
+    MAX_CONNECTIONS: int = int(os.getenv("MAX_CONNECTIONS", "100"))
+    KEEP_ALIVE_TIMEOUT: int = int(os.getenv("KEEP_ALIVE_TIMEOUT", "65"))
+    TIMEOUT_GRACEFUL_SHUTDOWN: int = int(os.getenv("TIMEOUT_GRACEFUL_SHUTDOWN", "30"))
+    # Database settings
+    DB_POOL_SIZE: int = int(os.getenv("DB_POOL_SIZE", "20"))
+    DB_MAX_OVERFLOW: int = int(os.getenv("DB_MAX_OVERFLOW", "30"))
+    DB_POOL_TIMEOUT: int = int(os.getenv("DB_POOL_TIMEOUT", "30"))
+    DB_POOL_RECYCLE: int = int(os.getenv("DB_POOL_RECYCLE", "3600"))
+    # CORS settings - Allow all origins for development
+    CORS_ORIGINS: list = ["*"]  # Allow all origins
 
-  # Alternative: If you want to be more specific, uncomment and use this instead:
-  # CORS_ORIGINS: list = [
-  #     'http://localhost:3000',
-  #     'http://127.0.0.1:3000',
-  #     'http://localhost:5173',
-  #     'http://127.0.0.1:5173',
-  #     'https://human-eval-workshop-1444828305810485.aws.databricksapps.com',
-  #     'https://e2-demo-field-eng.cloud.databricks.com',
-  # ]
-  # # Add additional CORS origins from environment
-  # additional_cors_origins = os.getenv('CORS_ORIGINS', '').split(',')
-  # if additional_cors_origins and additional_cors_origins[0]:
-  #     CORS_ORIGINS.extend([origin.strip() for origin in additional_cors_origins])
-  @classmethod
-  def get_uvicorn_config(cls) -> dict:
-    """Get uvicorn configuration for production deployment."""
-    return {
-      'host': cls.HOST,
-      'port': cls.PORT,
-      'workers': cls.WORKERS,
-      'worker_class': cls.WORKER_CLASS,
-      'timeout_keep_alive': cls.KEEP_ALIVE_TIMEOUT,
-      'timeout_graceful_shutdown': cls.TIMEOUT_GRACEFUL_SHUTDOWN,
-      'limit_concurrency': cls.MAX_CONNECTIONS,
-      'limit_max_requests': 1000,  # Restart workers after 1000 requests
-      'preload_app': True,  # Load app before forking workers
-      'access_log': True,
-      'log_level': 'info',
-    }
+    # Alternative: If you want to be more specific, uncomment and use this instead:
+    # CORS_ORIGINS: list = [
+    #     'http://localhost:3000',
+    #     'http://127.0.0.1:3000',
+    #     'http://localhost:5173',
+    #     'http://127.0.0.1:5173',
+    #     'https://human-eval-workshop-1444828305810485.aws.databricksapps.com',
+    #     'https://e2-demo-field-eng.cloud.databricks.com',
+    # ]
+    # # Add additional CORS origins from environment
+    # additional_cors_origins = os.getenv('CORS_ORIGINS', '').split(',')
+    # if additional_cors_origins and additional_cors_origins[0]:
+    #     CORS_ORIGINS.extend([origin.strip() for origin in additional_cors_origins])
+    @classmethod
+    def get_uvicorn_config(cls) -> dict:
+        """Get uvicorn configuration for production deployment."""
+        return {
+            "host": cls.HOST,
+            "port": cls.PORT,
+            "workers": cls.WORKERS,
+            "worker_class": cls.WORKER_CLASS,
+            "timeout_keep_alive": cls.KEEP_ALIVE_TIMEOUT,
+            "timeout_graceful_shutdown": cls.TIMEOUT_GRACEFUL_SHUTDOWN,
+            "limit_concurrency": cls.MAX_CONNECTIONS,
+            "limit_max_requests": 1000,  # Restart workers after 1000 requests
+            "preload_app": True,  # Load app before forking workers
+            "access_log": True,
+            "log_level": "info",
+        }
 
-  @classmethod
-  def get_development_config(cls) -> dict:
-    """Get uvicorn configuration for development."""
-    return {
-      'host': cls.HOST,
-      'port': cls.PORT,
-      'reload': True,
-      'reload_dirs': ['server'],
-      'log_level': 'debug',
-      'access_log': True,
-    }
+    @classmethod
+    def get_development_config(cls) -> dict:
+        """Get uvicorn configuration for development."""
+        return {
+            "host": cls.HOST,
+            "port": cls.PORT,
+            "reload": True,
+            "reload_dirs": ["server"],
+            "log_level": "debug",
+            "access_log": True,
+        }

--- a/server/database.py
+++ b/server/database.py
@@ -61,14 +61,17 @@ engine = create_engine_for_backend(DATABASE_BACKEND)
 # This listener fires after successful commits and notifies the rescue module
 # Only applies to SQLite backend
 if DATABASE_BACKEND == DatabaseBackend.SQLITE:
+
     @event.listens_for(engine, "commit")
     def on_commit(conn):
         """Record write operations for SQLite rescue backup triggering."""
         try:
             from server.sqlite_rescue import record_write_operation
+
             record_write_operation()
         except ImportError:
             pass  # sqlite_rescue not available
+
 
 # Create session factory with better session management
 SessionLocal = sessionmaker(
@@ -182,9 +185,7 @@ class WorkshopDB(Base):
     custom_llm_provider = relationship(
         "CustomLLMProviderConfigDB", back_populates="workshop", uselist=False, cascade="all, delete-orphan"
     )
-    participant_notes = relationship(
-        "ParticipantNoteDB", back_populates="workshop", cascade="all, delete-orphan"
-    )
+    participant_notes = relationship("ParticipantNoteDB", back_populates="workshop", cascade="all, delete-orphan")
 
 
 class TraceDB(Base):
@@ -468,6 +469,7 @@ def _reset_connection_pool() -> None:
     if DATABASE_BACKEND == DatabaseBackend.POSTGRESQL:
         try:
             from .db_config import get_token_manager
+
             get_token_manager().force_refresh()
             logger.info("Connection pool reset and OAuth token marked for refresh")
         except Exception as e:
@@ -500,6 +502,7 @@ def get_db():
             # Quick connectivity check on PostgreSQL to surface stale connections early
             if DATABASE_BACKEND == DatabaseBackend.POSTGRESQL:
                 from sqlalchemy import text
+
                 db.execute(text("SELECT 1"))
             break  # Connection succeeded
         except Exception as e:
@@ -512,9 +515,11 @@ def get_db():
             if _is_connection_error(e) and attempt < max_attempts - 1:
                 backoff = 0.5 * (attempt + 1)  # 0.5s, 1.0s
                 logger.warning(
-                    "Database connection failed (attempt %d/%d), "
-                    "resetting pool and retrying in %.1fs: %s",
-                    attempt + 1, max_attempts, backoff, e,
+                    "Database connection failed (attempt %d/%d), resetting pool and retrying in %.1fs: %s",
+                    attempt + 1,
+                    max_attempts,
+                    backoff,
+                    e,
                 )
                 _reset_connection_pool()
                 _time.sleep(backoff)
@@ -541,7 +546,7 @@ def create_tables():
     from .db_config import get_schema_name
 
     try:
-        print('🔧 Creating database tables...')
+        print("🔧 Creating database tables...")
 
         # For PostgreSQL/Lakebase, create schema first if needed
         if DATABASE_BACKEND == DatabaseBackend.POSTGRESQL:
@@ -549,16 +554,17 @@ def create_tables():
             pg_user = os.getenv("PGUSER", "")
             if schema_name:
                 from sqlalchemy import text
+
                 with engine.connect() as conn:
                     conn.execute(text(f'CREATE SCHEMA IF NOT EXISTS "{schema_name}"'))
                     if pg_user:
                         conn.execute(text(f'GRANT ALL PRIVILEGES ON SCHEMA "{schema_name}" TO "{pg_user}"'))
                     conn.commit()
-                    print(f'✅ Created/verified schema: {schema_name}')
+                    print(f"✅ Created/verified schema: {schema_name}")
 
         # Use checkfirst=True to avoid errors if tables already exist
         Base.metadata.create_all(bind=engine, checkfirst=True)
-        print('✅ Database tables created successfully')
+        print("✅ Database tables created successfully")
 
         # Grant privileges on all tables to PGUSER (PostgreSQL only)
         if DATABASE_BACKEND == DatabaseBackend.POSTGRESQL:
@@ -567,33 +573,39 @@ def create_tables():
             if schema_name and pg_user:
                 try:
                     from sqlalchemy import text
+
                     with engine.connect() as conn:
-                        conn.execute(text(f'GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA "{schema_name}" TO "{pg_user}"'))
-                        conn.execute(text(f'GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA "{schema_name}" TO "{pg_user}"'))
+                        conn.execute(
+                            text(f'GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA "{schema_name}" TO "{pg_user}"')
+                        )
+                        conn.execute(
+                            text(f'GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA "{schema_name}" TO "{pg_user}"')
+                        )
                         conn.commit()
-                        print(f'✅ Privileges granted to {pg_user} on schema {schema_name}')
+                        print(f"✅ Privileges granted to {pg_user} on schema {schema_name}")
                 except Exception as grant_err:
-                    print(f'ℹ️ Privilege grant skipped: {grant_err}')
+                    print(f"ℹ️ Privilege grant skipped: {grant_err}")
     except Exception as e:
         # Handle case where tables already exist (common in production)
         error_msg = str(e).lower()
-        if 'already exists' in error_msg or 'table' in error_msg and 'exists' in error_msg:
-            print('ℹ️ Some tables already exist, continuing with schema updates...')
+        if "already exists" in error_msg or ("table" in error_msg and "exists" in error_msg):
+            print("ℹ️ Some tables already exist, continuing with schema updates...")
         else:
-            print(f'❌ Error creating database tables: {e}')
+            print(f"❌ Error creating database tables: {e}")
             raise e
 
     # Enable WAL mode for better SQLite concurrency (only for SQLite)
     if DATABASE_BACKEND == DatabaseBackend.SQLITE:
         try:
             from sqlalchemy import text
+
             with engine.connect() as conn:
-                conn.execute(text('PRAGMA journal_mode=WAL'))
-                conn.execute(text('PRAGMA busy_timeout=60000'))  # 60 second busy timeout
+                conn.execute(text("PRAGMA journal_mode=WAL"))
+                conn.execute(text("PRAGMA busy_timeout=60000"))  # 60 second busy timeout
                 conn.commit()
-                print('✅ SQLite WAL mode enabled for better concurrency')
+                print("✅ SQLite WAL mode enabled for better concurrency")
         except Exception as e:
-            print(f'ℹ️ Could not enable WAL mode (non-critical): {e}')
+            print(f"ℹ️ Could not enable WAL mode (non-critical): {e}")
 
     # Update schema for existing databases
     _apply_schema_updates()
@@ -614,92 +626,115 @@ def _apply_schema_updates():
             try:
                 # Add new columns to judge_prompts table if they don't exist
                 if is_postgres:
-                    conn.execute(text("ALTER TABLE judge_prompts ADD COLUMN IF NOT EXISTS model_name VARCHAR DEFAULT 'demo'"))
-                    conn.execute(text('ALTER TABLE judge_prompts ADD COLUMN IF NOT EXISTS model_parameters JSON'))
+                    conn.execute(
+                        text("ALTER TABLE judge_prompts ADD COLUMN IF NOT EXISTS model_name VARCHAR DEFAULT 'demo'")
+                    )
+                    conn.execute(text("ALTER TABLE judge_prompts ADD COLUMN IF NOT EXISTS model_parameters JSON"))
                 else:
                     conn.execute(text("ALTER TABLE judge_prompts ADD COLUMN model_name VARCHAR DEFAULT 'demo'"))
-                    conn.execute(text('ALTER TABLE judge_prompts ADD COLUMN model_parameters JSON'))
+                    conn.execute(text("ALTER TABLE judge_prompts ADD COLUMN model_parameters JSON"))
                 conn.commit()
-                print('✅ Database schema updated for judge_prompts')
+                print("✅ Database schema updated for judge_prompts")
             except Exception as e:
                 # Columns already exist or table doesn't exist yet
-                print(f'ℹ️ judge_prompts schema update skipped (columns may already exist): {e}')
+                print(f"ℹ️ judge_prompts schema update skipped (columns may already exist): {e}")
 
             try:
                 # Add ratings column to annotations table for multiple question support
                 if is_postgres:
-                    conn.execute(text('ALTER TABLE annotations ADD COLUMN IF NOT EXISTS ratings JSON'))
+                    conn.execute(text("ALTER TABLE annotations ADD COLUMN IF NOT EXISTS ratings JSON"))
                 else:
-                    conn.execute(text('ALTER TABLE annotations ADD COLUMN ratings JSON'))
+                    conn.execute(text("ALTER TABLE annotations ADD COLUMN ratings JSON"))
                 conn.commit()
-                print('✅ Database schema updated for annotations (added ratings column)')
+                print("✅ Database schema updated for annotations (added ratings column)")
             except Exception as e:
-                print(f'ℹ️ annotations schema update skipped (ratings column may already exist): {e}')
+                print(f"ℹ️ annotations schema update skipped (ratings column may already exist): {e}")
 
             try:
                 # Add include_in_alignment column to traces table for alignment filtering
                 if is_postgres:
-                    conn.execute(text('ALTER TABLE traces ADD COLUMN IF NOT EXISTS include_in_alignment BOOLEAN DEFAULT TRUE'))
+                    conn.execute(
+                        text("ALTER TABLE traces ADD COLUMN IF NOT EXISTS include_in_alignment BOOLEAN DEFAULT TRUE")
+                    )
                 else:
-                    conn.execute(text('ALTER TABLE traces ADD COLUMN include_in_alignment BOOLEAN DEFAULT 1'))
+                    conn.execute(text("ALTER TABLE traces ADD COLUMN include_in_alignment BOOLEAN DEFAULT 1"))
                 conn.commit()
-                print('✅ Database schema updated for traces (added include_in_alignment column)')
+                print("✅ Database schema updated for traces (added include_in_alignment column)")
             except Exception as e:
-                print(f'ℹ️ traces schema update skipped (include_in_alignment column may already exist): {e}')
+                print(f"ℹ️ traces schema update skipped (include_in_alignment column may already exist): {e}")
 
             try:
                 # Add sme_feedback column to traces table for concatenated SME feedback
                 if is_postgres:
-                    conn.execute(text('ALTER TABLE traces ADD COLUMN IF NOT EXISTS sme_feedback TEXT'))
+                    conn.execute(text("ALTER TABLE traces ADD COLUMN IF NOT EXISTS sme_feedback TEXT"))
                 else:
-                    conn.execute(text('ALTER TABLE traces ADD COLUMN sme_feedback TEXT'))
+                    conn.execute(text("ALTER TABLE traces ADD COLUMN sme_feedback TEXT"))
                 conn.commit()
-                print('✅ Database schema updated for traces (added sme_feedback column)')
+                print("✅ Database schema updated for traces (added sme_feedback column)")
             except Exception as e:
-                print(f'ℹ️ traces schema update skipped (sme_feedback column may already exist): {e}')
+                print(f"ℹ️ traces schema update skipped (sme_feedback column may already exist): {e}")
 
             try:
                 # Add unique constraint to discovery_findings to prevent duplicate entries
                 if is_postgres:
-                    conn.execute(text('CREATE UNIQUE INDEX IF NOT EXISTS idx_discovery_findings_unique ON discovery_findings (workshop_id, trace_id, user_id)'))
+                    conn.execute(
+                        text(
+                            "CREATE UNIQUE INDEX IF NOT EXISTS idx_discovery_findings_unique ON discovery_findings (workshop_id, trace_id, user_id)"
+                        )
+                    )
                 else:
-                    conn.execute(text('CREATE UNIQUE INDEX IF NOT EXISTS idx_discovery_findings_unique ON discovery_findings (workshop_id, trace_id, user_id)'))
+                    conn.execute(
+                        text(
+                            "CREATE UNIQUE INDEX IF NOT EXISTS idx_discovery_findings_unique ON discovery_findings (workshop_id, trace_id, user_id)"
+                        )
+                    )
                 conn.commit()
-                print('✅ Database schema updated: added unique constraint to discovery_findings')
+                print("✅ Database schema updated: added unique constraint to discovery_findings")
             except Exception as e:
-                print(f'ℹ️ discovery_findings unique constraint skipped (may already exist): {e}')
+                print(f"ℹ️ discovery_findings unique constraint skipped (may already exist): {e}")
 
             try:
                 # Add unique constraint to annotations to prevent duplicate entries (user_id + trace_id)
-                conn.execute(text('CREATE UNIQUE INDEX IF NOT EXISTS idx_annotations_unique ON annotations (user_id, trace_id)'))
+                conn.execute(
+                    text("CREATE UNIQUE INDEX IF NOT EXISTS idx_annotations_unique ON annotations (user_id, trace_id)")
+                )
                 conn.commit()
-                print('✅ Database schema updated: added unique constraint to annotations')
+                print("✅ Database schema updated: added unique constraint to annotations")
             except Exception as e:
-                print(f'ℹ️ annotations unique constraint skipped (may already exist): {e}')
+                print(f"ℹ️ annotations unique constraint skipped (may already exist): {e}")
 
             try:
                 # Add unique constraint to judge_evaluations to prevent duplicate entries (prompt_id + trace_id)
-                conn.execute(text('CREATE UNIQUE INDEX IF NOT EXISTS idx_judge_evaluations_unique ON judge_evaluations (prompt_id, trace_id)'))
+                conn.execute(
+                    text(
+                        "CREATE UNIQUE INDEX IF NOT EXISTS idx_judge_evaluations_unique ON judge_evaluations (prompt_id, trace_id)"
+                    )
+                )
                 conn.commit()
-                print('✅ Database schema updated: added unique constraint to judge_evaluations')
+                print("✅ Database schema updated: added unique constraint to judge_evaluations")
             except Exception as e:
-                print(f'ℹ️ judge_evaluations unique constraint skipped (may already exist): {e}')
+                print(f"ℹ️ judge_evaluations unique constraint skipped (may already exist): {e}")
 
             try:
                 # Add show_participant_notes column to workshops table
                 if is_postgres:
-                    conn.execute(text('ALTER TABLE workshops ADD COLUMN IF NOT EXISTS show_participant_notes BOOLEAN DEFAULT FALSE'))
+                    conn.execute(
+                        text(
+                            "ALTER TABLE workshops ADD COLUMN IF NOT EXISTS show_participant_notes BOOLEAN DEFAULT FALSE"
+                        )
+                    )
                 else:
-                    conn.execute(text('ALTER TABLE workshops ADD COLUMN show_participant_notes BOOLEAN DEFAULT 0'))
+                    conn.execute(text("ALTER TABLE workshops ADD COLUMN show_participant_notes BOOLEAN DEFAULT 0"))
                 conn.commit()
-                print('✅ Database schema updated for workshops (added show_participant_notes column)')
+                print("✅ Database schema updated for workshops (added show_participant_notes column)")
             except Exception as e:
-                print(f'ℹ️ workshops show_participant_notes column skipped (may already exist): {e}')
+                print(f"ℹ️ workshops show_participant_notes column skipped (may already exist): {e}")
 
             try:
                 # Create participant_notes table if it doesn't exist
                 if is_postgres:
-                    conn.execute(text('''
+                    conn.execute(
+                        text("""
                         CREATE TABLE IF NOT EXISTS participant_notes (
                             id VARCHAR PRIMARY KEY,
                             workshop_id VARCHAR NOT NULL REFERENCES workshops(id) ON DELETE CASCADE,
@@ -710,9 +745,11 @@ def _apply_schema_updates():
                             created_at TIMESTAMP DEFAULT NOW(),
                             updated_at TIMESTAMP DEFAULT NOW()
                         )
-                    '''))
+                    """)
+                    )
                 else:
-                    conn.execute(text('''
+                    conn.execute(
+                        text("""
                         CREATE TABLE IF NOT EXISTS participant_notes (
                             id VARCHAR PRIMARY KEY,
                             workshop_id VARCHAR NOT NULL REFERENCES workshops(id) ON DELETE CASCADE,
@@ -723,27 +760,38 @@ def _apply_schema_updates():
                             created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
                             updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
                         )
-                    '''))
-                conn.execute(text('CREATE INDEX IF NOT EXISTS ix_participant_notes_workshop_user ON participant_notes (workshop_id, user_id)'))
+                    """)
+                    )
+                conn.execute(
+                    text(
+                        "CREATE INDEX IF NOT EXISTS ix_participant_notes_workshop_user ON participant_notes (workshop_id, user_id)"
+                    )
+                )
                 conn.commit()
-                print('✅ Database schema updated: created participant_notes table')
+                print("✅ Database schema updated: created participant_notes table")
             except Exception as e:
-                print(f'ℹ️ participant_notes table creation skipped (may already exist): {e}')
+                print(f"ℹ️ participant_notes table creation skipped (may already exist): {e}")
 
             try:
                 # Add phase column to participant_notes table
                 if is_postgres:
-                    conn.execute(text("ALTER TABLE participant_notes ADD COLUMN IF NOT EXISTS phase VARCHAR DEFAULT 'discovery' NOT NULL"))
+                    conn.execute(
+                        text(
+                            "ALTER TABLE participant_notes ADD COLUMN IF NOT EXISTS phase VARCHAR DEFAULT 'discovery' NOT NULL"
+                        )
+                    )
                 else:
-                    conn.execute(text("ALTER TABLE participant_notes ADD COLUMN phase VARCHAR DEFAULT 'discovery' NOT NULL"))
+                    conn.execute(
+                        text("ALTER TABLE participant_notes ADD COLUMN phase VARCHAR DEFAULT 'discovery' NOT NULL")
+                    )
                 conn.commit()
-                print('✅ Database schema updated for participant_notes (added phase column)')
+                print("✅ Database schema updated for participant_notes (added phase column)")
             except Exception as e:
-                print(f'ℹ️ participant_notes phase column skipped (may already exist): {e}')
+                print(f"ℹ️ participant_notes phase column skipped (may already exist): {e}")
 
     except Exception as e:
         # Schema updates are optional, don't fail if they error
-        print(f'ℹ️ Schema update error (non-critical): {e}')
+        print(f"ℹ️ Schema update error (non-critical): {e}")
 
 
 def drop_tables():

--- a/server/db_bootstrap.py
+++ b/server/db_bootstrap.py
@@ -103,6 +103,7 @@ def _list_postgres_tables(database_url: str) -> list[str]:
     except Exception as e:
         print(f"⚠️ Could not list PostgreSQL tables: {e}")
         import traceback
+
         traceback.print_exc()
         return []
 
@@ -231,16 +232,12 @@ def _widen_alembic_version_column(database_url: str) -> None:
             # Try to widen in the app schema
             conn.execute(
                 text(
-                    f'ALTER TABLE IF EXISTS "{schema_name}".alembic_version '
-                    f"ALTER COLUMN version_num TYPE VARCHAR(128)"
+                    f'ALTER TABLE IF EXISTS "{schema_name}".alembic_version ALTER COLUMN version_num TYPE VARCHAR(128)'
                 )
             )
             # Also try public schema in case alembic_version landed there
             conn.execute(
-                text(
-                    "ALTER TABLE IF EXISTS public.alembic_version "
-                    "ALTER COLUMN version_num TYPE VARCHAR(128)"
-                )
+                text("ALTER TABLE IF EXISTS public.alembic_version ALTER COLUMN version_num TYPE VARCHAR(128)")
             )
             conn.commit()
             print("✅ Widened alembic_version.version_num to VARCHAR(128)")
@@ -331,10 +328,7 @@ def _bootstrap_if_missing_postgres(plan: BootstrapPlan) -> None:
         if "already exists" in error_str or "duplicatetable" in error_str or "stringdataright" in error_str:
             # Tables already exist (listing failed earlier) — stamp to head
             # since Base.metadata.create_all creates the full latest schema.
-            print(
-                "⚠️  Tables already exist (listing may have failed earlier). "
-                "Stamping Alembic to head..."
-            )
+            print("⚠️  Tables already exist (listing may have failed earlier). Stamping Alembic to head...")
             try:
                 _run_alembic_stamp_baseline(plan.database_url, revision="head")
                 print("✅ Recovery successful — stamped to head")
@@ -395,10 +389,7 @@ def _bootstrap_full_postgres(plan: BootstrapPlan) -> None:
         except Exception as e:
             error_str = str(e).lower()
             if "already exists" in error_str or "duplicatetable" in error_str or "stringdataright" in error_str:
-                print(
-                    "⚠️  Tables already exist (listing may have failed). "
-                    "Stamping to head..."
-                )
+                print("⚠️  Tables already exist (listing may have failed). Stamping to head...")
                 _run_alembic_stamp_baseline(plan.database_url, revision="head")
                 print("✅ Recovery successful — stamped to head!")
             else:
@@ -507,7 +498,9 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         help="Time to wait for inter-process lock (defaults to DB_BOOTSTRAP_LOCK_TIMEOUT_S or 300).",
     )
 
-    p_if_missing = sub.add_parser("bootstrap-if-missing", help="Create DB via migrations only when DB is missing/empty.")
+    p_if_missing = sub.add_parser(
+        "bootstrap-if-missing", help="Create DB via migrations only when DB is missing/empty."
+    )
     p_if_missing.add_argument(
         "--database-url", default=None, help="Override DATABASE_URL (otherwise uses env/default)."
     )

--- a/server/db_config.py
+++ b/server/db_config.py
@@ -91,6 +91,7 @@ class OAuthTokenManager:
         """Lazily initialize WorkspaceClient."""
         if self._workspace_client is None:
             from databricks.sdk import WorkspaceClient
+
             self._workspace_client = WorkspaceClient()
         return self._workspace_client
 
@@ -191,7 +192,7 @@ def get_database_url() -> str:
     return url
 
 
-def create_engine_for_backend(backend: DatabaseBackend) -> "Engine":
+def create_engine_for_backend(backend: DatabaseBackend) -> Engine:
     """Create SQLAlchemy engine for the specified backend.
 
     Args:

--- a/server/make_openapi.py
+++ b/server/make_openapi.py
@@ -7,29 +7,29 @@ import click
 
 
 @click.command()
-@click.option('--output', help='Output file path', default='/tmp/openapi.json')
+@click.option("--output", help="Output file path", default="/tmp/openapi.json")
 def main(output: str) -> None:
-  """Generate OpenAPI spec to file."""
-  try:
-    # Import the FastAPI app
-    from server.app import app
+    """Generate OpenAPI spec to file."""
+    try:
+        # Import the FastAPI app
+        from server.app import app
 
-    # Generate OpenAPI spec
-    openapi_spec = app.openapi()
+        # Generate OpenAPI spec
+        openapi_spec = app.openapi()
 
-    # Write to file
-    output_path = Path(output)
-    output_path.parent.mkdir(parents=True, exist_ok=True)
+        # Write to file
+        output_path = Path(output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
 
-    with open(output_path, 'w') as f:
-      json.dump(openapi_spec, f, indent=2)
+        with open(output_path, "w") as f:
+            json.dump(openapi_spec, f, indent=2)
 
-    print(f'OpenAPI spec written to {output}')
+        print(f"OpenAPI spec written to {output}")
 
-  except Exception as e:
-    print(f'Error generating OpenAPI spec: {e}')
-    raise
+    except Exception as e:
+        print(f"Error generating OpenAPI spec: {e}")
+        raise
 
 
-if __name__ == '__main__':
-  main()
+if __name__ == "__main__":
+    main()

--- a/server/models.py
+++ b/server/models.py
@@ -1,276 +1,281 @@
-# ruff: noqa: D101
-
 """Data models for the workshop application."""
 
 from datetime import datetime
-from enum import Enum
-from typing import Any, Dict, List, Optional
+from enum import StrEnum
+from typing import Any
 
 from pydantic import BaseModel, Field
 
 
-class WorkshopStatus(str, Enum):
-  ACTIVE = 'active'
-  COMPLETED = 'completed'
-  CANCELLED = 'cancelled'
+class WorkshopStatus(StrEnum):
+    ACTIVE = "active"
+    COMPLETED = "completed"
+    CANCELLED = "cancelled"
 
 
-class WorkshopPhase(str, Enum):
-  INTAKE = 'intake'
-  DISCOVERY = 'discovery'
-  RUBRIC = 'rubric'
-  ANNOTATION = 'annotation'
-  RESULTS = 'results'
-  JUDGE_TUNING = 'judge_tuning'
-  UNITY_VOLUME = 'unity_volume'
+class WorkshopPhase(StrEnum):
+    INTAKE = "intake"
+    DISCOVERY = "discovery"
+    RUBRIC = "rubric"
+    ANNOTATION = "annotation"
+    RESULTS = "results"
+    JUDGE_TUNING = "judge_tuning"
+    UNITY_VOLUME = "unity_volume"
 
 
-class UserRole(str, Enum):
-  FACILITATOR = 'facilitator'
-  SME = 'sme'  # Subject Matter Expert
-  PARTICIPANT = 'participant'
+class UserRole(StrEnum):
+    FACILITATOR = "facilitator"
+    SME = "sme"  # Subject Matter Expert
+    PARTICIPANT = "participant"
 
 
-class UserStatus(str, Enum):
-  ACTIVE = 'active'
-  INACTIVE = 'inactive'
-  PENDING = 'pending'
+class UserStatus(StrEnum):
+    ACTIVE = "active"
+    INACTIVE = "inactive"
+    PENDING = "pending"
 
 
-class JudgeType(str, Enum):
-  """Type of judge evaluation."""
-  LIKERT = 'likert'       # Likert scale rubric-based scoring (1-5 scale)
-  BINARY = 'binary'       # Pass/Fail or Yes/No evaluation
-  FREEFORM = 'freeform'   # Free-form feedback without structured ratings
+class JudgeType(StrEnum):
+    """Type of judge evaluation."""
+
+    LIKERT = "likert"  # Likert scale rubric-based scoring (1-5 scale)
+    BINARY = "binary"  # Pass/Fail or Yes/No evaluation
+    FREEFORM = "freeform"  # Free-form feedback without structured ratings
 
 
 # User Models
 class UserCreate(BaseModel):
-  email: str
-  name: str
-  role: UserRole
-  workshop_id: str
-  password: Optional[str] = None  # Optional for backward compatibility
+    email: str
+    name: str
+    role: UserRole
+    workshop_id: str
+    password: str | None = None  # Optional for backward compatibility
 
 
 class UserLogin(BaseModel):
-  email: str
-  password: str
-  workshop_id: Optional[str] = None  # Required for participants/SMEs to validate access
+    email: str
+    password: str
+    workshop_id: str | None = None  # Required for participants/SMEs to validate access
 
 
 class User(BaseModel):
-  id: str
-  email: str
-  name: str
-  role: UserRole
-  workshop_id: Optional[str] = None  # Nullable for facilitators not tied to a workshop
-  status: UserStatus = UserStatus.ACTIVE
-  created_at: datetime = Field(default_factory=datetime.now)
-  last_active: Optional[datetime] = None
-  password_hash: Optional[str] = None  # For internal use only
+    id: str
+    email: str
+    name: str
+    role: UserRole
+    workshop_id: str | None = None  # Nullable for facilitators not tied to a workshop
+    status: UserStatus = UserStatus.ACTIVE
+    created_at: datetime = Field(default_factory=datetime.now)
+    last_active: datetime | None = None
+    password_hash: str | None = None  # For internal use only
 
 
 class UserPermissions(BaseModel):
-  can_view_discovery: bool = True
-  can_create_findings: bool = True
-  can_view_all_findings: bool = False
-  can_create_rubric: bool = False
-  can_view_rubric: bool = True
-  can_annotate: bool = True
-  can_view_all_annotations: bool = False
-  can_view_results: bool = True
-  can_manage_workshop: bool = False
-  can_assign_annotations: bool = False
+    can_view_discovery: bool = True
+    can_create_findings: bool = True
+    can_view_all_findings: bool = False
+    can_create_rubric: bool = False
+    can_view_rubric: bool = True
+    can_annotate: bool = True
+    can_view_all_annotations: bool = False
+    can_view_results: bool = True
+    can_manage_workshop: bool = False
+    can_assign_annotations: bool = False
 
-  @classmethod
-  def for_role(cls, role: UserRole) -> 'UserPermissions':
-    """Get permissions for a specific role."""
-    if role == UserRole.FACILITATOR:
-      return cls(
-        can_view_discovery=True,
-        can_create_findings=False,  # Facilitators do NOT participate in discovery - monitor only
-        can_view_all_findings=True,  # Facilitators can see all findings for monitoring
-        can_create_rubric=True,  # ONLY facilitators create rubrics
-        can_view_rubric=True,
-        can_annotate=False,  # Facilitators do NOT annotate
-        can_view_all_annotations=True,  # Facilitators can see all annotations for monitoring
-        can_view_results=True,  # ONLY facilitators view IRR results
-        can_manage_workshop=True,
-        can_assign_annotations=True,
-      )
-    elif role == UserRole.SME:
-      return cls(
-        can_view_discovery=True,
-        can_create_findings=True,
-        can_view_all_findings=False,  # SMEs can only see their own findings
-        can_create_rubric=False,  # SMEs do NOT create rubrics
-        can_view_rubric=False,  # SMEs cannot view rubric - facilitator shares screen
-        can_annotate=True,  # SMEs can annotate
-        can_view_all_annotations=False,  # SMEs can only see their own annotations
-        can_view_results=False,  # SMEs do NOT view IRR results
-        can_manage_workshop=False,
-        can_assign_annotations=False,
-      )
-    else:  # PARTICIPANT
-      return cls(
-        can_view_discovery=True,
-        can_create_findings=True,
-        can_view_all_findings=False,  # Participants can only see their own findings
-        can_create_rubric=False,  # Participants do NOT create rubrics
-        can_view_rubric=False,  # Participants cannot view rubric - facilitator shares screen
-        can_annotate=True,  # Participants CAN annotate (corrected)
-        can_view_all_annotations=False,  # Participants can only see their own annotations
-        can_view_results=False,  # Participants do NOT view IRR results
-        can_manage_workshop=False,
-        can_assign_annotations=False,
-      )
+    @classmethod
+    def for_role(cls, role: UserRole) -> "UserPermissions":
+        """Get permissions for a specific role."""
+        if role == UserRole.FACILITATOR:
+            return cls(
+                can_view_discovery=True,
+                can_create_findings=False,  # Facilitators do NOT participate in discovery - monitor only
+                can_view_all_findings=True,  # Facilitators can see all findings for monitoring
+                can_create_rubric=True,  # ONLY facilitators create rubrics
+                can_view_rubric=True,
+                can_annotate=False,  # Facilitators do NOT annotate
+                can_view_all_annotations=True,  # Facilitators can see all annotations for monitoring
+                can_view_results=True,  # ONLY facilitators view IRR results
+                can_manage_workshop=True,
+                can_assign_annotations=True,
+            )
+        if role == UserRole.SME:
+            return cls(
+                can_view_discovery=True,
+                can_create_findings=True,
+                can_view_all_findings=False,  # SMEs can only see their own findings
+                can_create_rubric=False,  # SMEs do NOT create rubrics
+                can_view_rubric=False,  # SMEs cannot view rubric - facilitator shares screen
+                can_annotate=True,  # SMEs can annotate
+                can_view_all_annotations=False,  # SMEs can only see their own annotations
+                can_view_results=False,  # SMEs do NOT view IRR results
+                can_manage_workshop=False,
+                can_assign_annotations=False,
+            )
+        # PARTICIPANT
+        return cls(
+            can_view_discovery=True,
+            can_create_findings=True,
+            can_view_all_findings=False,  # Participants can only see their own findings
+            can_create_rubric=False,  # Participants do NOT create rubrics
+            can_view_rubric=False,  # Participants cannot view rubric - facilitator shares screen
+            can_annotate=True,  # Participants CAN annotate (corrected)
+            can_view_all_annotations=False,  # Participants can only see their own annotations
+            can_view_results=False,  # Participants do NOT view IRR results
+            can_manage_workshop=False,
+            can_assign_annotations=False,
+        )
 
 
 class WorkshopParticipant(BaseModel):
-  user_id: str
-  workshop_id: str
-  role: UserRole
-  assigned_traces: List[str] = Field(default_factory=list)
-  annotation_quota: Optional[int] = None
-  joined_at: datetime = Field(default_factory=datetime.now)
+    user_id: str
+    workshop_id: str
+    role: UserRole
+    assigned_traces: list[str] = Field(default_factory=list)
+    annotation_quota: int | None = None
+    joined_at: datetime = Field(default_factory=datetime.now)
 
 
 # Request/Response Models
 class WorkshopCreate(BaseModel):
-  name: str
-  description: Optional[str] = None
-  facilitator_id: str
+    name: str
+    description: str | None = None
+    facilitator_id: str
 
 
 class Workshop(BaseModel):
-  id: str
-  name: str
-  description: Optional[str] = None
-  facilitator_id: str
-  status: WorkshopStatus = WorkshopStatus.ACTIVE
-  current_phase: WorkshopPhase = WorkshopPhase.INTAKE
-  completed_phases: List[str] = Field(default_factory=list)
-  discovery_started: bool = False
-  annotation_started: bool = False
-  active_discovery_trace_ids: List[str] = Field(default_factory=list)
-  active_annotation_trace_ids: List[str] = Field(default_factory=list)
-  discovery_randomize_traces: bool = False  # Whether to randomize trace order in discovery
-  annotation_randomize_traces: bool = False  # Whether to randomize trace order in annotation
-  judge_name: str = 'workshop_judge'  # Name used for MLflow feedback entries
-  input_jsonpath: Optional[str] = None  # JSONPath query for extracting trace input display
-  output_jsonpath: Optional[str] = None  # JSONPath query for extracting trace output display
-  auto_evaluation_job_id: Optional[str] = None  # Job ID for auto-evaluation on annotation start
-  auto_evaluation_prompt: Optional[str] = None  # Derived judge prompt used for auto-evaluation
-  auto_evaluation_model: Optional[str] = None  # Model used for auto-evaluation
-  show_participant_notes: bool = False  # Facilitator toggle: show notepad to SMEs
-  created_at: datetime = Field(default_factory=datetime.now)
+    id: str
+    name: str
+    description: str | None = None
+    facilitator_id: str
+    status: WorkshopStatus = WorkshopStatus.ACTIVE
+    current_phase: WorkshopPhase = WorkshopPhase.INTAKE
+    completed_phases: list[str] = Field(default_factory=list)
+    discovery_started: bool = False
+    annotation_started: bool = False
+    active_discovery_trace_ids: list[str] = Field(default_factory=list)
+    active_annotation_trace_ids: list[str] = Field(default_factory=list)
+    discovery_randomize_traces: bool = False  # Whether to randomize trace order in discovery
+    annotation_randomize_traces: bool = False  # Whether to randomize trace order in annotation
+    judge_name: str = "workshop_judge"  # Name used for MLflow feedback entries
+    input_jsonpath: str | None = None  # JSONPath query for extracting trace input display
+    output_jsonpath: str | None = None  # JSONPath query for extracting trace output display
+    auto_evaluation_job_id: str | None = None  # Job ID for auto-evaluation on annotation start
+    auto_evaluation_prompt: str | None = None  # Derived judge prompt used for auto-evaluation
+    auto_evaluation_model: str | None = None  # Model used for auto-evaluation
+    show_participant_notes: bool = False  # Facilitator toggle: show notepad to SMEs
+    created_at: datetime = Field(default_factory=datetime.now)
 
 
 class TraceUpload(BaseModel):
-  input: str
-  output: str
-  context: Optional[Dict[str, Any]] = None
-  trace_metadata: Optional[Dict[str, Any]] = None  # Renamed from metadata
-  mlflow_trace_id: Optional[str] = None
-  mlflow_url: Optional[str] = None
-  mlflow_host: Optional[str] = None
-  mlflow_experiment_id: Optional[str] = None
+    input: str
+    output: str
+    context: dict[str, Any] | None = None
+    trace_metadata: dict[str, Any] | None = None  # Renamed from metadata
+    mlflow_trace_id: str | None = None
+    mlflow_url: str | None = None
+    mlflow_host: str | None = None
+    mlflow_experiment_id: str | None = None
 
 
 class Trace(BaseModel):
-  id: str
-  workshop_id: str
-  input: str
-  output: str
-  context: Optional[Dict[str, Any]] = None
-  trace_metadata: Optional[Dict[str, Any]] = None  # Renamed from metadata
-  mlflow_trace_id: Optional[str] = None
-  mlflow_url: Optional[str] = None
-  mlflow_host: Optional[str] = None
-  mlflow_experiment_id: Optional[str] = None
-  include_in_alignment: bool = True  # Whether to include in judge alignment
-  sme_feedback: Optional[str] = None  # Concatenated SME feedback for alignment
-  created_at: datetime = Field(default_factory=datetime.now)
+    id: str
+    workshop_id: str
+    input: str
+    output: str
+    context: dict[str, Any] | None = None
+    trace_metadata: dict[str, Any] | None = None  # Renamed from metadata
+    mlflow_trace_id: str | None = None
+    mlflow_url: str | None = None
+    mlflow_host: str | None = None
+    mlflow_experiment_id: str | None = None
+    include_in_alignment: bool = True  # Whether to include in judge alignment
+    sme_feedback: str | None = None  # Concatenated SME feedback for alignment
+    created_at: datetime = Field(default_factory=datetime.now)
 
 
 class DiscoveryFindingCreate(BaseModel):
-  trace_id: str
-  user_id: str
-  insight: str
+    trace_id: str
+    user_id: str
+    insight: str
 
 
 class DiscoveryFinding(BaseModel):
-  id: str
-  workshop_id: str
-  trace_id: str
-  user_id: str
-  insight: str
-  created_at: datetime = Field(default_factory=datetime.now)
+    id: str
+    workshop_id: str
+    trace_id: str
+    user_id: str
+    insight: str
+    created_at: datetime = Field(default_factory=datetime.now)
 
 
 class RubricCreate(BaseModel):
-  question: str
-  created_by: str
-  judge_type: Optional[JudgeType] = Field(default=JudgeType.LIKERT, description='Type of judge: likert, binary, or freeform')
-  binary_labels: Optional[Dict[str, str]] = Field(default=None, description='Custom labels for binary judge')
-  rating_scale: Optional[int] = Field(default=5, description='Rating scale for rubric judge')
+    question: str
+    created_by: str
+    judge_type: JudgeType | None = Field(
+        default=JudgeType.LIKERT, description="Type of judge: likert, binary, or freeform"
+    )
+    binary_labels: dict[str, str] | None = Field(default=None, description="Custom labels for binary judge")
+    rating_scale: int | None = Field(default=5, description="Rating scale for rubric judge")
 
 
 class Rubric(BaseModel):
-  id: str
-  workshop_id: str
-  question: str
-  judge_type: JudgeType = Field(default=JudgeType.LIKERT)
-  binary_labels: Optional[Dict[str, str]] = None
-  rating_scale: int = 5
-  created_by: str
-  created_at: datetime = Field(default_factory=datetime.now)
+    id: str
+    workshop_id: str
+    question: str
+    judge_type: JudgeType = Field(default=JudgeType.LIKERT)
+    binary_labels: dict[str, str] | None = None
+    rating_scale: int = 5
+    created_by: str
+    created_at: datetime = Field(default_factory=datetime.now)
 
 
 class RubricGenerationRequest(BaseModel):
-  """Request model for generating rubric suggestions using AI."""
-  endpoint_name: str = Field(default="databricks-claude-sonnet-4-5", description="Databricks model serving endpoint name")
-  temperature: float = Field(default=0.3, ge=0.0, le=2.0, description="Model temperature (0.0-2.0)")
-  include_notes: bool = Field(default=True, description="Include participant notes in prompt")
+    """Request model for generating rubric suggestions using AI."""
+
+    endpoint_name: str = Field(
+        default="databricks-claude-sonnet-4-5", description="Databricks model serving endpoint name"
+    )
+    temperature: float = Field(default=0.3, ge=0.0, le=2.0, description="Model temperature (0.0-2.0)")
+    include_notes: bool = Field(default=True, description="Include participant notes in prompt")
 
 
 class RubricSuggestion(BaseModel):
-  """AI-generated rubric suggestion."""
-  title: str = Field(..., min_length=3, max_length=100, description="Short criterion name")
-  description: str = Field(..., min_length=10, max_length=1000, description="Clear definition of what this measures")
-  positive: Optional[str] = Field(None, max_length=500, description="What excellent responses demonstrate")
-  negative: Optional[str] = Field(None, max_length=500, description="What poor responses demonstrate")
-  examples: Optional[str] = Field(None, max_length=500, description="Concrete examples of good and bad")
-  judgeType: str = Field(default="likert", pattern="^(likert|binary|freeform)$", description="Judge type")
+    """AI-generated rubric suggestion."""
+
+    title: str = Field(..., min_length=3, max_length=100, description="Short criterion name")
+    description: str = Field(..., min_length=10, max_length=1000, description="Clear definition of what this measures")
+    positive: str | None = Field(None, max_length=500, description="What excellent responses demonstrate")
+    negative: str | None = Field(None, max_length=500, description="What poor responses demonstrate")
+    examples: str | None = Field(None, max_length=500, description="Concrete examples of good and bad")
+    judgeType: str = Field(default="likert", pattern="^(likert|binary|freeform)$", description="Judge type")
 
 
 class AnnotationCreate(BaseModel):
-  trace_id: str
-  user_id: str
-  rating: int = Field(..., ge=1, le=5)  # Legacy: single rating (for backward compatibility)
-  ratings: Optional[Dict[str, int]] = None  # New: multiple ratings as {"question_id": rating}
-  comment: Optional[str] = None
+    trace_id: str
+    user_id: str
+    rating: int = Field(..., ge=1, le=5)  # Legacy: single rating (for backward compatibility)
+    ratings: dict[str, int] | None = None  # New: multiple ratings as {"question_id": rating}
+    comment: str | None = None
 
 
 class Annotation(BaseModel):
-  id: str
-  workshop_id: str
-  trace_id: str
-  user_id: str
-  rating: int = Field(..., ge=1, le=5)  # Legacy: single rating (for backward compatibility)
-  ratings: Optional[Dict[str, int]] = None  # New: multiple ratings as {"question_id": rating}
-  comment: Optional[str] = None
-  mlflow_trace_id: Optional[str] = None
-  created_at: datetime = Field(default_factory=datetime.now)
+    id: str
+    workshop_id: str
+    trace_id: str
+    user_id: str
+    rating: int = Field(..., ge=1, le=5)  # Legacy: single rating (for backward compatibility)
+    ratings: dict[str, int] | None = None  # New: multiple ratings as {"question_id": rating}
+    comment: str | None = None
+    mlflow_trace_id: str | None = None
+    created_at: datetime = Field(default_factory=datetime.now)
 
 
 class IRRResult(BaseModel):
-  workshop_id: str
-  score: float
-  ready_to_proceed: bool
-  calculated_at: datetime = Field(default_factory=datetime.now)
-  details: Optional[Dict[str, Any]] = None
+    workshop_id: str
+    score: float
+    ready_to_proceed: bool
+    calculated_at: datetime = Field(default_factory=datetime.now)
+    details: dict[str, Any] | None = None
 
 
 # Note: Database storage is now handled by DatabaseService
@@ -279,364 +284,372 @@ class IRRResult(BaseModel):
 
 # MLflow Intake Models
 class MLflowIntakeConfig(BaseModel):
-  """Configuration for MLflow trace intake."""
+    """Configuration for MLflow trace intake."""
 
-  databricks_host: str = Field(..., description='Databricks workspace host URL')
-  databricks_token: str = Field(..., description='Databricks access token')
-  experiment_id: str = Field(..., description='MLflow experiment ID to pull traces from')
-  max_traces: Optional[int] = Field(100, description='Maximum number of traces to pull')
-  filter_string: Optional[str] = Field(None, description='Optional filter string for traces')
+    databricks_host: str = Field(..., description="Databricks workspace host URL")
+    databricks_token: str = Field(..., description="Databricks access token")
+    experiment_id: str = Field(..., description="MLflow experiment ID to pull traces from")
+    max_traces: int | None = Field(100, description="Maximum number of traces to pull")
+    filter_string: str | None = Field(None, description="Optional filter string for traces")
 
 
 class MLflowIntakeConfigCreate(BaseModel):
-  """Request model for creating MLflow intake configuration."""
+    """Request model for creating MLflow intake configuration."""
 
-  databricks_host: str = Field(..., description='Databricks workspace host URL')
-  databricks_token: str = Field(..., description='Databricks access token')
-  experiment_id: str = Field(..., description='MLflow experiment ID to pull traces from')
-  max_traces: Optional[int] = Field(100, description='Maximum number of traces to pull')
-  filter_string: Optional[str] = Field(None, description='Optional filter string for traces')
+    databricks_host: str = Field(..., description="Databricks workspace host URL")
+    databricks_token: str = Field(..., description="Databricks access token")
+    experiment_id: str = Field(..., description="MLflow experiment ID to pull traces from")
+    max_traces: int | None = Field(100, description="Maximum number of traces to pull")
+    filter_string: str | None = Field(None, description="Optional filter string for traces")
 
 
 class MLflowIntakeStatus(BaseModel):
-  """Status of MLflow intake process."""
+    """Status of MLflow intake process."""
 
-  workshop_id: str
-  is_configured: bool = False
-  is_ingested: bool = False
-  trace_count: int = 0
-  last_ingestion_time: Optional[datetime] = None
-  error_message: Optional[str] = None
-  config: Optional[MLflowIntakeConfig] = None
+    workshop_id: str
+    is_configured: bool = False
+    is_ingested: bool = False
+    trace_count: int = 0
+    last_ingestion_time: datetime | None = None
+    error_message: str | None = None
+    config: MLflowIntakeConfig | None = None
 
 
 class MLflowTraceInfo(BaseModel):
-  """Information about an MLflow trace."""
+    """Information about an MLflow trace."""
 
-  trace_id: str
-  request_preview: str
-  response_preview: str
-  execution_time_ms: Optional[int] = None
-  status: str
-  timestamp_ms: int
-  tags: Optional[Dict[str, str]] = None
-  mlflow_url: Optional[str] = None
+    trace_id: str
+    request_preview: str
+    response_preview: str
+    execution_time_ms: int | None = None
+    status: str
+    timestamp_ms: int
+    tags: dict[str, str] | None = None
+    mlflow_url: str | None = None
 
 
 # Judge Tuning Models
 class JudgePromptCreate(BaseModel):
-  """Request model for creating a judge prompt."""
+    """Request model for creating a judge prompt."""
 
-  prompt_text: str = Field(..., description='The judge prompt text')
-  judge_type: JudgeType = Field(default=JudgeType.LIKERT, description='Type of judge: likert, binary, or freeform')
-  few_shot_examples: Optional[List[str]] = Field(default=[], description='Selected few-shot example trace IDs')
-  model_name: Optional[str] = Field(default='demo', description='Model to use: demo, databricks-dbrx-instruct, openai-gpt-4, etc.')
-  model_parameters: Optional[Dict[str, Any]] = Field(default=None, description='Model parameters like temperature')
-  # Binary judge specific config
-  binary_labels: Optional[Dict[str, str]] = Field(default=None, description='Custom labels for binary judge, e.g. {"pass": "Pass", "fail": "Fail"}')
-  # Rubric judge specific config  
-  rating_scale: Optional[int] = Field(default=5, description='Rating scale for rubric judge (default 5-point)')
+    prompt_text: str = Field(..., description="The judge prompt text")
+    judge_type: JudgeType = Field(default=JudgeType.LIKERT, description="Type of judge: likert, binary, or freeform")
+    few_shot_examples: list[str] | None = Field(default=[], description="Selected few-shot example trace IDs")
+    model_name: str | None = Field(
+        default="demo", description="Model to use: demo, databricks-dbrx-instruct, openai-gpt-4, etc."
+    )
+    model_parameters: dict[str, Any] | None = Field(default=None, description="Model parameters like temperature")
+    # Binary judge specific config
+    binary_labels: dict[str, str] | None = Field(
+        default=None, description='Custom labels for binary judge, e.g. {"pass": "Pass", "fail": "Fail"}'
+    )
+    # Rubric judge specific config
+    rating_scale: int | None = Field(default=5, description="Rating scale for rubric judge (default 5-point)")
 
 
 class JudgePrompt(BaseModel):
-  """Judge prompt model."""
+    """Judge prompt model."""
 
-  id: str
-  workshop_id: str
-  prompt_text: str
-  judge_type: JudgeType = Field(default=JudgeType.LIKERT)
-  version: int
-  few_shot_examples: List[str] = Field(default=[])
-  model_name: str = Field(default='demo')
-  model_parameters: Optional[Dict[str, Any]] = None
-  binary_labels: Optional[Dict[str, str]] = None
-  rating_scale: Optional[int] = 5
-  created_by: str
-  created_at: datetime = Field(default_factory=datetime.now)
-  performance_metrics: Optional[Dict[str, Any]] = None
+    id: str
+    workshop_id: str
+    prompt_text: str
+    judge_type: JudgeType = Field(default=JudgeType.LIKERT)
+    version: int
+    few_shot_examples: list[str] = Field(default=[])
+    model_name: str = Field(default="demo")
+    model_parameters: dict[str, Any] | None = None
+    binary_labels: dict[str, str] | None = None
+    rating_scale: int | None = 5
+    created_by: str
+    created_at: datetime = Field(default_factory=datetime.now)
+    performance_metrics: dict[str, Any] | None = None
 
 
 class JudgeEvaluation(BaseModel):
-  """Judge evaluation result for a single trace."""
+    """Judge evaluation result for a single trace."""
 
-  id: str
-  workshop_id: str
-  prompt_id: str
-  trace_id: str
-  # For rubric judges (1-5 scale)
-  predicted_rating: Optional[int] = None
-  human_rating: Optional[int] = None
-  # For binary judges (pass/fail)
-  predicted_binary: Optional[bool] = None
-  human_binary: Optional[bool] = None
-  # For freeform judges (text feedback)
-  predicted_feedback: Optional[str] = None
-  human_feedback: Optional[str] = None
-  # Common fields
-  confidence: Optional[float] = None
-  reasoning: Optional[str] = None
+    id: str
+    workshop_id: str
+    prompt_id: str
+    trace_id: str
+    # For rubric judges (1-5 scale)
+    predicted_rating: int | None = None
+    human_rating: int | None = None
+    # For binary judges (pass/fail)
+    predicted_binary: bool | None = None
+    human_binary: bool | None = None
+    # For freeform judges (text feedback)
+    predicted_feedback: str | None = None
+    human_feedback: str | None = None
+    # Common fields
+    confidence: float | None = None
+    reasoning: str | None = None
 
 
 class JudgeEvaluationRequest(BaseModel):
-  """Request model for evaluating a judge prompt."""
+    """Request model for evaluating a judge prompt."""
 
-  prompt_id: str
-  trace_ids: Optional[List[str]] = Field(None, description='Specific traces to evaluate, or None for all')
-  override_model: Optional[str] = Field(None, description="Override model selection from UI (e.g., 'demo' to force simulation)")
+    prompt_id: str
+    trace_ids: list[str] | None = Field(None, description="Specific traces to evaluate, or None for all")
+    override_model: str | None = Field(
+        None, description="Override model selection from UI (e.g., 'demo' to force simulation)"
+    )
 
 
 class JudgeEvaluationDirectRequest(BaseModel):
-  """Request model for evaluating a judge prompt without saving it."""
+    """Request model for evaluating a judge prompt without saving it."""
 
-  prompt_text: str
-  model_name: str = 'demo'
-  model_parameters: Optional[Dict[str, Any]] = None
-  trace_ids: Optional[List[str]] = Field(None, description='Specific traces to evaluate, or None for all')
+    prompt_text: str
+    model_name: str = "demo"
+    model_parameters: dict[str, Any] | None = None
+    trace_ids: list[str] | None = Field(None, description="Specific traces to evaluate, or None for all")
 
 
 class JudgePerformanceMetrics(BaseModel):
-  """Performance metrics for a judge prompt."""
+    """Performance metrics for a judge prompt."""
 
-  prompt_id: str
-  correlation: float
-  accuracy: float
-  mean_absolute_error: float
-  agreement_by_rating: Dict[str, float]
-  confusion_matrix: List[List[int]]
-  total_evaluations: int
+    prompt_id: str
+    correlation: float
+    accuracy: float
+    mean_absolute_error: float
+    agreement_by_rating: dict[str, float]
+    confusion_matrix: list[list[int]]
+    total_evaluations: int
 
 
 class JudgeEvaluationResult(BaseModel):
-  """Result from direct evaluation including both metrics and individual evaluations."""
+    """Result from direct evaluation including both metrics and individual evaluations."""
 
-  metrics: JudgePerformanceMetrics
-  evaluations: List[JudgeEvaluation]
+    metrics: JudgePerformanceMetrics
+    evaluations: list[JudgeEvaluation]
 
 
 class JudgeExportConfig(BaseModel):
-  """Configuration for exporting a judge."""
+    """Configuration for exporting a judge."""
 
-  prompt_id: str
-  export_format: str = Field(default='json', description='Export format: json, python, or api')
-  include_examples: bool = Field(default=True, description='Include few-shot examples in export')
+    prompt_id: str
+    export_format: str = Field(default="json", description="Export format: json, python, or api")
+    include_examples: bool = Field(default=True, description="Include few-shot examples in export")
 
 
 # DBSQL Export Models
 class DBSQLExportRequest(BaseModel):
-  """Request model for DBSQL export operations."""
+    """Request model for DBSQL export operations."""
 
-  databricks_host: str = Field(..., description='Databricks workspace URL (e.g., https://your-workspace.cloud.databricks.com)')
-  databricks_token: str = Field(..., description='Databricks access token for DBSQL authentication')
-  http_path: str = Field(..., description='DBSQL warehouse HTTP path (e.g., /sql/1.0/warehouses/xxxxxx)')
-  catalog: str = Field(..., description='Unity Catalog catalog name')
-  schema_name: str = Field(..., description='Unity Catalog schema name')
+    databricks_host: str = Field(
+        ..., description="Databricks workspace URL (e.g., https://your-workspace.cloud.databricks.com)"
+    )
+    databricks_token: str = Field(..., description="Databricks access token for DBSQL authentication")
+    http_path: str = Field(..., description="DBSQL warehouse HTTP path (e.g., /sql/1.0/warehouses/xxxxxx)")
+    catalog: str = Field(..., description="Unity Catalog catalog name")
+    schema_name: str = Field(..., description="Unity Catalog schema name")
 
 
 class DBSQLExportResponse(BaseModel):
-  """Response model for DBSQL export operations."""
+    """Response model for DBSQL export operations."""
 
-  success: bool = Field(..., description='Whether the export was successful')
-  message: str = Field(..., description='Human-readable message about the export')
-  tables_exported: Optional[List[Dict[str, Any]]] = Field(None, description='List of exported tables')
-  total_rows: Optional[int] = Field(None, description='Total number of rows exported')
-  errors: Optional[List[str]] = Field(None, description='List of errors encountered during export')
+    success: bool = Field(..., description="Whether the export was successful")
+    message: str = Field(..., description="Human-readable message about the export")
+    tables_exported: list[dict[str, Any]] | None = Field(None, description="List of exported tables")
+    total_rows: int | None = Field(None, description="Total number of rows exported")
+    errors: list[str] | None = Field(None, description="List of errors encountered during export")
 
 
 # Participant Note Models
 class ParticipantNoteCreate(BaseModel):
-  """Request model for creating a participant note."""
+    """Request model for creating a participant note."""
 
-  user_id: str
-  trace_id: Optional[str] = None  # Nullable: note can be general or trace-specific
-  content: str
-  phase: str = "discovery"  # 'discovery' or 'annotation'
+    user_id: str
+    trace_id: str | None = None  # Nullable: note can be general or trace-specific
+    content: str
+    phase: str = "discovery"  # 'discovery' or 'annotation'
 
 
 class ParticipantNote(BaseModel):
-  """Participant note model."""
+    """Participant note model."""
 
-  id: str
-  workshop_id: str
-  user_id: str
-  trace_id: Optional[str] = None
-  content: str
-  phase: str = "discovery"  # 'discovery' or 'annotation'
-  user_name: Optional[str] = None  # Populated when returning notes with user details
-  created_at: datetime = Field(default_factory=datetime.now)
-  updated_at: datetime = Field(default_factory=datetime.now)
+    id: str
+    workshop_id: str
+    user_id: str
+    trace_id: str | None = None
+    content: str
+    phase: str = "discovery"  # 'discovery' or 'annotation'
+    user_name: str | None = None  # Populated when returning notes with user details
+    created_at: datetime = Field(default_factory=datetime.now)
+    updated_at: datetime = Field(default_factory=datetime.now)
 
 
 # User Trace Order Models
 class UserTraceOrderCreate(BaseModel):
-  """Model for creating user trace order."""
+    """Model for creating user trace order."""
 
-  user_id: str
-  workshop_id: str
-  discovery_traces: List[str] = Field(default_factory=list)
-  annotation_traces: List[str] = Field(default_factory=list)
+    user_id: str
+    workshop_id: str
+    discovery_traces: list[str] = Field(default_factory=list)
+    annotation_traces: list[str] = Field(default_factory=list)
 
 
 class UserTraceOrder(BaseModel):
-  """Model for user-specific trace orderings."""
+    """Model for user-specific trace orderings."""
 
-  id: str
-  user_id: str
-  workshop_id: str
-  discovery_traces: List[str] = Field(default_factory=list)
-  annotation_traces: List[str] = Field(default_factory=list)
-  created_at: datetime
-  updated_at: datetime
+    id: str
+    user_id: str
+    workshop_id: str
+    discovery_traces: list[str] = Field(default_factory=list)
+    annotation_traces: list[str] = Field(default_factory=list)
+    created_at: datetime
+    updated_at: datetime
 
 
 # Authentication Models
 class FacilitatorConfig(BaseModel):
-  """Configuration for pre-configured facilitators."""
+    """Configuration for pre-configured facilitators."""
 
-  email: str
-  password_hash: str
-  name: str
-  description: Optional[str] = None
-  created_at: datetime = Field(default_factory=datetime.now)
+    email: str
+    password_hash: str
+    name: str
+    description: str | None = None
+    created_at: datetime = Field(default_factory=datetime.now)
 
 
 class FacilitatorConfigCreate(BaseModel):
-  """Request model for creating facilitator configuration."""
+    """Request model for creating facilitator configuration."""
 
-  email: str
-  password: str
-  name: str
-  description: Optional[str] = None
+    email: str
+    password: str
+    name: str
+    description: str | None = None
 
 
 class AuthResponse(BaseModel):
-  """Response model for authentication."""
+    """Response model for authentication."""
 
-  user: User
-  is_preconfigured_facilitator: bool = False
-  message: str
+    user: User
+    is_preconfigured_facilitator: bool = False
+    message: str
 
 
 class UserInvite(BaseModel):
-  """Model for user invitations."""
+    """Model for user invitations."""
 
-  email: str
-  name: str
-  role: UserRole
-  workshop_id: str
-  invited_by: str
-  expires_at: datetime
+    email: str
+    name: str
+    role: UserRole
+    workshop_id: str
+    invited_by: str
+    expires_at: datetime
 
 
 class UserInvitation(BaseModel):
-  """Model for user invitation responses."""
+    """Model for user invitation responses."""
 
-  token: str
-  password: str
+    token: str
+    password: str
 
 
 # Databricks Model Serving Models
 class DatabricksConfig(BaseModel):
-  """Configuration for Databricks workspace connection."""
+    """Configuration for Databricks workspace connection."""
 
-  workspace_url: str = Field(..., description='Databricks workspace URL')
-  token: str = Field(..., description='Databricks API token')
+    workspace_url: str = Field(..., description="Databricks workspace URL")
+    token: str = Field(..., description="Databricks API token")
 
 
 class DatabricksEndpointCall(BaseModel):
-  """Request model for calling a Databricks serving endpoint."""
+    """Request model for calling a Databricks serving endpoint."""
 
-  endpoint_name: str = Field(..., description='Name of the serving endpoint')
-  prompt: str = Field(..., description='The prompt to send to the model')
-  temperature: float = Field(default=0.5, ge=0.0, le=1.0, description='Temperature for generation')
-  max_tokens: Optional[int] = Field(default=None, gt=0, description='Maximum number of tokens to generate')
-  model_parameters: Optional[Dict[str, Any]] = Field(default=None, description='Additional model parameters')
+    endpoint_name: str = Field(..., description="Name of the serving endpoint")
+    prompt: str = Field(..., description="The prompt to send to the model")
+    temperature: float = Field(default=0.5, ge=0.0, le=1.0, description="Temperature for generation")
+    max_tokens: int | None = Field(default=None, gt=0, description="Maximum number of tokens to generate")
+    model_parameters: dict[str, Any] | None = Field(default=None, description="Additional model parameters")
 
 
 class DatabricksChatMessage(BaseModel):
-  """Model for chat completion messages."""
+    """Model for chat completion messages."""
 
-  role: str = Field(..., description='Role of the message sender (system, user, assistant)')
-  content: str = Field(..., description='Content of the message')
+    role: str = Field(..., description="Role of the message sender (system, user, assistant)")
+    content: str = Field(..., description="Content of the message")
 
 
 class DatabricksChatCompletion(BaseModel):
-  """Request model for Databricks chat completion."""
+    """Request model for Databricks chat completion."""
 
-  endpoint_name: str = Field(..., description='Name of the serving endpoint')
-  messages: List[DatabricksChatMessage] = Field(..., description='List of messages for chat completion')
-  temperature: float = Field(default=0.5, ge=0.0, le=1.0, description='Temperature for generation')
-  max_tokens: Optional[int] = Field(default=None, gt=0, description='Maximum number of tokens to generate')
-  model_parameters: Optional[Dict[str, Any]] = Field(default=None, description='Additional model parameters')
+    endpoint_name: str = Field(..., description="Name of the serving endpoint")
+    messages: list[DatabricksChatMessage] = Field(..., description="List of messages for chat completion")
+    temperature: float = Field(default=0.5, ge=0.0, le=1.0, description="Temperature for generation")
+    max_tokens: int | None = Field(default=None, gt=0, description="Maximum number of tokens to generate")
+    model_parameters: dict[str, Any] | None = Field(default=None, description="Additional model parameters")
 
 
 class DatabricksResponse(BaseModel):
-  """Response model for Databricks API calls."""
+    """Response model for Databricks API calls."""
 
-  success: bool = Field(..., description='Whether the request was successful')
-  data: Optional[Dict[str, Any]] = Field(default=None, description='Response data from the model')
-  error: Optional[str] = Field(default=None, description='Error message if request failed')
-  endpoint_name: str = Field(..., description='Name of the endpoint that was called')
-  timestamp: datetime = Field(default_factory=datetime.now, description='Timestamp of the request')
+    success: bool = Field(..., description="Whether the request was successful")
+    data: dict[str, Any] | None = Field(default=None, description="Response data from the model")
+    error: str | None = Field(default=None, description="Error message if request failed")
+    endpoint_name: str = Field(..., description="Name of the endpoint that was called")
+    timestamp: datetime = Field(default_factory=datetime.now, description="Timestamp of the request")
 
 
 class DatabricksEndpointInfo(BaseModel):
-  """Model for serving endpoint information."""
+    """Model for serving endpoint information."""
 
-  name: str = Field(..., description='Name of the serving endpoint')
-  id: str = Field(..., description='Unique identifier of the endpoint')
-  state: Optional[str] = Field(default=None, description='Current state of the endpoint')
-  config: Optional[Dict[str, Any]] = Field(default=None, description='Endpoint configuration')
-  creator: Optional[str] = Field(default=None, description='Creator of the endpoint')
-  created_at: Optional[str] = Field(default=None, description='Creation timestamp')
-  updated_at: Optional[str] = Field(default=None, description='Last update timestamp')
+    name: str = Field(..., description="Name of the serving endpoint")
+    id: str = Field(..., description="Unique identifier of the endpoint")
+    state: str | None = Field(default=None, description="Current state of the endpoint")
+    config: dict[str, Any] | None = Field(default=None, description="Endpoint configuration")
+    creator: str | None = Field(default=None, description="Creator of the endpoint")
+    created_at: str | None = Field(default=None, description="Creation timestamp")
+    updated_at: str | None = Field(default=None, description="Last update timestamp")
 
 
 class DatabricksConnectionTest(BaseModel):
-  """Model for connection test results."""
+    """Model for connection test results."""
 
-  status: str = Field(..., description='Connection status (connected/failed)')
-  workspace_url: str = Field(..., description='Workspace URL that was tested')
-  endpoints_count: Optional[int] = Field(default=None, description='Number of available endpoints')
-  error: Optional[str] = Field(default=None, description='Error message if connection failed')
-  message: str = Field(..., description='Human-readable status message')
+    status: str = Field(..., description="Connection status (connected/failed)")
+    workspace_url: str = Field(..., description="Workspace URL that was tested")
+    endpoints_count: int | None = Field(default=None, description="Number of available endpoints")
+    error: str | None = Field(default=None, description="Error message if connection failed")
+    message: str = Field(..., description="Human-readable status message")
 
 
 # Custom LLM Provider Models
 class CustomLLMProviderConfig(BaseModel):
-  """Configuration for custom OpenAI-compatible LLM provider."""
+    """Configuration for custom OpenAI-compatible LLM provider."""
 
-  provider_name: str = Field(..., description='User-friendly provider name')
-  base_url: str = Field(..., description='Base URL for the OpenAI-compatible endpoint')
-  api_key: str = Field(..., description='API key (not persisted to DB)')
-  model_name: str = Field(..., description='Model name/identifier')
-  is_enabled: bool = Field(default=True, description='Whether custom provider is active')
+    provider_name: str = Field(..., description="User-friendly provider name")
+    base_url: str = Field(..., description="Base URL for the OpenAI-compatible endpoint")
+    api_key: str = Field(..., description="API key (not persisted to DB)")
+    model_name: str = Field(..., description="Model name/identifier")
+    is_enabled: bool = Field(default=True, description="Whether custom provider is active")
 
 
 class CustomLLMProviderConfigCreate(BaseModel):
-  """Request model for creating/updating custom LLM provider config."""
+    """Request model for creating/updating custom LLM provider config."""
 
-  provider_name: str = Field(..., description='User-friendly provider name')
-  base_url: str = Field(..., description='Base URL for the OpenAI-compatible endpoint')
-  api_key: str = Field(..., description='API key for authentication')
-  model_name: str = Field(..., description='Model name/identifier')
+    provider_name: str = Field(..., description="User-friendly provider name")
+    base_url: str = Field(..., description="Base URL for the OpenAI-compatible endpoint")
+    api_key: str = Field(..., description="API key for authentication")
+    model_name: str = Field(..., description="Model name/identifier")
 
 
 class CustomLLMProviderStatus(BaseModel):
-  """Status of custom LLM provider configuration."""
+    """Status of custom LLM provider configuration."""
 
-  workshop_id: str
-  is_configured: bool = False
-  is_enabled: bool = False
-  provider_name: Optional[str] = None
-  base_url: Optional[str] = None  # Shown in UI for reference
-  model_name: Optional[str] = None
-  has_api_key: bool = False  # Whether key is stored (don't expose actual key)
+    workshop_id: str
+    is_configured: bool = False
+    is_enabled: bool = False
+    provider_name: str | None = None
+    base_url: str | None = None  # Shown in UI for reference
+    model_name: str | None = None
+    has_api_key: bool = False  # Whether key is stored (don't expose actual key)
 
 
 class CustomLLMProviderTestResult(BaseModel):
-  """Result of testing custom LLM provider connection."""
+    """Result of testing custom LLM provider connection."""
 
-  success: bool
-  message: str
-  response_time_ms: Optional[int] = None
-  error_code: Optional[str] = None
+    success: bool
+    message: str
+    response_time_ms: int | None = None
+    error_code: str | None = None

--- a/server/routers/__init__.py
+++ b/server/routers/__init__.py
@@ -9,7 +9,7 @@ from server.routers.users import router as users_router
 from server.routers.workshops import router as workshops_router
 
 router = APIRouter()
-router.include_router(workshops_router, prefix='/workshops', tags=['workshops'])
-router.include_router(users_router, prefix='/users', tags=['users'])
-router.include_router(dbsql_export_router, tags=['dbsql-export'])
-router.include_router(databricks_router, prefix='/databricks', tags=['databricks'])
+router.include_router(workshops_router, prefix="/workshops", tags=["workshops"])
+router.include_router(users_router, prefix="/users", tags=["users"])
+router.include_router(dbsql_export_router, tags=["dbsql-export"])
+router.include_router(databricks_router, prefix="/databricks", tags=["databricks"])

--- a/server/routers/databricks.py
+++ b/server/routers/databricks.py
@@ -1,18 +1,18 @@
 """Databricks Model Serving API endpoints."""
 
-from typing import Any, Dict, List
+from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
 from server.database import get_db
 from server.models import (
-  DatabricksChatCompletion,
-  DatabricksConfig,
-  DatabricksConnectionTest,
-  DatabricksEndpointCall,
-  DatabricksEndpointInfo,
-  DatabricksResponse,
+    DatabricksChatCompletion,
+    DatabricksConfig,
+    DatabricksConnectionTest,
+    DatabricksEndpointCall,
+    DatabricksEndpointInfo,
+    DatabricksResponse,
 )
 from server.services.database_service import DatabaseService
 from server.services.databricks_service import DatabricksService, create_databricks_service
@@ -21,264 +21,266 @@ router = APIRouter()
 
 
 def get_databricks_service(config: DatabricksConfig) -> DatabricksService:
-  """Create a Databricks service instance from configuration."""
-  try:
-    return create_databricks_service(workspace_url=config.workspace_url, token=config.token)
-  except Exception as e:
-    raise HTTPException(status_code=500, detail=f'Failed to initialize Databricks service: {str(e)}')
+    """Create a Databricks service instance from configuration."""
+    try:
+        return create_databricks_service(workspace_url=config.workspace_url, token=config.token)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to initialize Databricks service: {e!s}") from e
 
 
-@router.post('/test-connection', response_model=DatabricksConnectionTest)
+@router.post("/test-connection", response_model=DatabricksConnectionTest)
 async def test_databricks_connection(config: DatabricksConfig) -> DatabricksConnectionTest:
-  """Test the connection to a Databricks workspace.
+    """Test the connection to a Databricks workspace.
 
-  Args:
-      config: Databricks workspace configuration
+    Args:
+        config: Databricks workspace configuration
 
-  Returns:
-      Connection test results
-  """
-  try:
-    service = get_databricks_service(config)
-    result = service.test_connection()
-    return DatabricksConnectionTest(**result)
-  except Exception as e:
-    return DatabricksConnectionTest(
-      status='failed',
-      workspace_url=config.workspace_url,
-      error=str(e),
-      message=f'Connection test failed: {str(e)}',
-    )
-
-
-@router.get('/endpoints', response_model=List[DatabricksEndpointInfo])
-async def list_serving_endpoints(config: DatabricksConfig) -> List[DatabricksEndpointInfo]:
-  """List all available serving endpoints in the Databricks workspace.
-
-  Args:
-      config: Databricks workspace configuration
-
-  Returns:
-      List of serving endpoint information
-  """
-  service = get_databricks_service(config)
-  endpoints = service.list_serving_endpoints()
-  return [DatabricksEndpointInfo(**endpoint) for endpoint in endpoints]
-
-
-@router.get('/endpoints/{endpoint_name}', response_model=DatabricksEndpointInfo)
-async def get_endpoint_info(endpoint_name: str, config: DatabricksConfig) -> DatabricksEndpointInfo:
-  """Get detailed information about a specific serving endpoint.
-
-  Args:
-      endpoint_name: Name of the serving endpoint
-      config: Databricks workspace configuration
-
-  Returns:
-      Detailed endpoint information
-  """
-  service = get_databricks_service(config)
-  endpoint_info = service.get_endpoint_info(endpoint_name)
-  return DatabricksEndpointInfo(**endpoint_info)
-
-
-@router.post('/call', response_model=DatabricksResponse)
-async def call_serving_endpoint(request: DatabricksEndpointCall, config: DatabricksConfig) -> DatabricksResponse:
-  """Call a Databricks serving endpoint with a prompt.
-
-  Args:
-      request: Endpoint call request with prompt and parameters
-      config: Databricks workspace configuration
-
-  Returns:
-      Response from the model
-  """
-  try:
-    service = get_databricks_service(config)
-
-    # Prepare parameters for the service call
-    params = {
-      'endpoint_name': request.endpoint_name,
-      'prompt': request.prompt,
-      'temperature': request.temperature,
-    }
-
-    if request.max_tokens:
-      params['max_tokens'] = request.max_tokens
-
-    if request.model_parameters:
-      params['model_parameters'] = request.model_parameters
-
-    # Make the API call
-    result = service.call_serving_endpoint(**params)
-
-    return DatabricksResponse(success=True, data=result, endpoint_name=request.endpoint_name)
-
-  except Exception as e:
-    return DatabricksResponse(success=False, error=str(e), endpoint_name=request.endpoint_name)
-
-
-@router.post('/chat', response_model=DatabricksResponse)
-async def call_chat_completion(request: DatabricksChatCompletion, config: DatabricksConfig) -> DatabricksResponse:
-  """Call a Databricks serving endpoint using chat completion format.
-
-  Args:
-      request: Chat completion request with messages
-      config: Databricks workspace configuration
-
-  Returns:
-      Response from the model
-  """
-  try:
-    service = get_databricks_service(config)
-
-    # Convert messages to the format expected by the service
-    messages = [{'role': msg.role, 'content': msg.content} for msg in request.messages]
-
-    # Prepare parameters for the service call
-    params = {
-      'endpoint_name': request.endpoint_name,
-      'messages': messages,
-      'temperature': request.temperature,
-    }
-
-    if request.max_tokens:
-      params['max_tokens'] = request.max_tokens
-
-    if request.model_parameters:
-      params['model_parameters'] = request.model_parameters
-
-    # Make the API call
-    result = service.call_chat_completion(**params)
-
-    return DatabricksResponse(success=True, data=result, endpoint_name=request.endpoint_name)
-
-  except Exception as e:
-    return DatabricksResponse(success=False, error=str(e), endpoint_name=request.endpoint_name)
-
-
-@router.post('/judge-evaluate')
-async def evaluate_judge_prompt(request: dict, db: Session = Depends(get_db)) -> DatabricksResponse:
-  """Evaluate a judge prompt using Databricks serving endpoint.
-  This is specifically designed for judge evaluation with default parameters.
-
-  Args:
-      request: Dictionary containing endpoint_name, prompt, config, temperature, max_tokens
-      db: Database session
-
-  Returns:
-      Response from the model
-  """
-  try:
-    endpoint_name = request.get('endpoint_name')
-    prompt = request.get('prompt')
-    config_data = request.get('config', {})
-    temperature = request.get('temperature', 0.0)
-    max_tokens = request.get('max_tokens', 10)
-    workshop_id = request.get('workshop_id')
-
-    # Get MLflow config from database if workshop_id is provided
-    if workshop_id:
-      db_service = DatabaseService(db)
-      mlflow_config = db_service.get_mlflow_config(workshop_id)
-      if mlflow_config:
-        # Get token from memory storage
-        from server.services.token_storage_service import token_storage
-
-        databricks_token = token_storage.get_token(workshop_id)
-        if not databricks_token:
-          databricks_token = db_service.get_databricks_token(workshop_id)
-          if databricks_token:
-            token_storage.store_token(workshop_id, databricks_token)
-        if databricks_token:
-          # Use token from memory storage - same approach as intake service
-          # Set environment variables like the intake service does
-          import os
-
-          os.environ['DATABRICKS_HOST'] = mlflow_config.databricks_host.rstrip('/')
-          os.environ['DATABRICKS_TOKEN'] = databricks_token
-
-          # Clear profile-related environment variables that force profile auth
-          # These override token auth even when we provide explicit tokens
-          if 'DATABRICKS_CONFIG_PROFILE' in os.environ:
-            del os.environ['DATABRICKS_CONFIG_PROFILE']
-          if 'DATABRICKS_AUTH_TYPE' in os.environ:
-            del os.environ['DATABRICKS_AUTH_TYPE']
-
-          service = DatabricksService(
-            workspace_url=mlflow_config.databricks_host,
-            token=databricks_token,
-            init_sdk=True,  # Use SDK like intake service
-          )
-        else:
-          # Fallback to request config
-          service = DatabricksService(
-            workspace_url=config_data.get('workspace_url'),
-            token=config_data.get('token'),
-            init_sdk=True,  # Use SDK approach
-          )
-      else:
-        # Fallback to request config
-        service = DatabricksService(
-          workspace_url=config_data.get('workspace_url'),
-          token=config_data.get('token'),
-          init_sdk=True,  # Use SDK approach
+    Returns:
+        Connection test results
+    """
+    try:
+        service = get_databricks_service(config)
+        result = service.test_connection()
+        return DatabricksConnectionTest(**result)
+    except Exception as e:
+        return DatabricksConnectionTest(
+            status="failed",
+            workspace_url=config.workspace_url,
+            error=str(e),
+            message=f"Connection test failed: {e!s}",
         )
-    else:
-      # Use request config if no workshop_id
-      service = DatabricksService(
-        workspace_url=config_data.get('workspace_url'),
-        token=config_data.get('token'),
-        init_sdk=True,  # Use SDK approach
-      )
-
-    # Call the serving endpoint with judge-specific parameters using SDK (same as intake)
-    result = service.call_serving_endpoint(endpoint_name=endpoint_name, prompt=prompt, temperature=temperature, max_tokens=max_tokens)
-
-    return DatabricksResponse(success=True, data=result, endpoint_name=endpoint_name)
-
-  except Exception as e:
-    return DatabricksResponse(success=False, error=str(e), endpoint_name=endpoint_name)
 
 
-@router.post('/simple-call')
-async def simple_endpoint_call(
-  endpoint_name: str,
-  prompt: str,
-  temperature: float = 0.5,
-  max_tokens: int = None,
-  workspace_url: str = None,
-  token: str = None,
-) -> Dict[str, Any]:
-  """Simple endpoint call for testing purposes.
+@router.get("/endpoints", response_model=list[DatabricksEndpointInfo])
+async def list_serving_endpoints(config: DatabricksConfig) -> list[DatabricksEndpointInfo]:
+    """List all available serving endpoints in the Databricks workspace.
 
-  Args:
-      endpoint_name: Name of the serving endpoint
-      prompt: The prompt to send
-      temperature: Temperature for generation
-      max_tokens: Maximum tokens to generate
-      workspace_url: Databricks workspace URL
-      token: Databricks API token
+    Args:
+        config: Databricks workspace configuration
 
-  Returns:
-      Response from the model
-  """
-  try:
-    # Create config from parameters
-    config = DatabricksConfig(workspace_url=workspace_url, token=token)
-
+    Returns:
+        List of serving endpoint information
+    """
     service = get_databricks_service(config)
+    endpoints = service.list_serving_endpoints()
+    return [DatabricksEndpointInfo(**endpoint) for endpoint in endpoints]
 
-    # Prepare parameters
-    params = {'endpoint_name': endpoint_name, 'prompt': prompt, 'temperature': temperature}
 
-    if max_tokens:
-      params['max_tokens'] = max_tokens
+@router.get("/endpoints/{endpoint_name}", response_model=DatabricksEndpointInfo)
+async def get_endpoint_info(endpoint_name: str, config: DatabricksConfig) -> DatabricksEndpointInfo:
+    """Get detailed information about a specific serving endpoint.
 
-    # Make the API call
-    result = service.call_serving_endpoint(**params)
+    Args:
+        endpoint_name: Name of the serving endpoint
+        config: Databricks workspace configuration
 
-    return {'success': True, 'data': result, 'endpoint_name': endpoint_name}
+    Returns:
+        Detailed endpoint information
+    """
+    service = get_databricks_service(config)
+    endpoint_info = service.get_endpoint_info(endpoint_name)
+    return DatabricksEndpointInfo(**endpoint_info)
 
-  except Exception as e:
-    return {'success': False, 'error': str(e), 'endpoint_name': endpoint_name}
+
+@router.post("/call", response_model=DatabricksResponse)
+async def call_serving_endpoint(request: DatabricksEndpointCall, config: DatabricksConfig) -> DatabricksResponse:
+    """Call a Databricks serving endpoint with a prompt.
+
+    Args:
+        request: Endpoint call request with prompt and parameters
+        config: Databricks workspace configuration
+
+    Returns:
+        Response from the model
+    """
+    try:
+        service = get_databricks_service(config)
+
+        # Prepare parameters for the service call
+        params = {
+            "endpoint_name": request.endpoint_name,
+            "prompt": request.prompt,
+            "temperature": request.temperature,
+        }
+
+        if request.max_tokens:
+            params["max_tokens"] = request.max_tokens
+
+        if request.model_parameters:
+            params["model_parameters"] = request.model_parameters
+
+        # Make the API call
+        result = service.call_serving_endpoint(**params)
+
+        return DatabricksResponse(success=True, data=result, endpoint_name=request.endpoint_name)
+
+    except Exception as e:
+        return DatabricksResponse(success=False, error=str(e), endpoint_name=request.endpoint_name)
+
+
+@router.post("/chat", response_model=DatabricksResponse)
+async def call_chat_completion(request: DatabricksChatCompletion, config: DatabricksConfig) -> DatabricksResponse:
+    """Call a Databricks serving endpoint using chat completion format.
+
+    Args:
+        request: Chat completion request with messages
+        config: Databricks workspace configuration
+
+    Returns:
+        Response from the model
+    """
+    try:
+        service = get_databricks_service(config)
+
+        # Convert messages to the format expected by the service
+        messages = [{"role": msg.role, "content": msg.content} for msg in request.messages]
+
+        # Prepare parameters for the service call
+        params = {
+            "endpoint_name": request.endpoint_name,
+            "messages": messages,
+            "temperature": request.temperature,
+        }
+
+        if request.max_tokens:
+            params["max_tokens"] = request.max_tokens
+
+        if request.model_parameters:
+            params["model_parameters"] = request.model_parameters
+
+        # Make the API call
+        result = service.call_chat_completion(**params)
+
+        return DatabricksResponse(success=True, data=result, endpoint_name=request.endpoint_name)
+
+    except Exception as e:
+        return DatabricksResponse(success=False, error=str(e), endpoint_name=request.endpoint_name)
+
+
+@router.post("/judge-evaluate")
+async def evaluate_judge_prompt(request: dict, db: Session = Depends(get_db)) -> DatabricksResponse:
+    """Evaluate a judge prompt using Databricks serving endpoint.
+    This is specifically designed for judge evaluation with default parameters.
+
+    Args:
+        request: Dictionary containing endpoint_name, prompt, config, temperature, max_tokens
+        db: Database session
+
+    Returns:
+        Response from the model
+    """
+    try:
+        endpoint_name = request.get("endpoint_name")
+        prompt = request.get("prompt")
+        config_data = request.get("config", {})
+        temperature = request.get("temperature", 0.0)
+        max_tokens = request.get("max_tokens", 10)
+        workshop_id = request.get("workshop_id")
+
+        # Get MLflow config from database if workshop_id is provided
+        if workshop_id:
+            db_service = DatabaseService(db)
+            mlflow_config = db_service.get_mlflow_config(workshop_id)
+            if mlflow_config:
+                # Get token from memory storage
+                from server.services.token_storage_service import token_storage
+
+                databricks_token = token_storage.get_token(workshop_id)
+                if not databricks_token:
+                    databricks_token = db_service.get_databricks_token(workshop_id)
+                    if databricks_token:
+                        token_storage.store_token(workshop_id, databricks_token)
+                if databricks_token:
+                    # Use token from memory storage - same approach as intake service
+                    # Set environment variables like the intake service does
+                    import os
+
+                    os.environ["DATABRICKS_HOST"] = mlflow_config.databricks_host.rstrip("/")
+                    os.environ["DATABRICKS_TOKEN"] = databricks_token
+
+                    # Clear profile-related environment variables that force profile auth
+                    # These override token auth even when we provide explicit tokens
+                    if "DATABRICKS_CONFIG_PROFILE" in os.environ:
+                        del os.environ["DATABRICKS_CONFIG_PROFILE"]
+                    if "DATABRICKS_AUTH_TYPE" in os.environ:
+                        del os.environ["DATABRICKS_AUTH_TYPE"]
+
+                    service = DatabricksService(
+                        workspace_url=mlflow_config.databricks_host,
+                        token=databricks_token,
+                        init_sdk=True,  # Use SDK like intake service
+                    )
+                else:
+                    # Fallback to request config
+                    service = DatabricksService(
+                        workspace_url=config_data.get("workspace_url"),
+                        token=config_data.get("token"),
+                        init_sdk=True,  # Use SDK approach
+                    )
+            else:
+                # Fallback to request config
+                service = DatabricksService(
+                    workspace_url=config_data.get("workspace_url"),
+                    token=config_data.get("token"),
+                    init_sdk=True,  # Use SDK approach
+                )
+        else:
+            # Use request config if no workshop_id
+            service = DatabricksService(
+                workspace_url=config_data.get("workspace_url"),
+                token=config_data.get("token"),
+                init_sdk=True,  # Use SDK approach
+            )
+
+        # Call the serving endpoint with judge-specific parameters using SDK (same as intake)
+        result = service.call_serving_endpoint(
+            endpoint_name=endpoint_name, prompt=prompt, temperature=temperature, max_tokens=max_tokens
+        )
+
+        return DatabricksResponse(success=True, data=result, endpoint_name=endpoint_name)
+
+    except Exception as e:
+        return DatabricksResponse(success=False, error=str(e), endpoint_name=endpoint_name)
+
+
+@router.post("/simple-call")
+async def simple_endpoint_call(
+    endpoint_name: str,
+    prompt: str,
+    temperature: float = 0.5,
+    max_tokens: int = None,
+    workspace_url: str = None,
+    token: str = None,
+) -> dict[str, Any]:
+    """Simple endpoint call for testing purposes.
+
+    Args:
+        endpoint_name: Name of the serving endpoint
+        prompt: The prompt to send
+        temperature: Temperature for generation
+        max_tokens: Maximum tokens to generate
+        workspace_url: Databricks workspace URL
+        token: Databricks API token
+
+    Returns:
+        Response from the model
+    """
+    try:
+        # Create config from parameters
+        config = DatabricksConfig(workspace_url=workspace_url, token=token)
+
+        service = get_databricks_service(config)
+
+        # Prepare parameters
+        params = {"endpoint_name": endpoint_name, "prompt": prompt, "temperature": temperature}
+
+        if max_tokens:
+            params["max_tokens"] = max_tokens
+
+        # Make the API call
+        result = service.call_serving_endpoint(**params)
+
+        return {"success": True, "data": result, "endpoint_name": endpoint_name}
+
+    except Exception as e:
+        return {"success": False, "error": str(e), "endpoint_name": endpoint_name}

--- a/server/routers/dbsql_export.py
+++ b/server/routers/dbsql_export.py
@@ -68,8 +68,8 @@ async def export_workshop_to_dbsql(
         )
 
     except Exception as e:
-        logger.error(f"Failed to export workshop {workshop_id} to DBSQL: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"Failed to export workshop to DBSQL: {str(e)}")
+        logger.error(f"Failed to export workshop {workshop_id} to DBSQL: {e!s}")
+        raise HTTPException(status_code=500, detail=f"Failed to export workshop to DBSQL: {e!s}") from e
 
 
 @router.get("/{workshop_id}/export-status")
@@ -107,5 +107,5 @@ async def get_dbsql_export_status(workshop_id: str, db: Session = Depends(get_db
         }
 
     except Exception as e:
-        logger.error(f"Failed to get DBSQL export status for workshop {workshop_id}: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"Failed to get export status: {str(e)}")
+        logger.error(f"Failed to get DBSQL export status for workshop {workshop_id}: {e!s}")
+        raise HTTPException(status_code=500, detail=f"Failed to get export status: {e!s}") from e

--- a/server/routers/users.py
+++ b/server/routers/users.py
@@ -1,178 +1,176 @@
 """User management API endpoints."""
 
 from datetime import datetime
-from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
 from server.database import get_db
 from server.models import (
-  AuthResponse,
-  FacilitatorConfigCreate,
-  User,
-  UserCreate,
-  UserInvite,
-  UserLogin,
-  UserPermissions,
-  UserRole,
-  UserStatus,
-  WorkshopParticipant,
+    AuthResponse,
+    FacilitatorConfigCreate,
+    User,
+    UserCreate,
+    UserInvite,
+    UserLogin,
+    UserPermissions,
+    UserRole,
+    UserStatus,
+    WorkshopParticipant,
 )
 from server.services.database_service import DatabaseService
 
 
 def get_database_service(db: Session = Depends(get_db)) -> DatabaseService:
-  """Get database service instance."""
-  return DatabaseService(db)
+    """Get database service instance."""
+    return DatabaseService(db)
 
 
 router = APIRouter()
 
 
-@router.post('/auth/login', response_model=AuthResponse)
+@router.post("/auth/login", response_model=AuthResponse)
 async def login(login_data: UserLogin, db_service=Depends(get_database_service)):
-  """Authenticate a user with email and password."""
-  # First, try to authenticate as a facilitator from YAML config
-  facilitator_data = db_service.authenticate_facilitator_from_yaml(login_data.email, login_data.password)
+    """Authenticate a user with email and password."""
+    # First, try to authenticate as a facilitator from YAML config
+    facilitator_data = db_service.authenticate_facilitator_from_yaml(login_data.email, login_data.password)
 
-  if facilitator_data:
-    # Facilitator authenticated from YAML - get or create user
-    user = db_service.get_or_create_facilitator_user(facilitator_data)
+    if facilitator_data:
+        # Facilitator authenticated from YAML - get or create user
+        user = db_service.get_or_create_facilitator_user(facilitator_data)
 
-    return AuthResponse(user=user, is_preconfigured_facilitator=True, message='Facilitator login successful')
+        return AuthResponse(user=user, is_preconfigured_facilitator=True, message="Facilitator login successful")
 
-  # If not a facilitator, try regular user authentication
-  user = db_service.authenticate_user(login_data.email, login_data.password)
-  if not user:
-    raise HTTPException(status_code=401, detail='Invalid email or password')
+    # If not a facilitator, try regular user authentication
+    user = db_service.authenticate_user(login_data.email, login_data.password)
+    if not user:
+        raise HTTPException(status_code=401, detail="Invalid email or password")
 
-  # For participants/SMEs (no password), validate workshop access
-  # They can only access workshops they've been invited to
-  if user.role in ['sme', 'participant'] and login_data.workshop_id:
-    # Check if user is invited to the selected workshop
-    if user.workshop_id != login_data.workshop_id:
-      # Also check workshop_participants table for multi-workshop support
-      participant = db_service.get_workshop_participant(login_data.workshop_id, user.id)
-      if not participant:
-        raise HTTPException(
-          status_code=403, 
-          detail='You are not invited to this workshop. Please contact the facilitator to be added.'
-        )
+    # For participants/SMEs (no password), validate workshop access
+    # They can only access workshops they've been invited to
+    if user.role in ["sme", "participant"] and login_data.workshop_id:
+        # Check if user is invited to the selected workshop
+        if user.workshop_id != login_data.workshop_id:
+            # Also check workshop_participants table for multi-workshop support
+            participant = db_service.get_workshop_participant(login_data.workshop_id, user.id)
+            if not participant:
+                raise HTTPException(
+                    status_code=403,
+                    detail="You are not invited to this workshop. Please contact the facilitator to be added.",
+                )
 
-  # Activate user if they were pending
-  db_service.activate_user_on_login(user.id)
+    # Activate user if they were pending
+    db_service.activate_user_on_login(user.id)
 
-  # Get updated user data with new status
-  updated_user = db_service.get_user(user.id)
+    # Get updated user data with new status
+    updated_user = db_service.get_user(user.id)
 
-  return AuthResponse(user=updated_user, is_preconfigured_facilitator=False, message='Login successful')
+    return AuthResponse(user=updated_user, is_preconfigured_facilitator=False, message="Login successful")
 
 
-@router.post('/')
+@router.post("/")
 async def create_user(user_data: UserCreate, db_service=Depends(get_database_service)):
-  """Create a new user (no authentication required)."""
-  # Check if user already exists
-  existing_user = db_service.get_user_by_email(user_data.email)
-  if existing_user:
-    raise HTTPException(status_code=400, detail='User with this email already exists')
+    """Create a new user (no authentication required)."""
+    # Check if user already exists
+    existing_user = db_service.get_user_by_email(user_data.email)
+    if existing_user:
+        raise HTTPException(status_code=400, detail="User with this email already exists")
 
-  # Create user with password
-  user = db_service.create_user_with_password(user_data)
+    # Create user with password
+    user = db_service.create_user_with_password(user_data)
 
-  # Add user as workshop participant
-  participant = WorkshopParticipant(user_id=user.id, workshop_id=user_data.workshop_id, role=user_data.role)
-  db_service.add_workshop_participant(participant)
-
-  return user
-
-
-@router.post('/admin/facilitators/')
-async def create_facilitator_config(config_data: FacilitatorConfigCreate, db_service=Depends(get_database_service)):
-  """Create a pre-configured facilitator (admin only)."""
-  # In a real system, you'd check admin permissions here
-  # For now, we'll allow this endpoint to be called
-
-  # Check if facilitator already exists
-  existing_config = db_service.get_facilitator_config(config_data.email)
-  if existing_config:
-    raise HTTPException(status_code=400, detail='Facilitator with this email already exists')
-
-  # Create facilitator configuration
-  config = db_service.create_facilitator_config(config_data)
-
-  return {'config': config, 'message': 'Facilitator configuration created successfully'}
-
-
-@router.get('/admin/facilitators/')
-async def list_facilitator_configs(db_service=Depends(get_database_service)):
-  """List all pre-configured facilitators (admin only)."""
-  configs = db_service.list_facilitator_configs()
-  return configs
-
-
-@router.post('/invitations/')
-async def create_invitation(invitation_data: UserInvite, db_service=Depends(get_database_service)):
-  """Create a new user invitation (facilitators only)."""
-  # Verify the inviter is a facilitator
-  inviter = db_service.get_user(invitation_data.invited_by)
-  if not inviter or inviter.role != UserRole.FACILITATOR:
-    raise HTTPException(status_code=403, detail='Only facilitators can create invitations')
-
-  # Check if user already exists
-  existing_user = db_service.get_user_by_email(invitation_data.email)
-  if existing_user:
-    raise HTTPException(status_code=400, detail='User with this email already exists')
-
-  # Create invitation
-  invitation = db_service.create_invitation(invitation_data)
-
-  return {
-    'invitation': invitation,
-    'invitation_url': f'/invite/{invitation.invitation_token}',
-    'message': 'Invitation created successfully',
-  }
-
-
-@router.get('/invitations/')
-async def list_invitations(
-  workshop_id: Optional[str] = None,
-  status: Optional[str] = None,
-  db_service=Depends(get_database_service),
-):
-  """List invitations (facilitators only)."""
-  invitations = db_service.list_invitations(workshop_id=workshop_id, status=status)
-  return invitations
-
-
-@router.post('/workshops/{workshop_id}/users/')
-async def add_user_to_workshop(workshop_id: str, user_data: UserCreate, db_service=Depends(get_database_service)):
-  """Add a user to a workshop."""
-  # Check if workshop exists
-  workshop = db_service.get_workshop(workshop_id)
-  if not workshop:
-    raise HTTPException(status_code=404, detail='Workshop not found')
-
-  # Check if user already exists globally
-  existing_user = db_service.get_user_by_email(user_data.email)
-
-  if existing_user:
-    # User exists globally - check if they're already in this workshop
-    existing_users = db_service.list_users(workshop_id=workshop_id)
-    for user in existing_users:
-      # Case-insensitive email comparison
-      if user.email.lower() == user_data.email.lower():
-        raise HTTPException(status_code=400, detail='User already exists in this workshop')
-
-    # User exists globally but not in this workshop - add them to the workshop
-    participant = WorkshopParticipant(user_id=existing_user.id, workshop_id=workshop_id, role=user_data.role)
+    # Add user as workshop participant
+    participant = WorkshopParticipant(user_id=user.id, workshop_id=user_data.workshop_id, role=user_data.role)
     db_service.add_workshop_participant(participant)
 
+    return user
+
+
+@router.post("/admin/facilitators/")
+async def create_facilitator_config(config_data: FacilitatorConfigCreate, db_service=Depends(get_database_service)):
+    """Create a pre-configured facilitator (admin only)."""
+    # In a real system, you'd check admin permissions here
+    # For now, we'll allow this endpoint to be called
+
+    # Check if facilitator already exists
+    existing_config = db_service.get_facilitator_config(config_data.email)
+    if existing_config:
+        raise HTTPException(status_code=400, detail="Facilitator with this email already exists")
+
+    # Create facilitator configuration
+    config = db_service.create_facilitator_config(config_data)
+
+    return {"config": config, "message": "Facilitator configuration created successfully"}
+
+
+@router.get("/admin/facilitators/")
+async def list_facilitator_configs(db_service=Depends(get_database_service)):
+    """List all pre-configured facilitators (admin only)."""
+    configs = db_service.list_facilitator_configs()
+    return configs
+
+
+@router.post("/invitations/")
+async def create_invitation(invitation_data: UserInvite, db_service=Depends(get_database_service)):
+    """Create a new user invitation (facilitators only)."""
+    # Verify the inviter is a facilitator
+    inviter = db_service.get_user(invitation_data.invited_by)
+    if not inviter or inviter.role != UserRole.FACILITATOR:
+        raise HTTPException(status_code=403, detail="Only facilitators can create invitations")
+
+    # Check if user already exists
+    existing_user = db_service.get_user_by_email(invitation_data.email)
+    if existing_user:
+        raise HTTPException(status_code=400, detail="User with this email already exists")
+
+    # Create invitation
+    invitation = db_service.create_invitation(invitation_data)
+
     return {
-      'user': existing_user,
-      'message': f'User {existing_user.email} added to workshop successfully',
+        "invitation": invitation,
+        "invitation_url": f"/invite/{invitation.invitation_token}",
+        "message": "Invitation created successfully",
     }
-  else:
+
+
+@router.get("/invitations/")
+async def list_invitations(
+    workshop_id: str | None = None,
+    status: str | None = None,
+    db_service=Depends(get_database_service),
+):
+    """List invitations (facilitators only)."""
+    invitations = db_service.list_invitations(workshop_id=workshop_id, status=status)
+    return invitations
+
+
+@router.post("/workshops/{workshop_id}/users/")
+async def add_user_to_workshop(workshop_id: str, user_data: UserCreate, db_service=Depends(get_database_service)):
+    """Add a user to a workshop."""
+    # Check if workshop exists
+    workshop = db_service.get_workshop(workshop_id)
+    if not workshop:
+        raise HTTPException(status_code=404, detail="Workshop not found")
+
+    # Check if user already exists globally
+    existing_user = db_service.get_user_by_email(user_data.email)
+
+    if existing_user:
+        # User exists globally - check if they're already in this workshop
+        existing_users = db_service.list_users(workshop_id=workshop_id)
+        for user in existing_users:
+            # Case-insensitive email comparison
+            if user.email.lower() == user_data.email.lower():
+                raise HTTPException(status_code=400, detail="User already exists in this workshop")
+
+        # User exists globally but not in this workshop - add them to the workshop
+        participant = WorkshopParticipant(user_id=existing_user.id, workshop_id=workshop_id, role=user_data.role)
+        db_service.add_workshop_participant(participant)
+
+        return {
+            "user": existing_user,
+            "message": f"User {existing_user.email} added to workshop successfully",
+        }
     # User doesn't exist globally - create them
     user_data.workshop_id = workshop_id
     user = db_service.create_user_with_password(user_data)
@@ -182,217 +180,213 @@ async def add_user_to_workshop(workshop_id: str, user_data: UserCreate, db_servi
     db_service.add_workshop_participant(participant)
 
     return {
-      'user': user,
-      'message': f'User {user.email} created and added to workshop successfully',
+        "user": user,
+        "message": f"User {user.email} created and added to workshop successfully",
     }
 
 
-@router.get('/workshops/{workshop_id}/users/')
+@router.get("/workshops/{workshop_id}/users/")
 async def list_workshop_users(workshop_id: str, db_service=Depends(get_database_service)):
-  """List all users in a workshop."""
-  # Check if workshop exists
-  workshop = db_service.get_workshop(workshop_id)
-  if not workshop:
-    raise HTTPException(status_code=404, detail='Workshop not found')
+    """List all users in a workshop."""
+    # Check if workshop exists
+    workshop = db_service.get_workshop(workshop_id)
+    if not workshop:
+        raise HTTPException(status_code=404, detail="Workshop not found")
 
-  # Get all users in the workshop
-  users = db_service.list_users(workshop_id=workshop_id)
+    # Get all users in the workshop
+    users = db_service.list_users(workshop_id=workshop_id)
 
-  return {'workshop_id': workshop_id, 'users': users, 'total_users': len(users)}
+    return {"workshop_id": workshop_id, "users": users, "total_users": len(users)}
 
 
-@router.get('/{user_id}', response_model=User)
+@router.get("/{user_id}", response_model=User)
 async def get_user(user_id: str, db_service=Depends(get_database_service)):
-  """Get user by ID."""
-  user = db_service.get_user(user_id)
-  if not user:
-    raise HTTPException(status_code=404, detail='User not found')
-  return user
+    """Get user by ID."""
+    user = db_service.get_user(user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return user
 
 
-@router.get('/', response_model=List[User])
+@router.get("/", response_model=list[User])
 async def list_users(
-  workshop_id: Optional[str] = None,
-  role: Optional[UserRole] = None,
-  db_service=Depends(get_database_service),
+    workshop_id: str | None = None,
+    role: UserRole | None = None,
+    db_service=Depends(get_database_service),
 ):
-  """List users, optionally filtered by workshop or role."""
-  return db_service.list_users(workshop_id=workshop_id, role=role)
+    """List users, optionally filtered by workshop or role."""
+    return db_service.list_users(workshop_id=workshop_id, role=role)
 
 
-@router.get('/{user_id}/permissions', response_model=UserPermissions)
+@router.get("/{user_id}/permissions", response_model=UserPermissions)
 async def get_user_permissions(user_id: str, db_service=Depends(get_database_service)):
-  """Get user permissions based on their role."""
-  user = db_service.get_user(user_id)
-  if not user:
-    raise HTTPException(status_code=404, detail='User not found')
+    """Get user permissions based on their role."""
+    user = db_service.get_user(user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
 
-  return UserPermissions.for_role(user.role)
+    return UserPermissions.for_role(user.role)
 
 
-@router.put('/{user_id}/status')
+@router.put("/{user_id}/status")
 async def update_user_status(user_id: str, status: UserStatus, db_service=Depends(get_database_service)):
-  """Update user status."""
-  user = db_service.get_user(user_id)
-  if not user:
-    raise HTTPException(status_code=404, detail='User not found')
+    """Update user status."""
+    user = db_service.get_user(user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
 
-  user.status = status
-  db_service.update_user(user)
-  return {'message': 'User status updated successfully'}
+    user.status = status
+    db_service.update_user(user)
+    return {"message": "User status updated successfully"}
 
 
-@router.put('/{user_id}/last-active')
+@router.put("/{user_id}/last-active")
 async def update_last_active(user_id: str, db_service=Depends(get_database_service)):
-  """Update user's last active timestamp."""
-  user = db_service.get_user(user_id)
-  if not user:
-    raise HTTPException(status_code=404, detail='User not found')
+    """Update user's last active timestamp."""
+    user = db_service.get_user(user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
 
-  user.last_active = datetime.now()
-  db_service.update_user(user)
-  return {'message': 'Last active timestamp updated'}
+    user.last_active = datetime.now()
+    db_service.update_user(user)
+    return {"message": "Last active timestamp updated"}
 
 
-@router.get('/workshops/{workshop_id}/participants', response_model=List[WorkshopParticipant])
+@router.get("/workshops/{workshop_id}/participants", response_model=list[WorkshopParticipant])
 async def get_workshop_participants(workshop_id: str, db_service=Depends(get_database_service)):
-  """Get all participants in a workshop."""
-  return db_service.get_workshop_participants(workshop_id)
+    """Get all participants in a workshop."""
+    return db_service.get_workshop_participants(workshop_id)
 
 
-@router.post('/workshops/{workshop_id}/participants/{user_id}/assign-traces')
-async def assign_traces_to_user(workshop_id: str, user_id: str, trace_ids: List[str], db_service=Depends(get_database_service)):
-  """Assign specific traces to a user for annotation."""
-  # Verify user exists and is part of workshop
-  user = db_service.get_user(user_id)
-  if not user or user.workshop_id != workshop_id:
-    raise HTTPException(status_code=404, detail='User not found in workshop')
-
-  # Get or create participant record
-  participant = db_service.get_workshop_participant(workshop_id, user_id)
-  if not participant:
-    participant = WorkshopParticipant(user_id=user_id, workshop_id=workshop_id, role=user.role)
-
-  # Assign traces
-  participant.assigned_traces = trace_ids
-  db_service.update_workshop_participant(participant)
-
-  return {'message': f'Assigned {len(trace_ids)} traces to user', 'trace_ids': trace_ids}
-
-
-@router.get('/workshops/{workshop_id}/participants/{user_id}/assigned-traces')
-async def get_assigned_traces(workshop_id: str, user_id: str, db_service=Depends(get_database_service)):
-  """Get traces assigned to a specific user."""
-  participant = db_service.get_workshop_participant(workshop_id, user_id)
-  if not participant:
-    raise HTTPException(status_code=404, detail='User not found in workshop')
-
-  return {'assigned_traces': participant.assigned_traces}
-
-
-@router.delete('/{user_id}')
-async def delete_user(user_id: str, db_service=Depends(get_database_service)):
-  """Delete a user (no authentication required)."""
-  # Get the user to delete
-  user_to_delete = db_service.get_user(user_id)
-  if not user_to_delete:
-    raise HTTPException(status_code=404, detail='User not found')
-
-  # Prevent deleting facilitators
-  if user_to_delete.role == UserRole.FACILITATOR:
-    raise HTTPException(status_code=403, detail='Cannot delete facilitators')
-
-  # Delete the user
-  db_service.delete_user(user_id)
-
-  return {'message': 'User deleted successfully'}
-
-
-@router.delete('/workshops/{workshop_id}/users/{user_id}')
-async def remove_user_from_workshop(workshop_id: str, user_id: str, db_service=Depends(get_database_service)):
-  """Remove a user from a workshop (but keep them in the system)."""
-  # Check if workshop exists
-  workshop = db_service.get_workshop(workshop_id)
-  if not workshop:
-    raise HTTPException(status_code=404, detail='Workshop not found')
-
-  # Check if user exists
-  user = db_service.get_user(user_id)
-  if not user:
-    raise HTTPException(status_code=404, detail='User not found')
-
-  # Remove user from workshop
-  db_service.remove_user_from_workshop(workshop_id, user_id)
-
-  return {'message': f'User {user.email} removed from workshop successfully'}
-
-
-@router.put('/workshops/{workshop_id}/users/{user_id}/role')
-async def update_user_role_in_workshop(
-  workshop_id: str, 
-  user_id: str, 
-  role_data: dict,
-  db_service=Depends(get_database_service)
+@router.post("/workshops/{workshop_id}/participants/{user_id}/assign-traces")
+async def assign_traces_to_user(
+    workshop_id: str, user_id: str, trace_ids: list[str], db_service=Depends(get_database_service)
 ):
-  """Update a user's role in a workshop (SME <-> Participant)."""
-  # Check if workshop exists
-  workshop = db_service.get_workshop(workshop_id)
-  if not workshop:
-    raise HTTPException(status_code=404, detail='Workshop not found')
+    """Assign specific traces to a user for annotation."""
+    # Verify user exists and is part of workshop
+    user = db_service.get_user(user_id)
+    if not user or user.workshop_id != workshop_id:
+        raise HTTPException(status_code=404, detail="User not found in workshop")
 
-  # Check if user exists
-  user = db_service.get_user(user_id)
-  if not user:
-    raise HTTPException(status_code=404, detail='User not found')
-
-  # Cannot change facilitator role
-  if user.role == UserRole.FACILITATOR:
-    raise HTTPException(status_code=403, detail='Cannot change facilitator role')
-
-  new_role = role_data.get('role')
-  if new_role not in ['sme', 'participant']:
-    raise HTTPException(status_code=400, detail='Role must be "sme" or "participant"')
-
-  # Update the user's role
-  updated_user = db_service.update_user_role_in_workshop(workshop_id, user_id, new_role)
-  
-  return {
-    'user': updated_user,
-    'message': f'User role updated to {new_role.upper()} successfully'
-  }
-
-
-@router.post('/workshops/{workshop_id}/auto-assign-annotations')
-async def auto_assign_annotations(workshop_id: str, db_service=Depends(get_database_service)):
-  """Automatically balance annotation assignments across SMEs and participants."""
-  # Get all traces in workshop
-  traces = db_service.get_traces_by_workshop(workshop_id)
-
-  # Get SMEs and participants (exclude facilitator from annotations)
-  participants = db_service.get_workshop_participants(workshop_id)
-  annotators = [p for p in participants if p.role in [UserRole.SME, UserRole.PARTICIPANT]]
-
-  if not annotators:
-    raise HTTPException(status_code=400, detail='No annotators available')
-
-  # Simple round-robin assignment
-  assignments = {}
-  for i, trace in enumerate(traces):
-    annotator = annotators[i % len(annotators)]
-    if annotator.user_id not in assignments:
-      assignments[annotator.user_id] = []
-    assignments[annotator.user_id].append(trace.id)
-
-  # Update assignments
-  for user_id, trace_ids in assignments.items():
+    # Get or create participant record
     participant = db_service.get_workshop_participant(workshop_id, user_id)
-    if participant:
-      participant.assigned_traces = trace_ids
-      db_service.update_workshop_participant(participant)
+    if not participant:
+        participant = WorkshopParticipant(user_id=user_id, workshop_id=workshop_id, role=user.role)
 
-  return {
-    'message': 'Annotations auto-assigned successfully',
-    'assignments': assignments,
-    'total_traces': len(traces),
-    'total_annotators': len(annotators),
-  }
+    # Assign traces
+    participant.assigned_traces = trace_ids
+    db_service.update_workshop_participant(participant)
+
+    return {"message": f"Assigned {len(trace_ids)} traces to user", "trace_ids": trace_ids}
+
+
+@router.get("/workshops/{workshop_id}/participants/{user_id}/assigned-traces")
+async def get_assigned_traces(workshop_id: str, user_id: str, db_service=Depends(get_database_service)):
+    """Get traces assigned to a specific user."""
+    participant = db_service.get_workshop_participant(workshop_id, user_id)
+    if not participant:
+        raise HTTPException(status_code=404, detail="User not found in workshop")
+
+    return {"assigned_traces": participant.assigned_traces}
+
+
+@router.delete("/{user_id}")
+async def delete_user(user_id: str, db_service=Depends(get_database_service)):
+    """Delete a user (no authentication required)."""
+    # Get the user to delete
+    user_to_delete = db_service.get_user(user_id)
+    if not user_to_delete:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    # Prevent deleting facilitators
+    if user_to_delete.role == UserRole.FACILITATOR:
+        raise HTTPException(status_code=403, detail="Cannot delete facilitators")
+
+    # Delete the user
+    db_service.delete_user(user_id)
+
+    return {"message": "User deleted successfully"}
+
+
+@router.delete("/workshops/{workshop_id}/users/{user_id}")
+async def remove_user_from_workshop(workshop_id: str, user_id: str, db_service=Depends(get_database_service)):
+    """Remove a user from a workshop (but keep them in the system)."""
+    # Check if workshop exists
+    workshop = db_service.get_workshop(workshop_id)
+    if not workshop:
+        raise HTTPException(status_code=404, detail="Workshop not found")
+
+    # Check if user exists
+    user = db_service.get_user(user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    # Remove user from workshop
+    db_service.remove_user_from_workshop(workshop_id, user_id)
+
+    return {"message": f"User {user.email} removed from workshop successfully"}
+
+
+@router.put("/workshops/{workshop_id}/users/{user_id}/role")
+async def update_user_role_in_workshop(
+    workshop_id: str, user_id: str, role_data: dict, db_service=Depends(get_database_service)
+):
+    """Update a user's role in a workshop (SME <-> Participant)."""
+    # Check if workshop exists
+    workshop = db_service.get_workshop(workshop_id)
+    if not workshop:
+        raise HTTPException(status_code=404, detail="Workshop not found")
+
+    # Check if user exists
+    user = db_service.get_user(user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    # Cannot change facilitator role
+    if user.role == UserRole.FACILITATOR:
+        raise HTTPException(status_code=403, detail="Cannot change facilitator role")
+
+    new_role = role_data.get("role")
+    if new_role not in ["sme", "participant"]:
+        raise HTTPException(status_code=400, detail='Role must be "sme" or "participant"')
+
+    # Update the user's role
+    updated_user = db_service.update_user_role_in_workshop(workshop_id, user_id, new_role)
+
+    return {"user": updated_user, "message": f"User role updated to {new_role.upper()} successfully"}
+
+
+@router.post("/workshops/{workshop_id}/auto-assign-annotations")
+async def auto_assign_annotations(workshop_id: str, db_service=Depends(get_database_service)):
+    """Automatically balance annotation assignments across SMEs and participants."""
+    # Get all traces in workshop
+    traces = db_service.get_traces_by_workshop(workshop_id)
+
+    # Get SMEs and participants (exclude facilitator from annotations)
+    participants = db_service.get_workshop_participants(workshop_id)
+    annotators = [p for p in participants if p.role in [UserRole.SME, UserRole.PARTICIPANT]]
+
+    if not annotators:
+        raise HTTPException(status_code=400, detail="No annotators available")
+
+    # Simple round-robin assignment
+    assignments = {}
+    for i, trace in enumerate(traces):
+        annotator = annotators[i % len(annotators)]
+        if annotator.user_id not in assignments:
+            assignments[annotator.user_id] = []
+        assignments[annotator.user_id].append(trace.id)
+
+    # Update assignments
+    for user_id, trace_ids in assignments.items():
+        participant = db_service.get_workshop_participant(workshop_id, user_id)
+        if participant:
+            participant.assigned_traces = trace_ids
+            db_service.update_workshop_participant(participant)
+
+    return {
+        "message": "Annotations auto-assigned successfully",
+        "assignments": assignments,
+        "total_traces": len(traces),
+        "total_annotators": len(annotators),
+    }

--- a/server/services/alignment_service.py
+++ b/server/services/alignment_service.py
@@ -15,11 +15,11 @@ import os
 import threading
 import time
 from collections import Counter
-from typing import Any, Dict, Generator, List, Optional
-
-from sklearn.metrics import accuracy_score, cohen_kappa_score, confusion_matrix
+from collections.abc import Generator
+from typing import Any
 
 import pandas as pd
+from sklearn.metrics import accuracy_score, cohen_kappa_score, confusion_matrix
 
 from server.services.database_service import DatabaseService
 
@@ -37,16 +37,17 @@ BINARY_FAIL_VALUE = 0.0
 
 def get_judge_type_from_rubric(db_service: DatabaseService, workshop_id: str) -> str:
     """Get the judge type from the workshop's rubric.
-    
+
     First checks individual question judge types (more accurate), then falls back to rubric-level judge_type.
     Returns 'likert', 'binary', or 'freeform'. Defaults to 'likert' if not set.
     """
     try:
         from server.models import JudgeType
+
         rubric = db_service.get_rubric(workshop_id)
         if not rubric:
-            return 'likert'  # Default
-        
+            return "likert"  # Default
+
         # First, try to parse rubric questions to get per-question judge types
         # This is more accurate than the rubric-level judge_type
         if rubric.question:
@@ -54,27 +55,33 @@ def get_judge_type_from_rubric(db_service: DatabaseService, workshop_id: str) ->
                 questions = db_service._parse_rubric_questions(rubric.question)
                 if questions:
                     # Check if any question is binary
-                    binary_questions = [q for q in questions if q.get('judge_type') == 'binary']
-                    likert_questions = [q for q in questions if q.get('judge_type') == 'likert']
-                    
+                    binary_questions = [q for q in questions if q.get("judge_type") == "binary"]
+                    likert_questions = [q for q in questions if q.get("judge_type") == "likert"]
+
                     if binary_questions and not likert_questions:
                         # All questions are binary
-                        logger.info(f"Detected binary judge type from rubric questions ({len(binary_questions)} binary questions)")
-                        return 'binary'
-                    elif likert_questions and not binary_questions:
+                        logger.info(
+                            f"Detected binary judge type from rubric questions ({len(binary_questions)} binary questions)"
+                        )
+                        return "binary"
+                    if likert_questions and not binary_questions:
                         # All questions are likert
-                        logger.info(f"Detected likert judge type from rubric questions ({len(likert_questions)} likert questions)")
-                        return 'likert'
-                    elif binary_questions:
+                        logger.info(
+                            f"Detected likert judge type from rubric questions ({len(likert_questions)} likert questions)"
+                        )
+                        return "likert"
+                    if binary_questions:
                         # Mixed - but if we have binary questions, prefer binary
                         # (most common case: rubric has default likert but questions are binary)
-                        logger.info(f"Detected binary judge type from rubric questions (mixed types, {len(binary_questions)} binary questions)")
-                        return 'binary'
+                        logger.info(
+                            f"Detected binary judge type from rubric questions (mixed types, {len(binary_questions)} binary questions)"
+                        )
+                        return "binary"
             except Exception as parse_error:
                 logger.warning(f"Could not parse rubric questions for judge type detection: {parse_error}")
-        
+
         # Fallback to rubric-level judge_type if no questions parsed or all questions are likert
-        if hasattr(rubric, 'judge_type') and rubric.judge_type:
+        if hasattr(rubric, "judge_type") and rubric.judge_type:
             # Handle JudgeType enum - extract string value
             judge_type = rubric.judge_type
             if isinstance(judge_type, JudgeType):
@@ -82,7 +89,7 @@ def get_judge_type_from_rubric(db_service: DatabaseService, workshop_id: str) ->
             return str(judge_type)
     except Exception as e:
         logger.warning("Could not get rubric judge_type for workshop %s: %s", workshop_id, e)
-    return 'likert'  # Default
+    return "likert"  # Default
 
 
 class AlignmentService:
@@ -98,13 +105,13 @@ class AlignmentService:
             return judge_prompt
         normalized = judge_prompt
         # Convert legacy single-brace placeholders to double-brace templates required by mlflow
-        normalized = normalized.replace('{{ inputs }}', '{inputs}')
-        normalized = normalized.replace('{{ outputs }}', '{outputs}')
-        normalized = normalized.replace('{input}', '{inputs}')
-        normalized = normalized.replace('{output}', '{outputs}')
+        normalized = normalized.replace("{{ inputs }}", "{inputs}")
+        normalized = normalized.replace("{{ outputs }}", "{outputs}")
+        normalized = normalized.replace("{input}", "{inputs}")
+        normalized = normalized.replace("{output}", "{outputs}")
         # Now ensure final form uses double braces
-        normalized = normalized.replace('{inputs}', '{{ inputs }}')
-        normalized = normalized.replace('{outputs}', '{{ outputs }}')
+        normalized = normalized.replace("{inputs}", "{{ inputs }}")
+        normalized = normalized.replace("{outputs}", "{{ outputs }}")
         return normalized
 
     def _search_tagged_traces(
@@ -115,7 +122,7 @@ class AlignmentService:
         tag_type: str = "eval",
     ):
         """Fetch traces labeled for this workshop via mlflow.search_traces.
-        
+
         Args:
             mlflow_config: MLflow configuration with experiment_id
             workshop_id: Workshop ID to filter by
@@ -131,7 +138,7 @@ class AlignmentService:
             f"tags.workshop_id = '{workshop_id}'",
         ]
         filter_string = " AND ".join(filter_parts)
-        
+
         logger.info("Searching for traces with tag_type='%s' in workshop '%s'", tag_type, workshop_id)
 
         return mlflow.search_traces(
@@ -140,13 +147,9 @@ class AlignmentService:
             return_type=return_type,
         )
 
-    def prepare_alignment_data(
-        self, 
-        workshop_id: str, 
-        judge_name: str
-    ) -> Dict[str, Any]:
+    def prepare_alignment_data(self, workshop_id: str, judge_name: str) -> dict[str, Any]:
         """Prepare traces with human feedback for alignment.
-        
+
         Returns a dict with:
         - traces: List of traces formatted for MLflow
         - human_feedback: Dict mapping trace_id to feedback data
@@ -154,42 +157,44 @@ class AlignmentService:
         """
         # Get traces marked for alignment
         traces = self.db_service.get_traces_for_alignment(workshop_id)
-        
+
         # Get all annotations
         annotations = self.db_service.get_annotations(workshop_id)
-        
+
         # Group annotations by trace and calculate mode rating + aggregate feedback
         trace_data = []
         missing_mlflow_ids = 0
         for trace in traces:
             trace_annotations = [a for a in annotations if a.trace_id == trace.id]
-            
+
             if not trace_annotations:
                 continue
             if not trace.mlflow_trace_id:
                 missing_mlflow_ids += 1
                 continue
-            
+
             # Calculate mode (most common rating) as ground truth
             ratings = [a.rating for a in trace_annotations]
             rating_counts = Counter(ratings)
             mode_rating = rating_counts.most_common(1)[0][0]
-            
+
             # Aggregate feedback from all annotations
             feedback_parts = []
             for ann in trace_annotations:
                 if ann.comment and ann.comment.strip():
                     feedback_parts.append(ann.comment.strip())
-            
+
             aggregated_feedback = "\n".join(feedback_parts) if feedback_parts else None
-            
-            trace_data.append({
-                'trace_id': trace.mlflow_trace_id,
-                'workshop_id': trace.id,
-                'human_rating': mode_rating,
-                'sme_feedback': aggregated_feedback,
-            })
-        
+
+            trace_data.append(
+                {
+                    "trace_id": trace.mlflow_trace_id,
+                    "workshop_id": trace.id,
+                    "human_rating": mode_rating,
+                    "sme_feedback": aggregated_feedback,
+                }
+            )
+
         if missing_mlflow_ids:
             logger.warning(
                 "prepare_alignment_data: skipped %s traces without mlflow_trace_id",
@@ -197,15 +202,15 @@ class AlignmentService:
             )
 
         return {
-            'traces': trace_data,
-            'judge_name': judge_name,
-            'trace_count': len(trace_data),
+            "traces": trace_data,
+            "judge_name": judge_name,
+            "trace_count": len(trace_data),
         }
 
     @staticmethod
-    def _calculate_eval_metrics(evaluations: List[Dict[str, Any]], judge_type: str = 'likert') -> Dict[str, Any]:
+    def _calculate_eval_metrics(evaluations: list[dict[str, Any]], judge_type: str = "likert") -> dict[str, Any]:
         """Compute Cohen's κ, accuracy, and related stats for evaluation results.
-        
+
         Args:
             evaluations: List of evaluation dictionaries with human_rating and predicted_rating
             judge_type: 'likert' for 1-5 scale, 'binary' for pass/fail
@@ -213,12 +218,12 @@ class AlignmentService:
         # Count total evaluations and valid pairs
         total_evaluations = len(evaluations)
         valid_pairs = [
-            (e.get('human_rating'), e.get('predicted_rating'))
+            (e.get("human_rating"), e.get("predicted_rating"))
             for e in evaluations
-            if isinstance(e.get('human_rating'), (int, float)) and isinstance(e.get('predicted_rating'), (int, float))
+            if isinstance(e.get("human_rating"), (int, float)) and isinstance(e.get("predicted_rating"), (int, float))
         ]
         total = len(valid_pairs)
-        
+
         # Log if there's a discrepancy
         if total_evaluations > total:
             missing_count = total_evaluations - total
@@ -228,35 +233,35 @@ class AlignmentService:
                 total_evaluations,
                 total,
             )
-        
+
         # Handle binary judges differently
-        if judge_type == 'binary':
+        if judge_type == "binary":
             default_matrix = [[0, 0], [0, 0]]  # 2x2 for binary
-            default_agreement = {'pass': 0.0, 'fail': 0.0}
-            
+            default_agreement = {"pass": 0.0, "fail": 0.0}
+
             if total == 0:
                 return {
-                    'correlation': 0.0,
-                    'accuracy': 0.0,
-                    'mean_absolute_error': 0.0,
-                    'agreement_by_rating': default_agreement,
-                    'confusion_matrix': default_matrix,
-                    'total_evaluations': 0,
-                    'total_evaluations_all': total_evaluations,
-                    'judge_type': 'binary',
+                    "correlation": 0.0,
+                    "accuracy": 0.0,
+                    "mean_absolute_error": 0.0,
+                    "agreement_by_rating": default_agreement,
+                    "confusion_matrix": default_matrix,
+                    "total_evaluations": 0,
+                    "total_evaluations_all": total_evaluations,
+                    "judge_type": "binary",
                 }
-            
+
             # Convert to binary: >= 0.5 is pass (1), < 0.5 is fail (0)
             humans = [1 if h >= 0.5 else 0 for h, _ in valid_pairs]
             preds = [1 if p >= 0.5 else 0 for _, p in valid_pairs]
-            
+
             matches = sum(1 for h, p in zip(humans, preds, strict=False) if h == p)
             simple_agreement = matches / total if total else 0.0
-            
+
             # Check if there's any variation in the data
             unique_humans = set(humans)
             unique_preds = set(preds)
-            
+
             # If all values are the same and they match, that's perfect agreement (kappa = 1.0)
             if len(unique_humans) == 1 and len(unique_preds) == 1 and humans == preds:
                 kappa = 1.0  # Perfect agreement when all values are the same and match
@@ -270,63 +275,63 @@ class AlignmentService:
                     kappa = simple_agreement
                 if math.isnan(kappa):
                     kappa = simple_agreement
-            
+
             try:
                 accuracy = accuracy_score(humans, preds)
             except Exception:
                 accuracy = simple_agreement
-            
+
             # For binary, agreement by pass/fail
             agreement_by_rating = {}
-            for label, value in [('pass', 1), ('fail', 0)]:
+            for label, value in [("pass", 1), ("fail", 0)]:
                 label_preds = [p for h, p in zip(humans, preds, strict=False) if h == value]
                 if label_preds:
                     label_matches = sum(1 for p in label_preds if p == value)
                     agreement_by_rating[label] = label_matches / len(label_preds)
                 else:
                     agreement_by_rating[label] = 0.0
-            
+
             try:
                 cm = confusion_matrix(humans, preds, labels=[0, 1]).tolist()
             except Exception:
                 cm = default_matrix
-            
+
             logger.info(
                 "Computed BINARY evaluation metrics: kappa=%.3f accuracy=%.3f (n=%d)",
                 kappa,
                 accuracy,
                 total,
             )
-            
+
             return {
-                'correlation': float(kappa),
-                'accuracy': float(accuracy),
-                'mean_absolute_error': 0.0,  # Not meaningful for binary
-                'agreement_by_rating': agreement_by_rating,
-                'confusion_matrix': cm,
-                'total_evaluations': total,  # Valid evaluations (both human and predicted ratings available)
-                'total_evaluations_all': total_evaluations,  # All evaluations including those with missing ratings
-                'judge_type': 'binary',
+                "correlation": float(kappa),
+                "accuracy": float(accuracy),
+                "mean_absolute_error": 0.0,  # Not meaningful for binary
+                "agreement_by_rating": agreement_by_rating,
+                "confusion_matrix": cm,
+                "total_evaluations": total,  # Valid evaluations (both human and predicted ratings available)
+                "total_evaluations_all": total_evaluations,  # All evaluations including those with missing ratings
+                "judge_type": "binary",
             }
-        
+
         # Likert scale (default)
         default_matrix = [[0] * 5 for _ in range(5)]
         default_agreement = {str(r): 0.0 for r in range(1, 6)}
 
         if total == 0:
             return {
-                'correlation': 0.0,
-                'accuracy': 0.0,
-                'mean_absolute_error': 0.0,
-                'agreement_by_rating': default_agreement,
-                'confusion_matrix': default_matrix,
-                'total_evaluations': 0,
-                'total_evaluations_all': total_evaluations,
-                'judge_type': 'likert',
+                "correlation": 0.0,
+                "accuracy": 0.0,
+                "mean_absolute_error": 0.0,
+                "agreement_by_rating": default_agreement,
+                "confusion_matrix": default_matrix,
+                "total_evaluations": 0,
+                "total_evaluations_all": total_evaluations,
+                "judge_type": "likert",
             }
 
         humans = [int(h) for h, _ in valid_pairs]
-        preds = [int(round(p)) for _, p in valid_pairs]
+        preds = [round(p) for _, p in valid_pairs]
 
         matches = sum(1 for h, p in zip(humans, preds, strict=False) if h == p)
         simple_agreement = matches / total if total else 0.0
@@ -345,7 +350,7 @@ class AlignmentService:
 
         mean_abs_error = sum(abs(h - p) for h, p in zip(humans, preds, strict=False)) / total if total else 0.0
 
-        agreement_by_rating: Dict[str, float] = {}
+        agreement_by_rating: dict[str, float] = {}
         for rating in range(1, 6):
             rating_preds = [p for h, p in zip(humans, preds, strict=False) if h == rating]
             if rating_preds:
@@ -367,14 +372,14 @@ class AlignmentService:
         )
 
         return {
-            'correlation': float(kappa),
-            'accuracy': float(accuracy),
-            'mean_absolute_error': float(mean_abs_error),
-            'agreement_by_rating': agreement_by_rating,
-            'confusion_matrix': cm,
-            'total_evaluations': total,  # Valid evaluations (both human and predicted ratings available)
-            'total_evaluations_all': total_evaluations,  # All evaluations including those with missing ratings
-            'judge_type': 'likert',
+            "correlation": float(kappa),
+            "accuracy": float(accuracy),
+            "mean_absolute_error": float(mean_abs_error),
+            "agreement_by_rating": agreement_by_rating,
+            "confusion_matrix": cm,
+            "total_evaluations": total,  # Valid evaluations (both human and predicted ratings available)
+            "total_evaluations_all": total_evaluations,  # All evaluations including those with missing ratings
+            "judge_type": "likert",
         }
 
     def run_evaluation_with_answer_sheet(
@@ -386,17 +391,17 @@ class AlignmentService:
         mlflow_config: Any,
         judge_type: str = None,  # Explicit judge type from selected rubric question
         require_human_ratings: bool = True,  # Set to False for auto-evaluation without human ratings
-        trace_ids_override: List[str] = None,  # Optional list of specific trace IDs to evaluate
+        trace_ids_override: list[str] = None,  # Optional list of specific trace IDs to evaluate
         tag_type: str = "eval",  # Tag to search for: 'eval' for auto-evaluation, 'align' for re-evaluation
         use_registered_judge: bool = False,  # If True, loads the registered judge from MLflow (with memory)
-    ) -> Generator[str, None, Dict[str, Any]]:
+    ) -> Generator[str, None, dict[str, Any]]:
         """Run evaluation using mlflow.genai.evaluate() with answer sheet approach.
-        
+
         This generator yields log messages and finally returns the evaluation results.
-        
+
         Critical: The judge_name must match for both human feedback and LLM evaluation
         so that align() can properly correlate them.
-        
+
         Args:
             judge_type: Explicit judge type ('likert', 'binary', 'freeform'). If not provided,
                        falls back to detecting from rubric (legacy behavior).
@@ -413,58 +418,58 @@ class AlignmentService:
         """
         # Stream connection is established by router's immediate "Establishing Connection" message
         logger.info("Evaluation generator started for judge '%s'", judge_name)
-        
+
         try:
             import mlflow
             from mlflow.genai import evaluate
         except ImportError as e:
             yield f"ERROR: Required package not available: {e}"
             yield {"error": str(e), "success": False}
-        
+
         yield f"Starting evaluation for judge: {judge_name}"
         yield f"Mode: {'require human ratings' if require_human_ratings else 'auto-evaluation (no human ratings required)'}"
-        
+
         # Build mapping from MLflow trace IDs to workshop trace IDs for auto-eval mode
-        mlflow_to_workshop_trace_map: Dict[str, str] = {}
+        mlflow_to_workshop_trace_map: dict[str, str] = {}
         if not require_human_ratings:
             # Query database to get mapping
             traces = self.db_service.get_traces(workshop_id)
             for trace in traces:
-                if hasattr(trace, 'mlflow_trace_id') and trace.mlflow_trace_id:
+                if hasattr(trace, "mlflow_trace_id") and trace.mlflow_trace_id:
                     mlflow_to_workshop_trace_map[trace.mlflow_trace_id] = trace.id
             yield f"Built MLflow-to-workshop trace mapping ({len(mlflow_to_workshop_trace_map)} traces)"
-        
+
         # Set up MLflow environment based on available credentials
-        os.environ['DATABRICKS_HOST'] = mlflow_config.databricks_host.rstrip('/')
-        has_oauth = bool(os.environ.get('DATABRICKS_CLIENT_ID') and os.environ.get('DATABRICKS_CLIENT_SECRET'))
+        os.environ["DATABRICKS_HOST"] = mlflow_config.databricks_host.rstrip("/")
+        has_oauth = bool(os.environ.get("DATABRICKS_CLIENT_ID") and os.environ.get("DATABRICKS_CLIENT_SECRET"))
         if has_oauth:
-            os.environ.pop('DATABRICKS_TOKEN', None)
+            os.environ.pop("DATABRICKS_TOKEN", None)
         else:
-            os.environ['DATABRICKS_TOKEN'] = mlflow_config.databricks_token
-            os.environ.pop('DATABRICKS_CLIENT_ID', None)
-            os.environ.pop('DATABRICKS_CLIENT_SECRET', None)
+            os.environ["DATABRICKS_TOKEN"] = mlflow_config.databricks_token
+            os.environ.pop("DATABRICKS_CLIENT_ID", None)
+            os.environ.pop("DATABRICKS_CLIENT_SECRET", None)
         # Set tracking URI
-        mlflow.set_tracking_uri('databricks')
-        
+        mlflow.set_tracking_uri("databricks")
+
         # Prepare the evaluation data
-        human_feedback_map: Dict[str, Dict[str, Any]] = {}
-        
+        human_feedback_map: dict[str, dict[str, Any]] = {}
+
         if require_human_ratings:
             # Original behavior: require human ratings
             alignment_data = self.prepare_alignment_data(workshop_id, judge_name)
-            traces_for_eval = alignment_data['traces']
-            
+            traces_for_eval = alignment_data["traces"]
+
             if not traces_for_eval:
                 yield "ERROR: No traces available for evaluation"
                 yield {"error": "No traces available for evaluation", "success": False}
                 return
-            
+
             for trace in traces_for_eval:
-                trace_id = str(trace['trace_id']).strip()
-                human_rating = trace.get('human_rating')
+                trace_id = str(trace["trace_id"]).strip()
+                human_rating = trace.get("human_rating")
                 if trace_id and human_rating is not None:
                     human_feedback_map[trace_id] = trace
-            
+
             if not human_feedback_map:
                 yield "ERROR: Annotated traces are missing human ratings"
                 yield {"error": "Annotated traces missing ratings", "success": False}
@@ -472,7 +477,7 @@ class AlignmentService:
         else:
             # Auto-evaluation mode: no human ratings required
             yield "Auto-evaluation mode: will evaluate all tagged traces without human ratings"
-        
+
         try:
             # Use specified tag_type: 'eval' for auto-evaluation, 'align' for re-evaluation
             trace_df = self._search_tagged_traces(mlflow_config, workshop_id, return_type="pandas", tag_type=tag_type)
@@ -480,27 +485,27 @@ class AlignmentService:
             yield f"ERROR: Failed to query MLflow traces: {exc}"
             yield {"error": f"Failed to query MLflow traces: {exc}", "success": False}
             return
-        
+
         if trace_df is None or trace_df.empty:
             yield f"ERROR: No MLflow traces found with label '{tag_type}'"
             yield {"error": "No tagged MLflow traces found", "success": False}
             return
-        
-        if 'trace_id' not in trace_df.columns:
+
+        if "trace_id" not in trace_df.columns:
             yield "ERROR: MLflow traces result is missing 'trace_id'"
             yield {"error": "search_traces missing trace_id", "success": False}
             return
-        
+
         trace_df = trace_df.copy()
-        trace_df['trace_id'] = trace_df['trace_id'].astype(str).str.strip()
-        
+        trace_df["trace_id"] = trace_df["trace_id"].astype(str).str.strip()
+
         # Filter traces based on mode
         if require_human_ratings:
             # Only include traces with human ratings
-            filtered_df = trace_df[trace_df['trace_id'].isin(human_feedback_map.keys())]
+            filtered_df = trace_df[trace_df["trace_id"].isin(human_feedback_map.keys())]
         elif trace_ids_override:
             # Use specific trace IDs if provided
-            filtered_df = trace_df[trace_df['trace_id'].isin(trace_ids_override)]
+            filtered_df = trace_df[trace_df["trace_id"].isin(trace_ids_override)]
             yield f"Filtering to {len(trace_ids_override)} specific trace IDs"
         else:
             # Auto-evaluation: use all tagged traces
@@ -513,10 +518,10 @@ class AlignmentService:
                 yield "ERROR: No tagged traces found for evaluation"
                 yield {"error": "No tagged traces found", "success": False}
             return
-        
-        trace_ids_for_eval = filtered_df['trace_id'].tolist()
+
+        trace_ids_for_eval = filtered_df["trace_id"].tolist()
         yield f"Prepared {len(trace_ids_for_eval)} traces for evaluation"
-        
+
         # Only check for missing IDs when human ratings are required
         if require_human_ratings and human_feedback_map:
             missing_ids = sorted(set(human_feedback_map.keys()) - set(trace_ids_for_eval))
@@ -527,10 +532,10 @@ class AlignmentService:
                     f"WARNING: {len(missing_ids)} annotated traces lacked MLflow tags and were skipped "
                     f"(sample: {preview}{suffix})"
                 )
-        
+
         eval_df = filtered_df
         yield f"search_traces returned {len(trace_df)} tagged rows; evaluating {len(eval_df)} traces"
-        
+
         experiment_id = mlflow_config.experiment_id
         if not experiment_id:
             error_msg = "MLflow experiment ID is not configured. Please set it in the Intake phase."
@@ -545,43 +550,48 @@ class AlignmentService:
             yield f"ERROR: {error_msg}"
             yield {"error": error_msg, "success": False}
             return
-        
+
         yield f"Created evaluation DataFrame with {len(eval_df)} rows via search_traces"
-        
+
         # Determine model URI for evaluation judge
-        if evaluation_model_name.startswith('databricks-'):
-            model_uri = f'databricks:/{evaluation_model_name}'
-        elif evaluation_model_name.startswith('openai-'):
-            model_uri = f'openai:/{evaluation_model_name.replace("openai-", "")}'
+        if evaluation_model_name.startswith("databricks-"):
+            model_uri = f"databricks:/{evaluation_model_name}"
+        elif evaluation_model_name.startswith("openai-"):
+            model_uri = f"openai:/{evaluation_model_name.replace('openai-', '')}"
         else:
-            model_uri = f'databricks:/{evaluation_model_name}'
-        
+            model_uri = f"databricks:/{evaluation_model_name}"
+
         yield f"Using evaluation model: {model_uri}"
-        
+
         try:
             # Create the judge using mlflow.genai.judges.make_judge
             from mlflow.genai.judges import make_judge
-            
+
             # Use explicit judge type if provided, otherwise detect from rubric (legacy)
-            effective_judge_type = judge_type if judge_type else get_judge_type_from_rubric(self.db_service, workshop_id)
-            yield f"Using judge type: {effective_judge_type}" + (" (explicitly set)" if judge_type else " (detected from rubric)")
-            
+            effective_judge_type = (
+                judge_type if judge_type else get_judge_type_from_rubric(self.db_service, workshop_id)
+            )
+            yield f"Using judge type: {effective_judge_type}" + (
+                " (explicitly set)" if judge_type else " (detected from rubric)"
+            )
+
             # Try to load registered judge if requested (for re-evaluation after alignment)
             judge = None
             if use_registered_judge:
                 try:
                     from mlflow.genai.scorers import get_scorer
+
                     experiment_id = mlflow_config.experiment_id
-                    
+
                     yield f"Attempting to load registered judge '{judge_name}' from MLflow..."
-                    
+
                     # get_scorer loads the judge with all its aligned properties including memory
                     judge = get_scorer(name=judge_name, experiment_id=experiment_id)
-                    
+
                     if judge is not None:
                         yield f"✓ Loaded registered judge '{judge_name}' (with episodic/semantic memory from alignment)"
                         # Check if the judge has aligned instructions
-                        if hasattr(judge, 'instructions') and judge.instructions:
+                        if hasattr(judge, "instructions") and judge.instructions:
                             yield f"Judge has {len(judge.instructions)} chars of instructions"
                     else:
                         yield f"WARNING: get_scorer returned None for '{judge_name}' - will create from prompt"
@@ -589,29 +599,29 @@ class AlignmentService:
                     yield f"WARNING: Could not load registered judge: {load_err}"
                     yield "Falling back to creating judge from prompt text"
                     judge = None
-            
+
             # If we didn't load a registered judge, create one from the prompt
             if judge is None:
                 # The prompt template with placeholders for judge instructions
                 mlflow_prompt_template = self._normalize_judge_prompt(judge_prompt)
-                
+
                 # For binary rubrics, enhance the prompt to clarify pass/fail criteria
                 # NOTE: Do NOT add custom output format instructions - MLflow InstructionsJudge
                 # expects JSON output with "result" and "rationale" fields, handled automatically
-                if effective_judge_type == 'binary':
+                if effective_judge_type == "binary":
                     yield "Binary judge - MLflow will handle JSON output format automatically"
-                
+
                 # Set feedback_value_type based on judge type
                 # - Binary judges: use float for 0/1 numeric ratings (NOT bool - bool is unreliable)
                 # - Likert judges: use float for 1-5 scale
                 # NOTE: feedback_value_type only affects parsing, not model output. Strong prompt instructions are critical.
-                if effective_judge_type == 'binary':
+                if effective_judge_type == "binary":
                     feedback_type = float  # Use float, not bool - more reliable for 0/1 parsing
                     yield "Binary judge - creating with feedback_value_type=float (expecting 0 or 1)"
                 else:
                     feedback_type = float
                     yield "Likert judge - creating with feedback_value_type=float (expecting 1-5)"
-                
+
                 # Create judge with the judge name - this name is critical for alignment
                 # The judge can be used as a scorer in evaluate()
                 judge = make_judge(
@@ -620,87 +630,87 @@ class AlignmentService:
                     feedback_value_type=feedback_type,
                     model=model_uri,
                 )
-                
+
                 yield f"Created new judge from prompt: {judge_name}"
-            
+
             yield f"Judge ready for evaluation: {judge_name}"
-            
+
             # Ensure eval_df has 'inputs' and 'outputs' columns required by MLflow evaluate()
             # MLflow's search_traces returns traces, but we need to fetch full trace data to get inputs/outputs
-            if 'inputs' not in eval_df.columns or 'outputs' not in eval_df.columns:
+            if "inputs" not in eval_df.columns or "outputs" not in eval_df.columns:
                 yield "Preparing inputs/outputs columns from MLflow trace data..."
-                
+
                 # Fetch full trace data for each trace_id to extract inputs/outputs
                 eval_df = eval_df.copy()
                 inputs_list = []
                 outputs_list = []
-                
-                for trace_id in eval_df['trace_id']:
+
+                for trace_id in eval_df["trace_id"]:
                     try:
                         full_trace = mlflow.get_trace(trace_id)
                         # Extract inputs/outputs from trace data structure
                         # MLflow traces have data.request and data.response
                         trace_inputs = None
                         trace_outputs = None
-                        
-                        if hasattr(full_trace, 'data'):
-                            if hasattr(full_trace.data, 'request'):
+
+                        if hasattr(full_trace, "data"):
+                            if hasattr(full_trace.data, "request"):
                                 trace_inputs = full_trace.data.request
-                            if hasattr(full_trace.data, 'response'):
+                            if hasattr(full_trace.data, "response"):
                                 trace_outputs = full_trace.data.response
-                        
+
                         inputs_list.append(trace_inputs)
                         outputs_list.append(trace_outputs)
                     except Exception as e:
                         yield f"WARNING: Could not fetch trace {trace_id[:8]}...: {e}"
                         inputs_list.append(None)
                         outputs_list.append(None)
-                
+
                 # Add inputs and outputs columns
-                if 'inputs' not in eval_df.columns:
-                    eval_df['inputs'] = inputs_list
-                if 'outputs' not in eval_df.columns:
-                    eval_df['outputs'] = outputs_list
-                
+                if "inputs" not in eval_df.columns:
+                    eval_df["inputs"] = inputs_list
+                if "outputs" not in eval_df.columns:
+                    eval_df["outputs"] = outputs_list
+
                 # Check if we successfully created the columns
-                missing_inputs = eval_df['inputs'].isna().sum() if 'inputs' in eval_df.columns else len(eval_df)
-                missing_outputs = eval_df['outputs'].isna().sum() if 'outputs' in eval_df.columns else len(eval_df)
-                
+                missing_inputs = eval_df["inputs"].isna().sum() if "inputs" in eval_df.columns else len(eval_df)
+                missing_outputs = eval_df["outputs"].isna().sum() if "outputs" in eval_df.columns else len(eval_df)
+
                 if missing_inputs > 0 or missing_outputs > 0:
                     yield f"WARNING: Missing inputs for {missing_inputs} traces, missing outputs for {missing_outputs} traces"
                     # Filter out rows with missing inputs or outputs
                     before_count = len(eval_df)
-                    eval_df = eval_df[eval_df['inputs'].notna() & eval_df['outputs'].notna()]
+                    eval_df = eval_df[eval_df["inputs"].notna() & eval_df["outputs"].notna()]
                     after_count = len(eval_df)
                     if before_count != after_count:
                         yield f"Filtered out {before_count - after_count} traces with missing inputs/outputs"
                 else:
                     yield f"✅ Successfully prepared inputs/outputs columns for {len(eval_df)} traces"
-            
+
             # Run evaluation using the judge as a scorer
             yield "Running mlflow.genai.evaluate()..."
-            
+
             results = evaluate(
                 data=eval_df,
                 scorers=[judge],  # Judge can be used as scorer
             )
-            
+
             yield "Evaluation complete. Processing results..."
-            
+
             result_df = results.result_df
             judge_value_col = None
             evaluations = []
-            
+
             if result_df is not None:
                 columns_list = list(result_df.columns)
                 yield f"Available columns in result_df: {columns_list}"
-                
+
                 # Look for the judge's value column: {judge_name}/value
                 expected_value_col = f"{judge_name}/value"
-                
+
                 if expected_value_col in result_df.columns:
                     judge_value_col = expected_value_col
-                
+
                 # Also look for reasoning/explanation/output columns that might contain the raw text response
                 reasoning_col = None
                 possible_reasoning_cols = [
@@ -714,34 +724,34 @@ class AlignmentService:
                     if col_name in result_df.columns:
                         reasoning_col = col_name
                         break
-                
+
                 yield f"Looking for column '{expected_value_col}': {'found' if judge_value_col else 'NOT FOUND'}"
                 if reasoning_col:
                     yield f"Found reasoning column: {reasoning_col}"
                 else:
                     yield f"WARNING: No reasoning/explanation column found. Available columns: {columns_list}"
-                
+
                 if judge_value_col:
                     null_prediction_rows = 0
                     rows_without_trace_id = 0
                     skipped_unknown_traces = 0
-                    
+
                     # Use the effective judge type determined earlier (explicit > detected)
-                    is_binary = effective_judge_type == 'binary'
+                    is_binary = effective_judge_type == "binary"
                     yield f"🔍 Processing results with judge_type='{effective_judge_type}', is_binary={is_binary}"
                     if is_binary:
                         yield "Binary judge - will convert PASS/FAIL to 1/0 and reject any values not 0 or 1"
-                    
-                    for idx, (_, row) in enumerate(result_df.iterrows()):
-                        raw_trace_id = row.get('trace_id')
+
+                    for _idx, (_, row) in enumerate(result_df.iterrows()):
+                        raw_trace_id = row.get("trace_id")
                         if raw_trace_id is None:
                             rows_without_trace_id += 1
                             continue
-                        
+
                         trace_id = str(raw_trace_id).strip()
                         trace_data = human_feedback_map.get(trace_id)
-                        
-                        # In auto-evaluation mode (require_human_ratings=False), 
+
+                        # In auto-evaluation mode (require_human_ratings=False),
                         # we don't skip traces without human ratings
                         if trace_data is None:
                             if require_human_ratings:
@@ -751,21 +761,21 @@ class AlignmentService:
                                 # Auto-eval mode: create minimal trace data with workshop trace ID
                                 workshop_trace_id = mlflow_to_workshop_trace_map.get(trace_id, trace_id)
                                 trace_data = {
-                                    'trace_id': trace_id, 
-                                    'workshop_id': workshop_trace_id,
-                                    'human_rating': None
+                                    "trace_id": trace_id,
+                                    "workshop_id": workshop_trace_id,
+                                    "human_rating": None,
                                 }
-                        
-                        workshop_uuid = trace_data.get('workshop_id', trace_id)
-                        
+
+                        workshop_uuid = trace_data.get("workshop_id", trace_id)
+
                         predicted_value = row.get(judge_value_col)
                         # Also try to get raw text response from reasoning column if available
                         raw_text_response = None
                         if reasoning_col and reasoning_col in result_df.columns:
                             raw_text_response = row.get(reasoning_col)
-                        
+
                         predicted_rating = None
-                        
+
                         # For binary judges, prioritize parsing numeric 0/1 values first
                         # We now request 0/1 numeric format, so MLflow should return float values
                         if is_binary and predicted_value is not None and not pd.isna(predicted_value):
@@ -781,26 +791,34 @@ class AlignmentService:
                                     if raw_text_response:
                                         text_lower = str(raw_text_response).lower()
                                         text_trimmed = text_lower.strip()
-                                        if text_trimmed.startswith('0') and (len(text_trimmed) == 1 or text_trimmed[1] in [' ', '\n', '.', ',', ':', ';']):
+                                        if text_trimmed.startswith("0") and (
+                                            len(text_trimmed) == 1 or text_trimmed[1] in [" ", "\n", ".", ",", ":", ";"]
+                                        ):
                                             predicted_rating = 0.0
-                                        elif text_trimmed.startswith('1') and (len(text_trimmed) == 1 or text_trimmed[1] in [' ', '\n', '.', ',', ':', ';']):
+                                        elif text_trimmed.startswith("1") and (
+                                            len(text_trimmed) == 1 or text_trimmed[1] in [" ", "\n", ".", ",", ":", ";"]
+                                        ):
                                             predicted_rating = 1.0
-                        
+
                         # If we didn't parse from numeric value, try parsing from raw text response
                         if predicted_rating is None and is_binary and raw_text_response:
                             text_lower = str(raw_text_response).lower()
                             text_trimmed = text_lower.strip()
-                            if text_trimmed.startswith('0') and (len(text_trimmed) == 1 or text_trimmed[1] in [' ', '\n', '.', ',', ':', ';']):
+                            if text_trimmed.startswith("0") and (
+                                len(text_trimmed) == 1 or text_trimmed[1] in [" ", "\n", ".", ",", ":", ";"]
+                            ):
                                 predicted_rating = 0.0
-                            elif text_trimmed.startswith('1') and (len(text_trimmed) == 1 or text_trimmed[1] in [' ', '\n', '.', ',', ':', ';']):
+                            elif text_trimmed.startswith("1") and (
+                                len(text_trimmed) == 1 or text_trimmed[1] in [" ", "\n", ".", ",", ":", ";"]
+                            ):
                                 predicted_rating = 1.0
                             else:
                                 # Fallback to PASS/FAIL text parsing (for backward compatibility)
-                                if 'pass' in text_lower and 'fail' not in text_lower[:text_lower.find('pass')+10]:
+                                if "pass" in text_lower and "fail" not in text_lower[: text_lower.find("pass") + 10]:
                                     predicted_rating = 1.0
-                                elif 'fail' in text_lower and 'pass' not in text_lower[:text_lower.find('fail')+10]:
+                                elif "fail" in text_lower and "pass" not in text_lower[: text_lower.find("fail") + 10]:
                                     predicted_rating = 0.0
-                        
+
                         # If we still didn't parse, try the parsed value as fallback
                         if predicted_rating is None and predicted_value is not None and not pd.isna(predicted_value):
                             # Handle boolean values (backward compatibility)
@@ -809,21 +827,25 @@ class AlignmentService:
                             else:
                                 # Try to convert strings to 0/1 for binary rubrics
                                 str_value = str(predicted_value).strip().upper()
-                                if str_value in ('0', '0.0', '0.', '0!', '0:', '0;'):
+                                if str_value in ("0", "0.0", "0.", "0!", "0:", "0;"):
                                     predicted_rating = 0.0
-                                elif str_value in ('1', '1.0', '1.', '1!', '1:', '1;'):
+                                elif str_value in ("1", "1.0", "1.", "1!", "1:", "1;") or str_value in (
+                                    "PASS",
+                                    "PASS.",
+                                    "PASS!",
+                                    "PASS:",
+                                    "PASS;",
+                                ):
                                     predicted_rating = 1.0
-                                elif str_value in ('PASS', 'PASS.', 'PASS!', 'PASS:', 'PASS;'):
-                                    predicted_rating = 1.0
-                                elif str_value in ('FAIL', 'FAIL.', 'FAIL!', 'FAIL:', 'FAIL;'):
+                                elif str_value in ("FAIL", "FAIL.", "FAIL!", "FAIL:", "FAIL;"):
                                     predicted_rating = 0.0
-                                elif str_value in ('TRUE', 'TRUE.', 'TRUE!', 'TRUE:', 'TRUE;'):
+                                elif str_value in ("TRUE", "TRUE.", "TRUE!", "TRUE:", "TRUE;"):
                                     predicted_rating = 1.0
-                                elif str_value in ('FALSE', 'FALSE.', 'FALSE!', 'FALSE:', 'FALSE;'):
+                                elif str_value in ("FALSE", "FALSE.", "FALSE!", "FALSE:", "FALSE;"):
                                     predicted_rating = 0.0
-                                elif str_value in ('YES', 'CORRECT', 'GOOD', 'ACCEPTABLE'):
+                                elif str_value in ("YES", "CORRECT", "GOOD", "ACCEPTABLE"):
                                     predicted_rating = 1.0
-                                elif str_value in ('NO', 'INCORRECT', 'BAD', 'UNACCEPTABLE'):
+                                elif str_value in ("NO", "INCORRECT", "BAD", "UNACCEPTABLE"):
                                     predicted_rating = 0.0
                                 else:
                                     # Try numeric conversion
@@ -838,13 +860,31 @@ class AlignmentService:
                                                 # Invalid binary value - try to parse from raw text response if available
                                                 if raw_text_response:
                                                     text_lower = str(raw_text_response).lower()
-                                                    if 'pass' in text_lower and 'fail' not in text_lower[:text_lower.find('pass')+10]:
+                                                    if (
+                                                        "pass" in text_lower
+                                                        and "fail" not in text_lower[: text_lower.find("pass") + 10]
+                                                    ):
                                                         predicted_rating = 1.0
-                                                    elif 'fail' in text_lower and 'pass' not in text_lower[:text_lower.find('fail')+10]:
+                                                    elif (
+                                                        "fail" in text_lower
+                                                        and "pass" not in text_lower[: text_lower.find("fail") + 10]
+                                                    ):
                                                         predicted_rating = 0.0
-                                                    elif any(word in text_lower for word in ['true', 'yes', 'correct', 'meets', 'acceptable']):
+                                                    elif any(
+                                                        word in text_lower
+                                                        for word in ["true", "yes", "correct", "meets", "acceptable"]
+                                                    ):
                                                         predicted_rating = 1.0
-                                                    elif any(word in text_lower for word in ['false', 'no', 'incorrect', 'does not meet', 'unacceptable']):
+                                                    elif any(
+                                                        word in text_lower
+                                                        for word in [
+                                                            "false",
+                                                            "no",
+                                                            "incorrect",
+                                                            "does not meet",
+                                                            "unacceptable",
+                                                        ]
+                                                    ):
                                                         predicted_rating = 0.0
                                                     elif 1 <= numeric_value <= 5:
                                                         # Fallback: convert Likert-style response to binary using threshold
@@ -869,7 +909,7 @@ class AlignmentService:
                                         pass  # Could not convert to rating
                         else:
                             null_prediction_rows += 1
-                        
+
                         # If we still couldn't parse a rating, use a sensible default
                         if predicted_rating is None:
                             if is_binary:
@@ -880,15 +920,17 @@ class AlignmentService:
                                 # Default to neutral (3) for Likert - matches simple evaluation behavior
                                 predicted_rating = 3.0
                                 yield f"⚠️ Could not parse rating for trace {trace_id[:8]}... - defaulting to 3.0 (neutral)"
-                        
-                        evaluations.append({
-                            'trace_id': trace_id,
-                            'workshop_uuid': workshop_uuid,
-                            'predicted_rating': predicted_rating,
-                            'human_rating': trace_data.get('human_rating'),
-                            'reasoning': None,
-                        })
-                    
+
+                        evaluations.append(
+                            {
+                                "trace_id": trace_id,
+                                "workshop_uuid": workshop_uuid,
+                                "predicted_rating": predicted_rating,
+                                "human_rating": trace_data.get("human_rating"),
+                                "reasoning": None,
+                            }
+                        )
+
                     if rows_without_trace_id:
                         yield f"WARNING: {rows_without_trace_id} result rows were missing trace_id values."
                     if skipped_unknown_traces:
@@ -896,8 +938,8 @@ class AlignmentService:
                     if len(evaluations) < len(trace_ids_for_eval):
                         missing = len(trace_ids_for_eval) - len(evaluations)
                         yield f"WARNING: Missing evaluation scores for {missing} traces."
-                    
-                    valid_count = sum(1 for e in evaluations if e['predicted_rating'] is not None)
+
+                    valid_count = sum(1 for e in evaluations if e["predicted_rating"] is not None)
                     yield (
                         f"Extracted {valid_count}/{len(evaluations)} evaluations with scores "
                         f"(null predictions: {null_prediction_rows})"
@@ -906,38 +948,36 @@ class AlignmentService:
                     yield f"ERROR: Column '{expected_value_col}' not found. Available: {columns_list}"
             else:
                 yield "WARNING: Result DataFrame is None"
-            
+
             # Use effective_judge_type for appropriate metrics calculation
             yield f"Computing metrics for judge type: {effective_judge_type}"
-            
+
             # Extract results with appropriate metrics for judge type
             metrics_payload = self._calculate_eval_metrics(evaluations, judge_type=effective_judge_type)
             evaluation_results = {
-                'judge_name': judge_name,
-                'trace_count': len(trace_ids_for_eval),
-                'metrics': metrics_payload,
-                'evaluations': evaluations,
-                'success': True,
-                'judge_type': effective_judge_type,
+                "judge_name": judge_name,
+                "trace_count": len(trace_ids_for_eval),
+                "metrics": metrics_payload,
+                "evaluations": evaluations,
+                "success": True,
+                "judge_type": effective_judge_type,
             }
-            
+
             yield f"Evaluation results prepared for {len(evaluations)} traces"
-            
+
             # Sync AI evaluations to MLflow for SIMBA alignment
             try:
                 sync_result = self.db_service.sync_evaluations_to_mlflow(
-                    workshop_id=workshop_id,
-                    judge_name=judge_name,
-                    evaluations=evaluations
+                    workshop_id=workshop_id, judge_name=judge_name, evaluations=evaluations
                 )
                 yield f"Synced {sync_result.get('synced', 0)} AI evaluations to MLflow for judge '{judge_name}'"
             except Exception as sync_err:
                 yield f"WARNING: Could not sync AI evaluations to MLflow: {sync_err}"
-            
+
             yield evaluation_results
-            
+
         except Exception as e:
-            error_msg = f"Evaluation failed: {str(e)}"
+            error_msg = f"Evaluation failed: {e!s}"
             yield f"ERROR: {error_msg}"
             yield {"error": error_msg, "success": False}
 
@@ -949,24 +989,24 @@ class AlignmentService:
         evaluation_model_name: str,  # Model for judge creation
         alignment_model_name: str,  # Model for MemAlign optimizer (reflection/distillation)
         mlflow_config: Any,
-    ) -> Generator[str, None, Dict[str, Any]]:
+    ) -> Generator[str, None, dict[str, Any]]:
         """Run judge alignment using MemAlignOptimizer.
-        
+
         MemAlign uses dual memory systems to align judges with human feedback:
         - Semantic Memory: Distills general guidelines from feedback patterns
         - Episodic Memory: Retrieves similar past examples during evaluation
-        
+
         This generator yields log messages and finally returns the aligned judge.
-        
+
         Prerequisites:
         - evaluate() must have been run first to create LLM assessments
         - Human feedback must exist on the traces with the same judge_name
-        
+
         Note: MemAlign works universally across all judge types (binary, likert, etc.)
         without requiring type-specific configuration.
         """
         logger.info("run_alignment() started for judge '%s'", judge_name)
-        
+
         try:
             import mlflow
             from mlflow.genai.judges import make_judge
@@ -976,22 +1016,22 @@ class AlignmentService:
             yield f"ERROR: {error_msg}"
             yield {"error": error_msg, "success": False}
             return
-        
+
         try:
             # Set up MLflow environment
-            os.environ['DATABRICKS_HOST'] = mlflow_config.databricks_host.rstrip('/')
-            has_oauth = bool(os.environ.get('DATABRICKS_CLIENT_ID') and os.environ.get('DATABRICKS_CLIENT_SECRET'))
+            os.environ["DATABRICKS_HOST"] = mlflow_config.databricks_host.rstrip("/")
+            has_oauth = bool(os.environ.get("DATABRICKS_CLIENT_ID") and os.environ.get("DATABRICKS_CLIENT_SECRET"))
             if has_oauth:
-                os.environ.pop('DATABRICKS_TOKEN', None)
+                os.environ.pop("DATABRICKS_TOKEN", None)
             else:
-                os.environ['DATABRICKS_TOKEN'] = mlflow_config.databricks_token
-                os.environ.pop('DATABRICKS_CLIENT_ID', None)
-                os.environ.pop('DATABRICKS_CLIENT_SECRET', None)
-            mlflow.set_tracking_uri('databricks')
-            
+                os.environ["DATABRICKS_TOKEN"] = mlflow_config.databricks_token
+                os.environ.pop("DATABRICKS_CLIENT_ID", None)
+                os.environ.pop("DATABRICKS_CLIENT_SECRET", None)
+            mlflow.set_tracking_uri("databricks")
+
             # Enable MemAlign debug logging
             logging.getLogger("mlflow.genai.judges.optimizers.memalign").setLevel(logging.DEBUG)
-            
+
             experiment_id = mlflow_config.experiment_id
             if not experiment_id:
                 yield "ERROR: MLflow experiment ID is not configured. Please set it in the Intake phase."
@@ -1003,10 +1043,12 @@ class AlignmentService:
                 yield f"ERROR: Failed to set experiment {experiment_id}: {e}"
                 yield {"error": f"Failed to set experiment {experiment_id}: {e}", "success": False}
                 return
-            
+
             # Fetch labeled traces - use 'align' tag for traces with human annotations
             try:
-                mlflow_traces = self._search_tagged_traces(mlflow_config, workshop_id, return_type="list", tag_type="align")
+                mlflow_traces = self._search_tagged_traces(
+                    mlflow_config, workshop_id, return_type="list", tag_type="align"
+                )
             except Exception as exc:
                 yield f"ERROR: Failed to search MLflow traces: {exc}"
                 yield {"error": f"Failed to search MLflow traces: {exc}", "success": False}
@@ -1017,30 +1059,30 @@ class AlignmentService:
                 yield "ERROR: No labeled traces available for alignment"
                 yield {"error": "No labeled traces available", "success": False}
                 return
-            
+
             # Determine model URI for the judge (use evaluation model)
-            if evaluation_model_name.startswith('databricks-'):
-                judge_model_uri = f'databricks:/{evaluation_model_name}'
-            elif evaluation_model_name.startswith('openai-'):
-                judge_model_uri = f'openai:/{evaluation_model_name.replace("openai-", "")}'
+            if evaluation_model_name.startswith("databricks-"):
+                judge_model_uri = f"databricks:/{evaluation_model_name}"
+            elif evaluation_model_name.startswith("openai-"):
+                judge_model_uri = f"openai:/{evaluation_model_name.replace('openai-', '')}"
             else:
-                judge_model_uri = f'databricks:/{evaluation_model_name}'
-            
+                judge_model_uri = f"databricks:/{evaluation_model_name}"
+
             normalized_judge_prompt = self._normalize_judge_prompt(judge_prompt)
-            
+
             # Get judge type from rubric to determine feedback_value_type
             judge_type = get_judge_type_from_rubric(self.db_service, workshop_id)
-            
+
             # For binary rubrics, log the judge type
             # NOTE: Do NOT add custom output format instructions - MLflow InstructionsJudge
             # expects JSON output with "result" and "rationale" fields, handled automatically
-            if judge_type == 'binary':
+            if judge_type == "binary":
                 yield "Binary judge - MLflow will handle JSON output format automatically"
-            
+
             # Set feedback_value_type based on judge type
             # - Binary judges: use float for 0/1 numeric ratings
             # - Likert judges: use float for 1-5 scale
-            if judge_type == 'binary':
+            if judge_type == "binary":
                 feedback_type = float
                 yield "Creating binary judge with feedback_value_type=float (expecting 0 or 1)"
             else:
@@ -1054,10 +1096,10 @@ class AlignmentService:
                 feedback_value_type=feedback_type,
                 model=judge_model_uri,
             )
-            
+
             logger.info("Judge '%s' created using model '%s' (type=%s)", judge.name, judge_model_uri, judge_type)
             yield f"Initial Judge Text:\n{judge.instructions}"
-            
+
             # Register or update the judge BEFORE alignment so it exists in MLflow
             try:
                 # Try to register first
@@ -1079,22 +1121,24 @@ class AlignmentService:
                         yield f"WARNING: Could not update existing judge: {update_err}"
                 else:
                     yield f"WARNING: Could not pre-register judge: {pre_register_err}"
-            
+
             # Determine model URI for the optimizer
             alignment_model = alignment_model_name or evaluation_model_name
-            if alignment_model.startswith('databricks-'):
-                optimizer_model_uri = f'databricks:/{alignment_model}'
-            elif alignment_model.startswith('openai-'):
-                optimizer_model_uri = f'openai:/{alignment_model.replace("openai-", "")}'
+            if alignment_model.startswith("databricks-"):
+                optimizer_model_uri = f"databricks:/{alignment_model}"
+            elif alignment_model.startswith("openai-"):
+                optimizer_model_uri = f"openai:/{alignment_model.replace('openai-', '')}"
             else:
-                optimizer_model_uri = f'databricks:/{alignment_model}'
-            
+                optimizer_model_uri = f"databricks:/{alignment_model}"
+
             # Set up log capture for MemAlign loggers
             log_handler = SimpleLogHandler()
             log_handler.setLevel(logging.DEBUG)
-            formatter = logging.Formatter('%(asctime)s %(levelname)s %(name)s: %(message)s', datefmt='%Y/%m/%d %H:%M:%S')
+            formatter = logging.Formatter(
+                "%(asctime)s %(levelname)s %(name)s: %(message)s", datefmt="%Y/%m/%d %H:%M:%S"
+            )
             log_handler.setFormatter(formatter)
-            
+
             target_loggers = [
                 logging.getLogger("mlflow.genai.judges.optimizers.memalign"),
                 logging.getLogger("mlflow.genai.judges.optimizers.memalign.optimizer"),
@@ -1105,12 +1149,12 @@ class AlignmentService:
                 lg.setLevel(logging.DEBUG)
                 lg.propagate = False
                 lg.addHandler(log_handler)
-            
+
             # Get judge type for informational purposes (MemAlign works with all types)
             judge_type = get_judge_type_from_rubric(self.db_service, workshop_id)
             logger.info("Detected judge type from rubric: %s", judge_type)
             yield f"Detected judge type: {judge_type}"
-            
+
             # Create MemAlignOptimizer - works universally for all judge types
             # MemAlign uses dual memory systems:
             # - Semantic Memory: Distills general guidelines from feedback
@@ -1123,9 +1167,9 @@ class AlignmentService:
                 # IMPORTANT: Databricks models don't support the JSON schema format required
                 # for guideline distillation (additionalProperties: false). OpenAI and Claude models
                 # support this, so we prefer those for the reflection_lm.
-                openai_api_key = os.environ.get('OPENAI_API_KEY')
-                is_openai_model = alignment_model.startswith('openai-') or alignment_model.startswith('gpt-')
-                is_claude_model = alignment_model.startswith('claude-') or 'claude' in alignment_model.lower()
+                openai_api_key = os.environ.get("OPENAI_API_KEY")
+                is_openai_model = alignment_model.startswith("openai-") or alignment_model.startswith("gpt-")
+                is_claude_model = alignment_model.startswith("claude-") or "claude" in alignment_model.lower()
 
                 if is_openai_model or is_claude_model:
                     # User selected OpenAI/Claude model - use it for reflection (supports JSON schema)
@@ -1154,14 +1198,14 @@ class AlignmentService:
                 yield f"ERROR: {error_msg}"
                 yield {"error": error_msg, "success": False}
                 return
-            
+
             yield f"Running alignment with {len(mlflow_traces)} traces..."
-            
+
             # Run alignment in background thread so we can yield logs periodically
-            aligned_judge_container: Dict[str, Any] = {}
-            alignment_error: Optional[Exception] = None
+            aligned_judge_container: dict[str, Any] = {}
+            alignment_error: Exception | None = None
             last_status_emit = time.time()
-            
+
             def _alignment_worker():
                 nonlocal alignment_error
                 try:
@@ -1182,14 +1226,14 @@ class AlignmentService:
                         last_status_emit = time.time()
                         for log_message in new_logs:
                             yield log_message
-                    
+
                     # Yield heartbeat if no activity
                     if not new_logs and time.time() - last_status_emit >= 5:
                         yield "MemAlign still optimizing..."
                         last_status_emit = time.time()
-                    
+
                     worker.join(timeout=0.5)
-                
+
                 # Drain any remaining logs
                 for log_message in log_handler.get_new_messages():
                     yield log_message
@@ -1210,16 +1254,16 @@ class AlignmentService:
             aligned_judge = aligned_judge_container["judge"]
             logger.info("Alignment complete for judge '%s' (%d traces)", aligned_judge.name, len(mlflow_traces))
             yield "Alignment complete!"
-            
+
             # Extract the aligned instructions (original prompt + distilled guidelines)
             aligned_instructions = aligned_judge.instructions
-            
+
             # Extract memory statistics for logging
-            semantic_memory = getattr(aligned_judge, '_semantic_memory', [])
-            episodic_memory = getattr(aligned_judge, '_episodic_memory', [])
+            semantic_memory = getattr(aligned_judge, "_semantic_memory", [])
+            episodic_memory = getattr(aligned_judge, "_episodic_memory", [])
             guideline_count = len(semantic_memory)
             example_count = len(episodic_memory)
-            
+
             yield f"Aligned judge instructions length: {len(aligned_instructions)} chars"
             yield f"Semantic memory: {guideline_count} distilled guidelines"
             yield f"Episodic memory: {example_count} examples (not persisted to registered judge)"
@@ -1234,21 +1278,21 @@ class AlignmentService:
             if semantic_memory:
                 yield "--- Distilled Guidelines (Semantic Memory) ---"
                 for i, guideline in enumerate(semantic_memory, 1):
-                    guideline_text = getattr(guideline, 'guideline_text', str(guideline))
+                    guideline_text = getattr(guideline, "guideline_text", str(guideline))
                     # Truncate long guidelines for display
                     if len(guideline_text) > 200:
                         guideline_text = guideline_text[:200] + "..."
                     yield f"  {i}. {guideline_text}"
-            
+
             # Log sample episodic memory examples
             if episodic_memory:
                 yield "--- Sample Episodic Memory Examples ---"
                 for i, example in enumerate(episodic_memory[:3], 1):  # Show first 3
-                    ex_dict = dict(example) if hasattr(example, '__iter__') else {}
-                    trace_id = getattr(example, '_trace_id', 'N/A')
+                    ex_dict = dict(example) if hasattr(example, "__iter__") else {}
+                    trace_id = getattr(example, "_trace_id", "N/A")
                     # Get a preview of inputs/outputs
-                    inputs_preview = str(ex_dict.get('inputs', ''))[:80]
-                    if len(str(ex_dict.get('inputs', ''))) > 80:
+                    inputs_preview = str(ex_dict.get("inputs", ""))[:80]
+                    if len(str(ex_dict.get("inputs", ""))) > 80:
                         inputs_preview += "..."
                     yield f"  Example {i} (trace: {trace_id}): {inputs_preview}"
                 if len(episodic_memory) > 3:
@@ -1282,10 +1326,10 @@ class AlignmentService:
                 # Update the existing registered judge with aligned instructions
                 # The aligned_instructions contain the original prompt + distilled guidelines (semantic memory)
                 # Note: Episodic memory (example retrieval) is not preserved - waiting for native MLflow support
-                registered_judge_name: Optional[str] = None
+                registered_judge_name: str | None = None
                 try:
                     from mlflow.genai.scorers import ScorerSamplingConfig
-                    
+
                     # Create judge with aligned instructions using the SAME name
                     registered_judge_name = judge_name  # Use original name, not _aligned suffix
                     aligned_judge_for_registration = make_judge(
@@ -1294,7 +1338,7 @@ class AlignmentService:
                         feedback_value_type=feedback_type,
                         model=judge_model_uri,
                     )
-                    
+
                     # Try to update existing scorer first, fall back to register if it doesn't exist
                     try:
                         # Use update() for existing scorers - this creates a new version
@@ -1324,7 +1368,7 @@ class AlignmentService:
                                 yield f"WARNING: Could not update sampling config: {config_err}"
                         else:
                             yield f"WARNING: Could not update judge: {update_err}"
-                        
+
                 except Exception as register_err:
                     registered_judge_name = None
                     yield f"WARNING: Failed to update/register aligned judge: {register_err}"
@@ -1337,19 +1381,20 @@ class AlignmentService:
                         pass
 
             yield {
-                'success': True,
-                'judge_name': judge_name,
-                'aligned_instructions': aligned_instructions,
-                'trace_count': len(mlflow_traces),
-                'mlflow_run_id': mlflow_run.info.run_id if mlflow_run else None,
-                'registered_judge_name': registered_judge_name,
-                'guideline_count': guideline_count,  # Semantic memory - persisted in instructions
-                'example_count': example_count,  # Episodic memory - not persisted
+                "success": True,
+                "judge_name": judge_name,
+                "aligned_instructions": aligned_instructions,
+                "trace_count": len(mlflow_traces),
+                "mlflow_run_id": mlflow_run.info.run_id if mlflow_run else None,
+                "registered_judge_name": registered_judge_name,
+                "guideline_count": guideline_count,  # Semantic memory - persisted in instructions
+                "example_count": example_count,  # Episodic memory - not persisted
             }
         except Exception as e:
             import traceback
+
             error_details = traceback.format_exc()
-            error_msg = f"Alignment failed: {str(e)}"
+            error_msg = f"Alignment failed: {e!s}"
             logger.exception("Alignment error: %s", error_details)
             yield f"ERROR: {error_msg}"
             yield {"error": error_msg, "success": False}
@@ -1357,21 +1402,20 @@ class AlignmentService:
 
 class SimpleLogHandler(logging.Handler):
     """Simple log handler that collects messages for polling."""
-    
+
     def __init__(self):
         super().__init__()
-        self.messages: List[str] = []
+        self.messages: list[str] = []
         self._lock = threading.Lock()
-        
+
     def emit(self, record: logging.LogRecord):
         msg = self.format(record)
         with self._lock:
             self.messages.append(msg)
-    
-    def get_new_messages(self) -> List[str]:
+
+    def get_new_messages(self) -> list[str]:
         """Get and clear accumulated messages."""
         with self._lock:
             messages = self.messages.copy()
             self.messages.clear()
         return messages
-

--- a/server/services/cohens_kappa.py
+++ b/server/services/cohens_kappa.py
@@ -12,192 +12,190 @@ Where:
 """
 
 from collections import Counter
-from typing import Dict, List, Tuple
 
 from server.models import Annotation
 
 
-def calculate_cohens_kappa(annotations: List[Annotation]) -> float:
-  """Calculate Cohen's Kappa for exactly 2 raters.
+def calculate_cohens_kappa(annotations: list[Annotation]) -> float:
+    """Calculate Cohen's Kappa for exactly 2 raters.
 
-  Args:
-      annotations: List of annotations from exactly 2 raters
+    Args:
+        annotations: List of annotations from exactly 2 raters
 
-  Returns:
-      float: Cohen's Kappa value (-1 to 1)
-      - 1.0 = Perfect agreement
-      - 0.0 = Agreement equal to chance
-      - <0.0 = Systematic disagreement
+    Returns:
+        float: Cohen's Kappa value (-1 to 1)
+        - 1.0 = Perfect agreement
+        - 0.0 = Agreement equal to chance
+        - <0.0 = Systematic disagreement
 
-  Raises:
-      ValueError: If not exactly 2 raters or insufficient data
+    Raises:
+        ValueError: If not exactly 2 raters or insufficient data
 
-  Example:
-      >>> annotations = [
-      ...     Annotation(trace_id="t1", user_id="u1", rating=4),
-      ...     Annotation(trace_id="t1", user_id="u2", rating=4),
-      ...     Annotation(trace_id="t2", user_id="u1", rating=2),
-      ...     Annotation(trace_id="t2", user_id="u2", rating=3),
-      ... ]
-      >>> kappa = calculate_cohens_kappa(annotations)
-      >>> # Returns kappa value based on agreement between u1 and u2
-  """
-  if len(annotations) == 0:
-    raise ValueError('No annotations provided')
+    Example:
+        >>> annotations = [
+        ...     Annotation(trace_id="t1", user_id="u1", rating=4),
+        ...     Annotation(trace_id="t1", user_id="u2", rating=4),
+        ...     Annotation(trace_id="t2", user_id="u1", rating=2),
+        ...     Annotation(trace_id="t2", user_id="u2", rating=3),
+        ... ]
+        >>> kappa = calculate_cohens_kappa(annotations)
+        >>> # Returns kappa value based on agreement between u1 and u2
+    """
+    if len(annotations) == 0:
+        raise ValueError("No annotations provided")
 
-  # Organize annotations by trace and rater
-  data_matrix = _organize_annotations_by_trace_and_rater(annotations)
+    # Organize annotations by trace and rater
+    data_matrix = _organize_annotations_by_trace_and_rater(annotations)
 
-  # Validate exactly 2 raters
-  all_raters = set()
-  for trace_ratings in data_matrix.values():
-    all_raters.update(trace_ratings.keys())
+    # Validate exactly 2 raters
+    all_raters = set()
+    for trace_ratings in data_matrix.values():
+        all_raters.update(trace_ratings.keys())
 
-  if len(all_raters) != 2:
-    raise ValueError(f"Cohen's Kappa requires exactly 2 raters, got {len(all_raters)}")
+    if len(all_raters) != 2:
+        raise ValueError(f"Cohen's Kappa requires exactly 2 raters, got {len(all_raters)}")
 
-  rater1, rater2 = list(all_raters)
+    rater1, rater2 = list(all_raters)
 
-  # Extract paired ratings (only traces rated by both raters)
-  paired_ratings = []
-  for trace_id, ratings in data_matrix.items():
-    if rater1 in ratings and rater2 in ratings:
-      paired_ratings.append((ratings[rater1], ratings[rater2]))
+    # Extract paired ratings (only traces rated by both raters)
+    paired_ratings = []
+    for ratings in data_matrix.values():
+        if rater1 in ratings and rater2 in ratings:
+            paired_ratings.append((ratings[rater1], ratings[rater2]))
 
-  if len(paired_ratings) < 2:
-    raise ValueError("Need at least 2 paired ratings to calculate Cohen's Kappa")
+    if len(paired_ratings) < 2:
+        raise ValueError("Need at least 2 paired ratings to calculate Cohen's Kappa")
 
-  # Calculate observed agreement
-  observed_agreement = _calculate_observed_agreement(paired_ratings)
+    # Calculate observed agreement
+    observed_agreement = _calculate_observed_agreement(paired_ratings)
 
-  # Calculate expected agreement by chance
-  expected_agreement = _calculate_expected_agreement(paired_ratings)
+    # Calculate expected agreement by chance
+    expected_agreement = _calculate_expected_agreement(paired_ratings)
 
-  # Calculate Cohen's Kappa
-  if expected_agreement == 1.0:
-    return 1.0 if observed_agreement == 1.0 else 0.0
+    # Calculate Cohen's Kappa
+    if expected_agreement == 1.0:
+        return 1.0 if observed_agreement == 1.0 else 0.0
 
-  kappa = (observed_agreement - expected_agreement) / (1 - expected_agreement)
-  return max(-1.0, min(1.0, kappa))  # Clamp to [-1, 1]
+    kappa = (observed_agreement - expected_agreement) / (1 - expected_agreement)
+    return max(-1.0, min(1.0, kappa))  # Clamp to [-1, 1]
 
 
 def _organize_annotations_by_trace_and_rater(
-  annotations: List[Annotation],
-) -> Dict[str, Dict[str, int]]:
-  """Organize annotations into a matrix: trace_id -> rater_id -> rating.
+    annotations: list[Annotation],
+) -> dict[str, dict[str, int]]:
+    """Organize annotations into a matrix: trace_id -> rater_id -> rating.
 
-  Args:
-      annotations: List of annotations
+    Args:
+        annotations: List of annotations
 
-  Returns:
-      Dict[str, Dict[str, int]]: Nested dictionary of trace->rater->rating
-  """
-  data_matrix = {}
+    Returns:
+        Dict[str, Dict[str, int]]: Nested dictionary of trace->rater->rating
+    """
+    data_matrix = {}
 
-  for annotation in annotations:
-    trace_id = annotation.trace_id
-    rater_id = annotation.user_id
-    rating = annotation.rating
+    for annotation in annotations:
+        trace_id = annotation.trace_id
+        rater_id = annotation.user_id
+        rating = annotation.rating
 
-    if trace_id not in data_matrix:
-      data_matrix[trace_id] = {}
+        if trace_id not in data_matrix:
+            data_matrix[trace_id] = {}
 
-    data_matrix[trace_id][rater_id] = rating
+        data_matrix[trace_id][rater_id] = rating
 
-  return data_matrix
-
-
-def _calculate_observed_agreement(paired_ratings: List[Tuple[int, int]]) -> float:
-  """Calculate observed agreement between two raters.
-
-  Args:
-      paired_ratings: List of (rater1_rating, rater2_rating) tuples
-
-  Returns:
-      float: Proportion of ratings where both raters agreed
-  """
-  total_pairs = len(paired_ratings)
-  agreed_pairs = sum(1 for r1, r2 in paired_ratings if r1 == r2)
-
-  return agreed_pairs / total_pairs
+    return data_matrix
 
 
-def _calculate_expected_agreement(paired_ratings: List[Tuple[int, int]]) -> float:
-  """Calculate expected agreement by chance based on marginal distributions.
+def _calculate_observed_agreement(paired_ratings: list[tuple[int, int]]) -> float:
+    """Calculate observed agreement between two raters.
 
-  Args:
-      paired_ratings: List of (rater1_rating, rater2_rating) tuples
+    Args:
+        paired_ratings: List of (rater1_rating, rater2_rating) tuples
 
-  Returns:
-      float: Expected agreement by chance
+    Returns:
+        float: Proportion of ratings where both raters agreed
+    """
+    total_pairs = len(paired_ratings)
+    agreed_pairs = sum(1 for r1, r2 in paired_ratings if r1 == r2)
 
-  Mathematical approach:
-      For each rating category, calculate the probability that both raters
-      would assign that rating by chance, then sum across all categories.
-  """
-  total_pairs = len(paired_ratings)
+    return agreed_pairs / total_pairs
 
-  # Count how often each rater used each rating
-  rater1_counts = Counter(r1 for r1, r2 in paired_ratings)
-  rater2_counts = Counter(r2 for r1, r2 in paired_ratings)
 
-  # Calculate expected agreement for each rating category
-  expected_agreement = 0.0
+def _calculate_expected_agreement(paired_ratings: list[tuple[int, int]]) -> float:
+    """Calculate expected agreement by chance based on marginal distributions.
 
-  # Consider all possible rating values (1-5 for Likert scale)
-  for rating in range(1, 6):
-    p_rater1 = rater1_counts.get(rating, 0) / total_pairs
-    p_rater2 = rater2_counts.get(rating, 0) / total_pairs
+    Args:
+        paired_ratings: List of (rater1_rating, rater2_rating) tuples
 
-    # Probability both raters assign this rating by chance
-    expected_agreement += p_rater1 * p_rater2
+    Returns:
+        float: Expected agreement by chance
 
-  return expected_agreement
+    Mathematical approach:
+        For each rating category, calculate the probability that both raters
+        would assign that rating by chance, then sum across all categories.
+    """
+    total_pairs = len(paired_ratings)
+
+    # Count how often each rater used each rating
+    rater1_counts = Counter(r1 for r1, r2 in paired_ratings)
+    rater2_counts = Counter(r2 for r1, r2 in paired_ratings)
+
+    # Calculate expected agreement for each rating category
+    expected_agreement = 0.0
+
+    # Consider all possible rating values (1-5 for Likert scale)
+    for rating in range(1, 6):
+        p_rater1 = rater1_counts.get(rating, 0) / total_pairs
+        p_rater2 = rater2_counts.get(rating, 0) / total_pairs
+
+        # Probability both raters assign this rating by chance
+        expected_agreement += p_rater1 * p_rater2
+
+    return expected_agreement
 
 
 def interpret_cohens_kappa(kappa: float) -> str:
-  """Provide human-readable interpretation of Cohen's Kappa score.
+    """Provide human-readable interpretation of Cohen's Kappa score.
 
-  Args:
-      kappa: Cohen's Kappa value
+    Args:
+        kappa: Cohen's Kappa value
 
-  Returns:
-      str: Human-readable interpretation
+    Returns:
+        str: Human-readable interpretation
 
-  Interpretation scale based on Landis & Koch (1977):
-  - < 0.00: Poor agreement
-  - 0.00-0.20: Slight agreement
-  - 0.21-0.40: Fair agreement
-  - 0.41-0.60: Moderate agreement
-  - 0.61-0.80: Substantial agreement
-  - 0.81-1.00: Almost perfect agreement
-  """
-  if kappa < 0.00:
-    return 'Poor agreement (systematic disagreement)'
-  elif kappa <= 0.20:
-    return 'Slight agreement'
-  elif kappa <= 0.40:
-    return 'Fair agreement'
-  elif kappa <= 0.60:
-    return 'Moderate agreement'
-  elif kappa <= 0.80:
-    return 'Substantial agreement'
-  else:
-    return 'Almost perfect agreement'
+    Interpretation scale based on Landis & Koch (1977):
+    - < 0.00: Poor agreement
+    - 0.00-0.20: Slight agreement
+    - 0.21-0.40: Fair agreement
+    - 0.41-0.60: Moderate agreement
+    - 0.61-0.80: Substantial agreement
+    - 0.81-1.00: Almost perfect agreement
+    """
+    if kappa < 0.00:
+        return "Poor agreement (systematic disagreement)"
+    if kappa <= 0.20:
+        return "Slight agreement"
+    if kappa <= 0.40:
+        return "Fair agreement"
+    if kappa <= 0.60:
+        return "Moderate agreement"
+    if kappa <= 0.80:
+        return "Substantial agreement"
+    return "Almost perfect agreement"
 
 
 def is_cohens_kappa_acceptable(kappa: float, threshold: float = 0.3) -> bool:
-  """Check if Cohen's Kappa meets acceptable threshold for workshop progression.
+    """Check if Cohen's Kappa meets acceptable threshold for workshop progression.
 
-  Args:
-      kappa: Cohen's Kappa value
-      threshold: Minimum acceptable threshold (default: 0.3)
+    Args:
+        kappa: Cohen's Kappa value
+        threshold: Minimum acceptable threshold (default: 0.3)
 
-  Returns:
-      bool: True if kappa meets threshold, False otherwise
+    Returns:
+        bool: True if kappa meets threshold, False otherwise
 
-  Note:
-      The default threshold of 0.3 is used for consistency with Krippendorff's Alpha,
-      though Cohen's Kappa typically uses different thresholds (e.g., 0.4 for fair agreement).
-  """
-  return kappa >= threshold
+    Note:
+        The default threshold of 0.3 is used for consistency with Krippendorff's Alpha,
+        though Cohen's Kappa typically uses different thresholds (e.g., 0.4 for fair agreement).
+    """
+    return kappa >= threshold

--- a/server/services/database_service.py
+++ b/server/services/database_service.py
@@ -4,1226 +4,1260 @@ import logging
 import os
 import uuid
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from sqlalchemy import and_
 from sqlalchemy.orm import Session
 
 from server.database import (
-  AnnotationDB,
-  DatabricksTokenDB,
-  DiscoveryFindingDB,
-  FacilitatorConfigDB,
-  JudgeEvaluationDB,
-  JudgePromptDB,
-  MLflowIntakeConfigDB,
-  ParticipantNoteDB,
-  RubricDB,
-  TraceDB,
-  UserDB,
-  UserDiscoveryCompletionDB,
-  UserTraceOrderDB,
-  WorkshopDB,
-  WorkshopParticipantDB,
+    AnnotationDB,
+    DatabricksTokenDB,
+    DiscoveryFindingDB,
+    FacilitatorConfigDB,
+    JudgeEvaluationDB,
+    JudgePromptDB,
+    MLflowIntakeConfigDB,
+    ParticipantNoteDB,
+    RubricDB,
+    TraceDB,
+    UserDB,
+    UserDiscoveryCompletionDB,
+    UserTraceOrderDB,
+    WorkshopDB,
+    WorkshopParticipantDB,
 )
 from server.models import (
-  Annotation,
-  AnnotationCreate,
-  DiscoveryFinding,
-  DiscoveryFindingCreate,
-  FacilitatorConfig,
-  FacilitatorConfigCreate,
-  JudgeEvaluation,
-  JudgePrompt,
-  JudgePromptCreate,
-  JudgeType,
-  MLflowIntakeConfig,
-  MLflowIntakeStatus,
-  ParticipantNote,
-  ParticipantNoteCreate,
-  Rubric,
-  RubricCreate,
-  Trace,
-  TraceUpload,
-  User,
-  UserCreate,
-  UserRole,
-  UserStatus,
-  UserTraceOrder,
-  Workshop,
-  WorkshopCreate,
-  WorkshopParticipant,
-  WorkshopPhase,
+    Annotation,
+    AnnotationCreate,
+    DiscoveryFinding,
+    DiscoveryFindingCreate,
+    FacilitatorConfig,
+    FacilitatorConfigCreate,
+    JudgeEvaluation,
+    JudgePrompt,
+    JudgePromptCreate,
+    JudgeType,
+    MLflowIntakeConfig,
+    MLflowIntakeStatus,
+    ParticipantNote,
+    ParticipantNoteCreate,
+    Rubric,
+    RubricCreate,
+    Trace,
+    TraceUpload,
+    User,
+    UserCreate,
+    UserRole,
+    UserStatus,
+    UserTraceOrder,
+    Workshop,
+    WorkshopCreate,
+    WorkshopParticipant,
+    WorkshopPhase,
 )
 from server.services.token_storage_service import token_storage
 from server.utils.config import get_facilitator_config
 from server.utils.password import generate_default_password, hash_password, verify_password
 
-
 logger = logging.getLogger(__name__)
 
 
-def _retry_mlflow_operation(operation, max_retries: int = 3, base_delay: float = 1.0, description: str = "MLflow operation"):
-  """Retry an MLflow operation with exponential backoff.
+def _retry_mlflow_operation(
+    operation, max_retries: int = 3, base_delay: float = 1.0, description: str = "MLflow operation"
+):
+    """Retry an MLflow operation with exponential backoff.
 
-  Args:
-    operation: Callable that performs the MLflow operation
-    max_retries: Maximum number of retry attempts (default: 3)
-    base_delay: Base delay in seconds between retries (default: 1.0)
-    description: Description for logging purposes
+    Args:
+      operation: Callable that performs the MLflow operation
+      max_retries: Maximum number of retry attempts (default: 3)
+      base_delay: Base delay in seconds between retries (default: 1.0)
+      description: Description for logging purposes
 
-  Returns:
-    Result of the operation if successful, None if all retries fail
-  """
-  import time
+    Returns:
+      Result of the operation if successful, None if all retries fail
+    """
+    import time
 
-  for attempt in range(max_retries):
-    try:
-      return operation()
-    except Exception as e:
-      error_str = str(e).lower()
+    for attempt in range(max_retries):
+        try:
+            return operation()
+        except Exception as e:
+            error_str = str(e).lower()
 
-      # Don't retry on certain errors
-      if "maximum allowed assessments" in error_str:
-        logger.warning(f"{description} hit assessment limit: {e}")
-        return None
-      if "not found" in error_str or "404" in error_str:
-        logger.warning(f"{description} resource not found: {e}")
-        return None
-      if "unauthorized" in error_str or "401" in error_str or "403" in error_str:
-        logger.warning(f"{description} auth error (not retrying): {e}")
-        return None
+            # Don't retry on certain errors
+            if "maximum allowed assessments" in error_str:
+                logger.warning(f"{description} hit assessment limit: {e}")
+                return None
+            if "not found" in error_str or "404" in error_str:
+                logger.warning(f"{description} resource not found: {e}")
+                return None
+            if "unauthorized" in error_str or "401" in error_str or "403" in error_str:
+                logger.warning(f"{description} auth error (not retrying): {e}")
+                return None
 
-      # Retry on transient errors
-      if attempt < max_retries - 1:
-        delay = base_delay * (2 ** attempt)  # Exponential backoff
-        logger.warning(f"{description} failed (attempt {attempt + 1}/{max_retries}), retrying in {delay}s: {e}")
-        time.sleep(delay)
-      else:
-        logger.error(f"{description} failed after {max_retries} attempts: {e}")
+            # Retry on transient errors
+            if attempt < max_retries - 1:
+                delay = base_delay * (2**attempt)  # Exponential backoff
+                logger.warning(f"{description} failed (attempt {attempt + 1}/{max_retries}), retrying in {delay}s: {e}")
+                time.sleep(delay)
+            else:
+                logger.error(f"{description} failed after {max_retries} attempts: {e}")
 
-  return None
+    return None
 
 
 class DatabaseService:
-  """Service layer for database operations."""
+    """Service layer for database operations."""
 
-  def __init__(self, db: Session):
-    self.db = db
+    def __init__(self, db: Session):
+        self.db = db
 
-  # Workshop operations
-  def create_workshop(self, workshop_data: WorkshopCreate) -> Workshop:
-    """Create a new workshop in the database."""
-    workshop_id = str(uuid.uuid4())
-    db_workshop = WorkshopDB(
-      id=workshop_id,
-      name=workshop_data.name,
-      description=workshop_data.description,
-      facilitator_id=workshop_data.facilitator_id,
-    )
-    self.db.add(db_workshop)
-    self.db.commit()
-    self.db.refresh(db_workshop)
-
-    # Use _workshop_from_db to ensure all fields are properly populated
-    return self._workshop_from_db(db_workshop)
-
-  def _workshop_from_db(self, db_workshop: WorkshopDB) -> Workshop:
-    """Convert a database workshop object to a Workshop model."""
-    return Workshop(
-      id=db_workshop.id,
-      name=db_workshop.name,
-      description=db_workshop.description,
-      facilitator_id=db_workshop.facilitator_id,
-      status=db_workshop.status,
-      current_phase=db_workshop.current_phase,
-      completed_phases=db_workshop.completed_phases or [],
-      discovery_started=db_workshop.discovery_started or False,
-      annotation_started=db_workshop.annotation_started or False,
-      active_discovery_trace_ids=db_workshop.active_discovery_trace_ids or [],
-      active_annotation_trace_ids=db_workshop.active_annotation_trace_ids or [],
-      discovery_randomize_traces=getattr(db_workshop, 'discovery_randomize_traces', False) or False,
-      annotation_randomize_traces=getattr(db_workshop, 'annotation_randomize_traces', False) or False,
-      judge_name=db_workshop.judge_name or 'workshop_judge',
-      input_jsonpath=getattr(db_workshop, 'input_jsonpath', None),
-      output_jsonpath=getattr(db_workshop, 'output_jsonpath', None),
-      auto_evaluation_job_id=getattr(db_workshop, 'auto_evaluation_job_id', None),
-      auto_evaluation_prompt=getattr(db_workshop, 'auto_evaluation_prompt', None),
-      auto_evaluation_model=getattr(db_workshop, 'auto_evaluation_model', None),
-      show_participant_notes=getattr(db_workshop, 'show_participant_notes', False) or False,
-      created_at=db_workshop.created_at,
-    )
-
-  def get_workshop(self, workshop_id: str) -> Optional[Workshop]:
-    """Get a workshop by ID."""
-    db_workshop = self.db.query(WorkshopDB).filter(WorkshopDB.id == workshop_id).first()
-    if not db_workshop:
-      return None
-
-    return self._workshop_from_db(db_workshop)
-
-  def list_workshops(self, facilitator_id: Optional[str] = None) -> List[Workshop]:
-    """List all workshops, optionally filtered by facilitator.
-    
-    Args:
-        facilitator_id: If provided, only return workshops created by this facilitator
-        
-    Returns:
-        List of Workshop objects sorted by creation date (newest first)
-    """
-    query = self.db.query(WorkshopDB)
-    
-    if facilitator_id:
-      query = query.filter(WorkshopDB.facilitator_id == facilitator_id)
-    
-    # Order by creation date, newest first
-    query = query.order_by(WorkshopDB.created_at.desc())
-    
-    db_workshops = query.all()
-    return [self._workshop_from_db(w) for w in db_workshops]
-
-  def get_workshops_for_user(self, user_id: str) -> List[Workshop]:
-    """Get all workshops that a user is part of (either as facilitator or participant).
-    
-    Args:
-        user_id: The user ID to find workshops for
-        
-    Returns:
-        List of Workshop objects the user has access to
-    """
-    from server.database import UserDB, WorkshopDB
-    
-    # Get workshops where user is the facilitator
-    facilitator_workshops = self.db.query(WorkshopDB).filter(
-      WorkshopDB.facilitator_id == user_id
-    ).all()
-    
-    # Get workshops where user has been added as a participant
-    participant_workshop_ids = self.db.query(UserDB.workshop_id).filter(
-      UserDB.id == user_id,
-      UserDB.workshop_id.isnot(None)
-    ).distinct().all()
-    
-    participant_workshop_ids = [w[0] for w in participant_workshop_ids if w[0]]
-    
-    participant_workshops = self.db.query(WorkshopDB).filter(
-      WorkshopDB.id.in_(participant_workshop_ids)
-    ).all() if participant_workshop_ids else []
-    
-    # Combine and deduplicate
-    all_workshops = {w.id: w for w in facilitator_workshops}
-    for w in participant_workshops:
-      if w.id not in all_workshops:
-        all_workshops[w.id] = w
-    
-    # Sort by creation date, newest first
-    sorted_workshops = sorted(all_workshops.values(), key=lambda w: w.created_at or '', reverse=True)
-    
-    return [self._workshop_from_db(w) for w in sorted_workshops]
-
-  def update_workshop_judge_name(self, workshop_id: str, judge_name: str) -> Optional[Workshop]:
-    """Update the judge name for a workshop."""
-    db_workshop = self.db.query(WorkshopDB).filter(WorkshopDB.id == workshop_id).first()
-    if not db_workshop:
-      return None
-
-    db_workshop.judge_name = judge_name
-    self.db.commit()
-    self.db.refresh(db_workshop)
-
-    return self.get_workshop(workshop_id)
-
-  def update_workshop_jsonpath_settings(
-    self,
-    workshop_id: str,
-    input_jsonpath: Optional[str] = None,
-    output_jsonpath: Optional[str] = None,
-  ) -> Optional[Workshop]:
-    """Update the JSONPath settings for trace display in a workshop.
-
-    Args:
-      workshop_id: The workshop ID
-      input_jsonpath: JSONPath expression for extracting trace input display (or None to clear)
-      output_jsonpath: JSONPath expression for extracting trace output display (or None to clear)
-
-    Returns:
-      Updated Workshop model or None if workshop not found
-    """
-    db_workshop = self.db.query(WorkshopDB).filter(WorkshopDB.id == workshop_id).first()
-    if not db_workshop:
-      return None
-
-    # Update the JSONPath fields (empty string is treated same as None)
-    db_workshop.input_jsonpath = input_jsonpath if input_jsonpath and input_jsonpath.strip() else None
-    db_workshop.output_jsonpath = output_jsonpath if output_jsonpath and output_jsonpath.strip() else None
-
-    self.db.commit()
-    self.db.refresh(db_workshop)
-
-    return self.get_workshop(workshop_id)
-
-  def update_workshop_phase(self, workshop_id: str, new_phase: WorkshopPhase) -> Optional[Workshop]:
-    """Update the current phase of a workshop."""
-    db_workshop = self.db.query(WorkshopDB).filter(WorkshopDB.id == workshop_id).first()
-    if not db_workshop:
-      return None
-
-    db_workshop.current_phase = new_phase
-    self.db.commit()
-    self.db.refresh(db_workshop)
-
-    return Workshop(
-      id=db_workshop.id,
-      name=db_workshop.name,
-      description=db_workshop.description,
-      facilitator_id=db_workshop.facilitator_id,
-      status=db_workshop.status,
-      current_phase=db_workshop.current_phase,
-      completed_phases=db_workshop.completed_phases or [],
-      discovery_started=db_workshop.discovery_started or False,
-      annotation_started=db_workshop.annotation_started or False,
-      active_discovery_trace_ids=db_workshop.active_discovery_trace_ids or [],
-      active_annotation_trace_ids=db_workshop.active_annotation_trace_ids or [],
-      created_at=db_workshop.created_at,
-    )
-
-  def update_phase_started(
-    self,
-    workshop_id: str,
-    discovery_started: Optional[bool] = None,
-    annotation_started: Optional[bool] = None,
-  ) -> Optional[Workshop]:
-    """Update the phase started flags for a workshop."""
-    db_workshop = self.db.query(WorkshopDB).filter(WorkshopDB.id == workshop_id).first()
-    if not db_workshop:
-      return None
-
-    if discovery_started is not None:
-      db_workshop.discovery_started = discovery_started
-    if annotation_started is not None:
-      db_workshop.annotation_started = annotation_started
-
-    self.db.commit()
-    self.db.refresh(db_workshop)
-
-    return Workshop(
-      id=db_workshop.id,
-      name=db_workshop.name,
-      description=db_workshop.description,
-      facilitator_id=db_workshop.facilitator_id,
-      status=db_workshop.status,
-      current_phase=db_workshop.current_phase,
-      completed_phases=db_workshop.completed_phases or [],
-      discovery_started=db_workshop.discovery_started or False,
-      annotation_started=db_workshop.annotation_started or False,
-      active_discovery_trace_ids=db_workshop.active_discovery_trace_ids or [],
-      active_annotation_trace_ids=db_workshop.active_annotation_trace_ids or [],
-      created_at=db_workshop.created_at,
-    )
-
-  def update_active_discovery_traces(self, workshop_id: str, trace_ids: List[str]) -> Optional[Workshop]:
-    """Update the active discovery trace IDs for a workshop."""
-    db_workshop = self.db.query(WorkshopDB).filter(WorkshopDB.id == workshop_id).first()
-    if not db_workshop:
-      return None
-
-    db_workshop.active_discovery_trace_ids = trace_ids
-    self.db.commit()
-    self.db.refresh(db_workshop)
-
-    return self._workshop_from_db(db_workshop)
-
-  def update_active_annotation_traces(self, workshop_id: str, trace_ids: List[str]) -> Optional[Workshop]:
-    """Update the active annotation trace IDs for a workshop."""
-    db_workshop = self.db.query(WorkshopDB).filter(WorkshopDB.id == workshop_id).first()
-    if not db_workshop:
-      return None
-
-    db_workshop.active_annotation_trace_ids = trace_ids
-    self.db.commit()
-    self.db.refresh(db_workshop)
-
-    return self._workshop_from_db(db_workshop)
-
-  def update_discovery_randomize_setting(self, workshop_id: str, randomize: bool) -> Optional[Workshop]:
-    """Update the discovery trace randomization setting for a workshop."""
-    db_workshop = self.db.query(WorkshopDB).filter(WorkshopDB.id == workshop_id).first()
-    if not db_workshop:
-      return None
-
-    db_workshop.discovery_randomize_traces = randomize
-    self.db.commit()
-    self.db.refresh(db_workshop)
-
-    return self._workshop_from_db(db_workshop)
-
-  def update_annotation_randomize_setting(self, workshop_id: str, randomize: bool) -> Optional[Workshop]:
-    """Update the annotation trace randomization setting for a workshop."""
-    db_workshop = self.db.query(WorkshopDB).filter(WorkshopDB.id == workshop_id).first()
-    if not db_workshop:
-      return None
-
-    db_workshop.annotation_randomize_traces = randomize
-    self.db.commit()
-    self.db.refresh(db_workshop)
-
-    return self._workshop_from_db(db_workshop)
-
-  def update_auto_evaluation_job(self, workshop_id: str, job_id: str, prompt: str, model: Optional[str] = None) -> Optional[Workshop]:
-    """Update the auto-evaluation job ID, derived prompt, and model for a workshop."""
-    db_workshop = self.db.query(WorkshopDB).filter(WorkshopDB.id == workshop_id).first()
-    if not db_workshop:
-      return None
-
-    db_workshop.auto_evaluation_job_id = job_id
-    db_workshop.auto_evaluation_prompt = prompt
-    if model:
-      db_workshop.auto_evaluation_model = model
-    self.db.commit()
-    self.db.refresh(db_workshop)
-
-    return self._workshop_from_db(db_workshop)
-
-  def get_auto_evaluation_job_id(self, workshop_id: str) -> Optional[str]:
-    """Get the auto-evaluation job ID for a workshop."""
-    db_workshop = self.db.query(WorkshopDB).filter(WorkshopDB.id == workshop_id).first()
-    if not db_workshop:
-      return None
-    return db_workshop.auto_evaluation_job_id
-
-  def get_auto_evaluation_prompt(self, workshop_id: str) -> Optional[str]:
-    """Get the auto-evaluation derived prompt for a workshop."""
-    db_workshop = self.db.query(WorkshopDB).filter(WorkshopDB.id == workshop_id).first()
-    if not db_workshop:
-      return None
-    return db_workshop.auto_evaluation_prompt
-
-  def get_auto_evaluation_model(self, workshop_id: str) -> Optional[str]:
-    """Get the auto-evaluation model for a workshop."""
-    db_workshop = self.db.query(WorkshopDB).filter(WorkshopDB.id == workshop_id).first()
-    if not db_workshop:
-      return None
-    return getattr(db_workshop, 'auto_evaluation_model', None)
-
-  # Trace operations
-  def add_traces(self, workshop_id: str, traces: List[TraceUpload]) -> List[Trace]:
-    """Add traces to a workshop."""
-    db_traces = []
-
-    for trace_data in traces:
-      trace_id = str(uuid.uuid4())
-      db_trace = TraceDB(
-        id=trace_id,
-        workshop_id=workshop_id,
-        input=trace_data.input,
-        output=trace_data.output,
-        context=trace_data.context,
-        trace_metadata=trace_data.trace_metadata,
-        mlflow_trace_id=trace_data.mlflow_trace_id,
-        mlflow_experiment_id=trace_data.mlflow_experiment_id,
-      )
-      self.db.add(db_trace)
-      db_traces.append(db_trace)
-
-    self.db.commit()
-
-    # Refresh and create response objects after commit
-    created_traces = []
-    for db_trace in db_traces:
-      self.db.refresh(db_trace)
-      created_traces.append(
-        Trace(
-          id=db_trace.id,
-          workshop_id=db_trace.workshop_id,
-          input=db_trace.input,
-          output=db_trace.output,
-          context=db_trace.context,
-          trace_metadata=db_trace.trace_metadata,
-          mlflow_trace_id=db_trace.mlflow_trace_id,
-          created_at=db_trace.created_at,
+    # Workshop operations
+    def create_workshop(self, workshop_data: WorkshopCreate) -> Workshop:
+        """Create a new workshop in the database."""
+        workshop_id = str(uuid.uuid4())
+        db_workshop = WorkshopDB(
+            id=workshop_id,
+            name=workshop_data.name,
+            description=workshop_data.description,
+            facilitator_id=workshop_data.facilitator_id,
         )
-      )
-
-    return created_traces
-
-  def get_traces(self, workshop_id: str) -> List[Trace]:
-    """Get all traces for a workshop in chronological order."""
-    db_traces = self.db.query(TraceDB).filter(TraceDB.workshop_id == workshop_id).order_by(TraceDB.created_at).all()
-
-    return [self._trace_from_db(db_trace) for db_trace in db_traces]
-
-  def get_traces_by_experiment(self, workshop_id: str, experiment_id: str) -> List[Trace]:
-    """Get all traces for a workshop that were ingested from a specific MLflow experiment."""
-    db_traces = self.db.query(TraceDB).filter(TraceDB.workshop_id == workshop_id, TraceDB.mlflow_experiment_id == experiment_id).all()
-
-    return [self._trace_from_db(db_trace) for db_trace in db_traces]
-
-  def get_active_discovery_traces(self, workshop_id: str, user_id: str) -> List[Trace]:
-    """Get only the active discovery traces for a workshop.
-
-    If randomization is enabled for the workshop, each user sees traces in a different 
-    randomized order (deterministic per user based on user_id seed).
-    If randomization is disabled (default), all users see traces in the same chronological order.
-
-    Args:
-        workshop_id: The workshop ID
-        user_id: The user ID (required for personalized trace ordering when randomization is enabled)
-
-    Returns:
-        List of traces in appropriate order
-
-    Raises:
-        ValueError: If user_id is not provided
-    """
-    import time
-
-    if not user_id:
-      raise ValueError('user_id is required for fetching discovery traces')
-
-    start_time = time.time()
-
-    # Get workshop data (cached)
-    workshop = self.get_workshop(workshop_id)
-    if not workshop or not workshop.active_discovery_trace_ids:
-      return []
-
-    active_trace_ids = workshop.active_discovery_trace_ids
-    
-    # Check if randomization is enabled for this workshop
-    randomize_enabled = getattr(workshop, 'discovery_randomize_traces', False) or False
-
-    if not randomize_enabled:
-      # Randomization OFF: Return traces in chronological order (same for all users)
-      # Fetch traces in the order they appear in active_discovery_trace_ids
-      db_traces = self.db.query(TraceDB).filter(TraceDB.id.in_(active_trace_ids)).all()
-      
-      # Create ordered result - preserve the chronological order from active_discovery_trace_ids
-      trace_map = {t.id: t for t in db_traces}
-      result = []
-      for tid in active_trace_ids:
-        if tid in trace_map:
-          result.append(self._trace_from_db(trace_map[tid]))
-
-      # Log performance metrics
-      load_time = time.time() - start_time
-      if load_time > 0.1:
-        print(f'⚠️ Slow trace load: {load_time:.3f}s for {len(result)} traces (user: {user_id[:8]}..., no randomization)')
-
-      return result
-
-    # Randomization ON: Get or create user-specific trace order
-    user_order = self.get_user_trace_order(workshop_id, user_id)
-    
-    if not user_order:
-      # Create new user trace order with randomized discovery traces
-      user_order = self.create_user_trace_order(workshop_id, user_id)
-      # Generate randomized order for this user
-      user_order.discovery_traces = self._generate_randomized_trace_order(active_trace_ids, user_id)
-      self.update_user_trace_order(user_order)
-    elif not user_order.discovery_traces or set(user_order.discovery_traces) != set(active_trace_ids):
-      # Update if trace set has changed (e.g., new traces added)
-      # Preserve existing order for traces already seen, add new ones randomly
-      existing_traces = [tid for tid in user_order.discovery_traces if tid in active_trace_ids]
-      new_traces = [tid for tid in active_trace_ids if tid not in user_order.discovery_traces]
-      
-      # Randomize only the new traces
-      randomized_new_traces = self._generate_randomized_trace_order(new_traces, user_id)
-      
-      # Combine: existing traces first (in their original order), then new randomized traces
-      user_order.discovery_traces = existing_traces + randomized_new_traces
-      self.update_user_trace_order(user_order)
-
-    # Use the user's personalized trace order
-    ordered_ids = user_order.discovery_traces
-
-    # Optimized trace fetching - single query with IN clause
-    if not ordered_ids:
-      return []
-
-    db_traces = self.db.query(TraceDB).filter(TraceDB.id.in_(ordered_ids)).all()
-
-    # Create ordered result efficiently - preserve the user-specific order
-    trace_map = {t.id: t for t in db_traces}
-    result = []
-    for tid in ordered_ids:
-      if tid in trace_map:
-        result.append(self._trace_from_db(trace_map[tid]))
-
-    # Log performance metrics
-    load_time = time.time() - start_time
-    if load_time > 0.1:  # Log slow requests
-      print(f'⚠️ Slow trace load: {load_time:.3f}s for {len(result)} traces (user: {user_id[:8]}..., randomized)')
-
-    return result
-
-  def _generate_randomized_trace_order(self, trace_ids: List[str], user_id: str) -> List[str]:
-    """Generate a randomized order of trace IDs for a specific user.
-
-    Uses the user_id combined with the sorted trace IDs as a seed to ensure:
-    1. Consistent randomization per user for the same set of traces
-    2. Different randomization when the trace set changes
-
-    Args:
-        trace_ids: List of trace IDs to randomize
-        user_id: User ID to use as random seed
-
-    Returns:
-        Randomized list of trace IDs
-    """
-    import random
-    import hashlib
-
-    if not trace_ids:
-      return []
-
-    # Create a deterministic seed from user_id + sorted trace IDs
-    # This ensures that the same user sees the same order for the same set of traces,
-    # but different traces (e.g., newly added ones) will have different randomization
-    sorted_trace_ids = sorted(trace_ids)
-    seed_string = f"{user_id}::{','.join(sorted_trace_ids)}"
-    seed = int(hashlib.md5(seed_string.encode()).hexdigest(), 16) % (2**31)
-    
-    # Create a new random instance with the user-specific seed
-    rng = random.Random(seed)
-    
-    # Create a copy and shuffle it
-    randomized_ids = trace_ids.copy()
-    rng.shuffle(randomized_ids)
-    
-    return randomized_ids
-
-  def get_active_annotation_traces(self, workshop_id: str, user_id: str) -> List[Trace]:
-    """Get only the active annotation traces for a workshop.
-
-    If randomization is enabled for the workshop, each user sees traces in a different 
-    randomized order (deterministic per user based on user_id seed).
-    If randomization is disabled (default), all users see traces in the same chronological order.
-
-    Args:
-        workshop_id: The workshop ID
-        user_id: The user ID (required for personalized trace ordering when randomization is enabled)
-
-    Returns:
-        List of traces in appropriate order
-
-    Raises:
-        ValueError: If user_id is not provided
-    """
-    import time
-
-    if not user_id:
-      raise ValueError('user_id is required for fetching annotation traces')
-
-    start_time = time.time()
-
-    workshop = self.get_workshop(workshop_id)
-    if not workshop or not workshop.active_annotation_trace_ids:
-      return []
-
-    active_trace_ids = workshop.active_annotation_trace_ids
-    
-    # Check if randomization is enabled for this workshop
-    randomize_enabled = getattr(workshop, 'annotation_randomize_traces', False) or False
-
-    if not randomize_enabled:
-      # Randomization OFF: Return traces in chronological order (same for all users)
-      # Fetch traces in the order they appear in active_annotation_trace_ids
-      db_traces = self.db.query(TraceDB).filter(TraceDB.id.in_(active_trace_ids)).all()
-      
-      # Create ordered result - preserve the chronological order from active_annotation_trace_ids
-      trace_map = {t.id: t for t in db_traces}
-      result = []
-      for tid in active_trace_ids:
-        if tid in trace_map:
-          result.append(self._trace_from_db(trace_map[tid]))
-
-      # Log performance metrics
-      load_time = time.time() - start_time
-      if load_time > 0.1:
-        print(f'⚠️ Slow annotation trace load: {load_time:.3f}s for {len(result)} traces (user: {user_id[:8]}..., no randomization)')
-
-      return result
-
-    # Randomization ON: Get or create user-specific trace order
-    user_order = self.get_user_trace_order(workshop_id, user_id)
-    
-    if not user_order:
-      # Create new user trace order with randomized annotation traces
-      user_order = self.create_user_trace_order(workshop_id, user_id)
-      # Generate randomized order for this user
-      user_order.annotation_traces = self._generate_randomized_trace_order(active_trace_ids, user_id)
-      self.update_user_trace_order(user_order)
-    elif not user_order.annotation_traces or set(user_order.annotation_traces) != set(active_trace_ids):
-      # Update if trace set has changed (e.g., new traces added)
-      # Preserve existing order for traces already seen, add new ones randomly
-      existing_traces = [tid for tid in user_order.annotation_traces if tid in active_trace_ids]
-      new_traces = [tid for tid in active_trace_ids if tid not in user_order.annotation_traces]
-      
-      # Randomize only the new traces
-      randomized_new_traces = self._generate_randomized_trace_order(new_traces, user_id)
-      
-      # Combine: existing traces first (in their original order), then new randomized traces
-      user_order.annotation_traces = existing_traces + randomized_new_traces
-      self.update_user_trace_order(user_order)
-
-    # Use the user's personalized trace order
-    ordered_ids = user_order.annotation_traces
-
-    # Optimized trace fetching - single query with IN clause
-    if not ordered_ids:
-      return []
-
-    db_traces = self.db.query(TraceDB).filter(TraceDB.id.in_(ordered_ids)).all()
-
-    # Create ordered result efficiently - preserve the user-specific order
-    trace_map = {t.id: t for t in db_traces}
-    result = []
-    for tid in ordered_ids:
-      if tid in trace_map:
-        result.append(self._trace_from_db(trace_map[tid]))
-
-    # Log performance metrics
-    load_time = time.time() - start_time
-    if load_time > 0.1:  # Log slow requests
-      print(f'⚠️ Slow annotation trace load: {load_time:.3f}s for {len(result)} traces (user: {user_id[:8]}..., randomized)')
-
-    return result
-
-  # Discovery finding operations
-  def add_finding(self, workshop_id: str, finding_data: DiscoveryFindingCreate) -> DiscoveryFinding:
-    """Add or update a discovery finding (upsert) with automatic retry on failure.
-
-    Retries are handled transparently in the backend - the frontend only sees
-    success or failure after all retries are exhausted.
-
-    Works with both SQLite and PostgreSQL (Lakebase) backends.
-
-    Handles:
-    - IntegrityError: Race conditions when multiple users save simultaneously
-    - OperationalError: Database locked/busy (SQLite) or deadlocks (PostgreSQL)
-    - General exceptions: Network issues, timeouts, etc.
-    """
-    from sqlalchemy.exc import IntegrityError, OperationalError
-    import time
-    
-    finding_id = str(uuid.uuid4())
-    max_retries = 3
-    base_delay = 0.2  # Base delay in seconds
-    
-    logger.info(f"📝 add_finding called: workshop_id={workshop_id}, trace_id={finding_data.trace_id}, user_id={finding_data.user_id}")
-    
-    last_error = None
-    for attempt in range(max_retries):
-      try:
-        # First, try to find existing record to preserve its ID
-        # Note: with_for_update() is not used for cross-database compatibility
-        # (SQLite uses file-level locking; PostgreSQL supports row-level but this works for both)
-        existing_finding = self.db.query(DiscoveryFindingDB).filter(
-          DiscoveryFindingDB.workshop_id == workshop_id,
-          DiscoveryFindingDB.trace_id == finding_data.trace_id,
-          DiscoveryFindingDB.user_id == finding_data.user_id
-        ).first()
-        
-        if existing_finding:
-          # Update existing finding
-          logger.info(f"🔄 Updating existing finding: id={existing_finding.id}")
-          existing_finding.insight = finding_data.insight
-          self.db.commit()
-          self.db.refresh(existing_finding)
-          db_finding = existing_finding
-          logger.info(f"✅ Finding updated successfully: id={db_finding.id}")
-        else:
-          # Create new finding
-          logger.info(f"🆕 Creating new finding (attempt {attempt + 1}/{max_retries})")
-          db_finding = DiscoveryFindingDB(
-            id=finding_id,
-            workshop_id=workshop_id,
-            trace_id=finding_data.trace_id,
-            user_id=finding_data.user_id,
-            insight=finding_data.insight,
-          )
-          self.db.add(db_finding)
-          self.db.commit()
-          self.db.refresh(db_finding)
-          logger.info(f"✅ Finding created successfully: id={db_finding.id}")
-
-        return DiscoveryFinding(
-          id=db_finding.id,
-          workshop_id=db_finding.workshop_id,
-          trace_id=db_finding.trace_id,
-          user_id=db_finding.user_id,
-          insight=db_finding.insight,
-          created_at=db_finding.created_at,
-        )
-        
-      except IntegrityError as e:
-        # Handle race condition - another request inserted the same record
-        last_error = e
-        logger.warning(f"⚠️ IntegrityError on finding save (attempt {attempt + 1}/{max_retries}): {e}")
-        self.db.rollback()
-        if attempt < max_retries - 1:
-          delay = base_delay * (2 ** attempt)  # Exponential backoff: 0.2, 0.4, 0.8s
-          logger.info(f"🔄 Retrying in {delay:.1f}s...")
-          time.sleep(delay)
-          continue
-        else:
-          # On final attempt, try to fetch and update the existing record
-          logger.info("🔄 Final attempt: fetching existing finding to update")
-          try:
-            existing = self.db.query(DiscoveryFindingDB).filter(
-              DiscoveryFindingDB.workshop_id == workshop_id,
-              DiscoveryFindingDB.trace_id == finding_data.trace_id,
-              DiscoveryFindingDB.user_id == finding_data.user_id
-            ).first()
-            if existing:
-              existing.insight = finding_data.insight
-              self.db.commit()
-              self.db.refresh(existing)
-              logger.info(f"✅ Finding updated after conflict: id={existing.id}")
-              return DiscoveryFinding(
-                id=existing.id,
-                workshop_id=existing.workshop_id,
-                trace_id=existing.trace_id,
-                user_id=existing.user_id,
-                insight=existing.insight,
-                created_at=existing.created_at,
-              )
-          except Exception as final_error:
-            logger.error(f"❌ Final recovery attempt also failed: {final_error}")
-          logger.error(f"❌ Failed to save finding after all retries: {e}")
-          raise e
-          
-      except OperationalError as e:
-        # Handle database contention errors (locked/busy for SQLite, deadlocks for PostgreSQL)
-        last_error = e
-        error_msg = str(e).lower()
-        if 'locked' in error_msg or 'busy' in error_msg or 'deadlock' in error_msg:
-          logger.warning(f"⚠️ Database contention on finding save (attempt {attempt + 1}/{max_retries}): {e}")
-        else:
-          logger.warning(f"⚠️ OperationalError on finding save (attempt {attempt + 1}/{max_retries}): {e}")
-        self.db.rollback()
-        if attempt < max_retries - 1:
-          delay = base_delay * (2 ** attempt) + 0.5  # Extra delay for database contention
-          logger.info(f"🔄 Retrying in {delay:.1f}s...")
-          time.sleep(delay)
-          continue
-        raise e
-        
-      except Exception as e:
-        last_error = e
-        logger.error(f"❌ Error saving finding (attempt {attempt + 1}/{max_retries}): {e}")
-        self.db.rollback()
-        if attempt < max_retries - 1:
-          delay = base_delay * (2 ** attempt)
-          logger.info(f"🔄 Retrying in {delay:.1f}s...")
-          time.sleep(delay)
-          continue
-        raise e
-    
-    # This shouldn't be reached, but just in case
-    logger.error(f"❌ Failed to save finding after all {max_retries} retries (loop exhausted)")
-    raise last_error or Exception("Failed to save finding after all retries")
-
-  def get_findings(self, workshop_id: str, user_id: Optional[str] = None) -> List[DiscoveryFinding]:
-    """Get discovery findings for a workshop, optionally filtered by user."""
-    query = self.db.query(DiscoveryFindingDB).filter(DiscoveryFindingDB.workshop_id == workshop_id)
-
-    # Filter by user_id if provided
-    if user_id:
-      query = query.filter(DiscoveryFindingDB.user_id == user_id)
-
-    db_findings = query.all()
-
-    return [
-      DiscoveryFinding(
-        id=db_finding.id,
-        workshop_id=db_finding.workshop_id,
-        trace_id=db_finding.trace_id,
-        user_id=db_finding.user_id,
-        insight=db_finding.insight,
-        created_at=db_finding.created_at,
-      )
-      for db_finding in db_findings
-    ]
-
-  def get_findings_with_user_details(self, workshop_id: str, user_id: Optional[str] = None) -> List[Dict[str, Any]]:
-    """Get discovery findings with user details for facilitator view."""
-    query = (
-      self.db.query(DiscoveryFindingDB, UserDB)
-      .join(UserDB, DiscoveryFindingDB.user_id == UserDB.id)
-      .filter(DiscoveryFindingDB.workshop_id == workshop_id)
-    )
-
-    # Filter by user_id if provided
-    if user_id:
-      query = query.filter(DiscoveryFindingDB.user_id == user_id)
-
-    results = query.all()
-
-    return [
-      {
-        'id': finding.id,
-        'workshop_id': finding.workshop_id,
-        'trace_id': finding.trace_id,
-        'user_id': finding.user_id,
-        'user_name': user.name,
-        'user_email': user.email,
-        'insight': finding.insight,
-        'created_at': finding.created_at,
-      }
-      for finding, user in results
-    ]
-
-  # Participant notes operations
-  def add_participant_note(self, workshop_id: str, note_data: ParticipantNoteCreate) -> ParticipantNote:
-    """Add a new participant note (always appends, never overwrites)."""
-    db_note = ParticipantNoteDB(
-      id=str(uuid.uuid4()),
-      workshop_id=workshop_id,
-      user_id=note_data.user_id,
-      trace_id=note_data.trace_id,
-      content=note_data.content,
-      phase=getattr(note_data, 'phase', 'discovery') or 'discovery',
-    )
-    self.db.add(db_note)
-    self.db.commit()
-    self.db.refresh(db_note)
-
-    # Get user name for the response
-    user = self.db.query(UserDB).filter(UserDB.id == db_note.user_id).first()
-
-    return ParticipantNote(
-      id=db_note.id,
-      workshop_id=db_note.workshop_id,
-      user_id=db_note.user_id,
-      trace_id=db_note.trace_id,
-      content=db_note.content,
-      phase=getattr(db_note, 'phase', 'discovery') or 'discovery',
-      user_name=user.name if user else None,
-      created_at=db_note.created_at,
-      updated_at=db_note.updated_at or db_note.created_at,
-    )
-
-  def get_participant_notes(self, workshop_id: str, user_id: Optional[str] = None, phase: Optional[str] = None) -> List[ParticipantNote]:
-    """Get participant notes for a workshop, optionally filtered by user and/or phase."""
-    query = (
-      self.db.query(ParticipantNoteDB, UserDB)
-      .outerjoin(UserDB, ParticipantNoteDB.user_id == UserDB.id)
-      .filter(ParticipantNoteDB.workshop_id == workshop_id)
-    )
-
-    if user_id:
-      query = query.filter(ParticipantNoteDB.user_id == user_id)
-
-    if phase:
-      query = query.filter(ParticipantNoteDB.phase == phase)
-
-    results = query.order_by(ParticipantNoteDB.created_at.desc()).all()
-
-    return [
-      ParticipantNote(
-        id=note.id,
-        workshop_id=note.workshop_id,
-        user_id=note.user_id,
-        trace_id=note.trace_id,
-        content=note.content,
-        phase=getattr(note, 'phase', 'discovery') or 'discovery',
-        user_name=user.name if user else None,
-        created_at=note.created_at,
-        updated_at=note.updated_at or note.created_at,
-      )
-      for note, user in results
-    ]
-
-  def delete_participant_note(self, note_id: str) -> bool:
-    """Delete a participant note by ID."""
-    note = self.db.query(ParticipantNoteDB).filter(ParticipantNoteDB.id == note_id).first()
-    if note:
-      self.db.delete(note)
-      self.db.commit()
-      return True
-    return False
-
-  # Rubric operations
-  def create_rubric(self, workshop_id: str, rubric_data: RubricCreate) -> Rubric:
-    """Create or update a rubric for a workshop."""
-    # Check if rubric already exists
-    existing_rubric = self.db.query(RubricDB).filter(RubricDB.workshop_id == workshop_id).first()
-
-    if existing_rubric:
-      # Update existing rubric
-      existing_rubric.question = rubric_data.question
-      existing_rubric.created_by = rubric_data.created_by
-      # Update judge type fields
-      if rubric_data.judge_type:
-        existing_rubric.judge_type = rubric_data.judge_type
-      if rubric_data.binary_labels:
-        existing_rubric.binary_labels = rubric_data.binary_labels
-      if rubric_data.rating_scale:
-        existing_rubric.rating_scale = rubric_data.rating_scale
-      self.db.commit()
-      self.db.refresh(existing_rubric)
-      db_rubric = existing_rubric
-    else:
-      # Create new rubric
-      rubric_id = str(uuid.uuid4())
-      db_rubric = RubricDB(
-        id=rubric_id,
-        workshop_id=workshop_id,
-        question=rubric_data.question,
-        created_by=rubric_data.created_by,
-        judge_type=rubric_data.judge_type or 'likert',
-        binary_labels=rubric_data.binary_labels,
-        rating_scale=rubric_data.rating_scale or 5,
-      )
-      self.db.add(db_rubric)
-      self.db.commit()
-      self.db.refresh(db_rubric)
-
-    # Auto-derive and save judge_name from the first rubric question title
-    # This ensures the backend always has the correct judge name for MLflow feedback
-    workshop_db = self.db.query(WorkshopDB).filter(WorkshopDB.id == workshop_id).first()
-    if workshop_db and (not workshop_db.judge_name or workshop_db.judge_name == 'workshop_judge'):
-      # Parse the rubric question to get the first title
-      questions = self._parse_rubric_questions(rubric_data.question)
-      if questions and questions[0].get('title'):
-        title = questions[0]['title']
-        # Convert to snake_case and append _judge
-        import re
-        snake_case = re.sub(r'[^a-z0-9]+', '_', title.lower()).strip('_')
-        derived_judge_name = f"{snake_case}_judge"
-        workshop_db.judge_name = derived_judge_name
+        self.db.add(db_workshop)
         self.db.commit()
-        logger.info("Auto-derived judge_name '%s' from rubric title '%s'", derived_judge_name, title)
+        self.db.refresh(db_workshop)
 
-    return Rubric(
-      id=db_rubric.id,
-      workshop_id=db_rubric.workshop_id,
-      question=db_rubric.question,
-      created_by=db_rubric.created_by,
-      created_at=db_rubric.created_at,
-    )
+        # Use _workshop_from_db to ensure all fields are properly populated
+        return self._workshop_from_db(db_workshop)
 
-  def update_rubric_question(self, workshop_id: str, question_id: str, title: str, description: str, judge_type: Optional[str] = None) -> Optional[Rubric]:
-    """Update a specific question in the rubric.
+    def _workshop_from_db(self, db_workshop: WorkshopDB) -> Workshop:
+        """Convert a database workshop object to a Workshop model."""
+        return Workshop(
+            id=db_workshop.id,
+            name=db_workshop.name,
+            description=db_workshop.description,
+            facilitator_id=db_workshop.facilitator_id,
+            status=db_workshop.status,
+            current_phase=db_workshop.current_phase,
+            completed_phases=db_workshop.completed_phases or [],
+            discovery_started=db_workshop.discovery_started or False,
+            annotation_started=db_workshop.annotation_started or False,
+            active_discovery_trace_ids=db_workshop.active_discovery_trace_ids or [],
+            active_annotation_trace_ids=db_workshop.active_annotation_trace_ids or [],
+            discovery_randomize_traces=getattr(db_workshop, "discovery_randomize_traces", False) or False,
+            annotation_randomize_traces=getattr(db_workshop, "annotation_randomize_traces", False) or False,
+            judge_name=db_workshop.judge_name or "workshop_judge",
+            input_jsonpath=getattr(db_workshop, "input_jsonpath", None),
+            output_jsonpath=getattr(db_workshop, "output_jsonpath", None),
+            auto_evaluation_job_id=getattr(db_workshop, "auto_evaluation_job_id", None),
+            auto_evaluation_prompt=getattr(db_workshop, "auto_evaluation_prompt", None),
+            auto_evaluation_model=getattr(db_workshop, "auto_evaluation_model", None),
+            show_participant_notes=getattr(db_workshop, "show_participant_notes", False) or False,
+            created_at=db_workshop.created_at,
+        )
 
-    Args:
-        workshop_id: Workshop ID
-        question_id: The ID of the question to update (e.g., "q_1", "q_2")
-        title: New question title
-        description: New question description
-        judge_type: Optional judge type ('likert', 'binary', 'freeform')
-    """
-    # Get existing rubric
-    existing_rubric = self.db.query(RubricDB).filter(RubricDB.workshop_id == workshop_id).first()
+    def get_workshop(self, workshop_id: str) -> Workshop | None:
+        """Get a workshop by ID."""
+        db_workshop = self.db.query(WorkshopDB).filter(WorkshopDB.id == workshop_id).first()
+        if not db_workshop:
+            return None
 
-    if not existing_rubric:
-      return None
+        return self._workshop_from_db(db_workshop)
 
-    # Parse existing questions
-    questions = self._parse_rubric_questions(existing_rubric.question)
+    def list_workshops(self, facilitator_id: str | None = None) -> list[Workshop]:
+        """List all workshops, optionally filtered by facilitator.
 
-    # Find and update the specific question
-    question_found = False
-    for i, question in enumerate(questions):
-      if question.get('id') == question_id:
-        questions[i]['title'] = title
-        questions[i]['description'] = description
-        # Update judge_type if provided
-        if judge_type:
-          questions[i]['judge_type'] = judge_type
-        question_found = True
-        break
+        Args:
+            facilitator_id: If provided, only return workshops created by this facilitator
 
-    if not question_found:
-      return None
+        Returns:
+            List of Workshop objects sorted by creation date (newest first)
+        """
+        query = self.db.query(WorkshopDB)
 
-    # Reconstruct the question field
-    updated_question = self._reconstruct_rubric_questions(questions)
+        if facilitator_id:
+            query = query.filter(WorkshopDB.facilitator_id == facilitator_id)
 
-    # Update the rubric
-    existing_rubric.question = updated_question
-    self.db.commit()
-    self.db.refresh(existing_rubric)
+        # Order by creation date, newest first
+        query = query.order_by(WorkshopDB.created_at.desc())
 
-    return Rubric(
-      id=existing_rubric.id,
-      workshop_id=existing_rubric.workshop_id,
-      question=existing_rubric.question,
-      created_by=existing_rubric.created_by,
-      created_at=existing_rubric.created_at,
-    )
+        db_workshops = query.all()
+        return [self._workshop_from_db(w) for w in db_workshops]
 
-  def delete_rubric_question(self, workshop_id: str, question_id: str) -> Optional[Rubric]:
-    """Delete a specific question from the rubric.
+    def get_workshops_for_user(self, user_id: str) -> list[Workshop]:
+        """Get all workshops that a user is part of (either as facilitator or participant).
 
-    Note: This does NOT delete any annotation data from the database.
-    Old annotation ratings remain in DB but won't be displayed in the UI
-    because they reference question IDs that no longer exist in the rubric.
+        Args:
+            user_id: The user ID to find workshops for
 
-    Args:
-        workshop_id: Workshop ID
-        question_id: The ID of the question to delete (e.g., "q_1", "q_2")
-    """
-    # Get existing rubric
-    existing_rubric = self.db.query(RubricDB).filter(RubricDB.workshop_id == workshop_id).first()
+        Returns:
+            List of Workshop objects the user has access to
+        """
+        from server.database import UserDB, WorkshopDB
 
-    if not existing_rubric:
-      return None
+        # Get workshops where user is the facilitator
+        facilitator_workshops = self.db.query(WorkshopDB).filter(WorkshopDB.facilitator_id == user_id).all()
 
-    # Parse existing questions
-    questions = self._parse_rubric_questions(existing_rubric.question)
+        # Get workshops where user has been added as a participant
+        participant_workshop_ids = (
+            self.db.query(UserDB.workshop_id)
+            .filter(UserDB.id == user_id, UserDB.workshop_id.isnot(None))
+            .distinct()
+            .all()
+        )
 
-    # Remove the specific question
-    questions = [q for q in questions if q.get('id') != question_id]
+        participant_workshop_ids = [w[0] for w in participant_workshop_ids if w[0]]
 
-    if not questions:
-      # If no questions left, delete the entire rubric
-      self.db.delete(existing_rubric)
-      self.db.commit()
-      return None
+        participant_workshops = (
+            self.db.query(WorkshopDB).filter(WorkshopDB.id.in_(participant_workshop_ids)).all()
+            if participant_workshop_ids
+            else []
+        )
 
-    # Reconstruct the question field
-    updated_question = self._reconstruct_rubric_questions(questions)
+        # Combine and deduplicate
+        all_workshops = {w.id: w for w in facilitator_workshops}
+        for w in participant_workshops:
+            if w.id not in all_workshops:
+                all_workshops[w.id] = w
 
-    # Update the rubric
-    existing_rubric.question = updated_question
-    self.db.commit()
-    self.db.refresh(existing_rubric)
+        # Sort by creation date, newest first
+        sorted_workshops = sorted(all_workshops.values(), key=lambda w: w.created_at or "", reverse=True)
 
-    return Rubric(
-      id=existing_rubric.id,
-      workshop_id=existing_rubric.workshop_id,
-      question=existing_rubric.question,
-      created_by=existing_rubric.created_by,
-      created_at=existing_rubric.created_at,
-    )
+        return [self._workshop_from_db(w) for w in sorted_workshops]
 
-  def _parse_rubric_questions(self, question_text: str) -> list:
-    """Parse the rubric question text into individual questions.
-    
-    Format: "title: description|||JUDGE_TYPE|||judgeType" separated by "|||QUESTION_SEPARATOR|||"
-    """
-    questions = []
-    if not question_text:
-      return questions
+    def update_workshop_judge_name(self, workshop_id: str, judge_name: str) -> Workshop | None:
+        """Update the judge name for a workshop."""
+        db_workshop = self.db.query(WorkshopDB).filter(WorkshopDB.id == workshop_id).first()
+        if not db_workshop:
+            return None
 
-    # Use a special delimiter to separate questions (supports newlines within descriptions)
-    QUESTION_DELIMITER = '|||QUESTION_SEPARATOR|||'
-    JUDGE_TYPE_DELIMITER = '|||JUDGE_TYPE|||'
-    question_parts = question_text.split(QUESTION_DELIMITER)
-    
-    for i, part in enumerate(question_parts):
-      part = part.strip()
-      if not part:
-        continue
-      
-      # Check if question has judge type embedded
-      content = part
-      judge_type = 'likert'  # default
-      
-      if JUDGE_TYPE_DELIMITER in part:
-        content_part, type_part = part.split(JUDGE_TYPE_DELIMITER, 1)
-        content = content_part.strip()
-        parsed_type = type_part.strip()
-        if parsed_type in ('likert', 'binary', 'freeform'):
-          judge_type = parsed_type
-        
-      # Split only at the first colon to separate title from description
-      if ':' in content:
-        title, description = content.split(':', 1)
-        questions.append({
-          'id': f'q_{i + 1}', 
-          'title': title.strip(), 
-          'description': description.strip(),
-          'judge_type': judge_type
-        })
+        db_workshop.judge_name = judge_name
+        self.db.commit()
+        self.db.refresh(db_workshop)
 
-    return questions
+        return self.get_workshop(workshop_id)
 
-  def _reconstruct_rubric_questions(self, questions: list) -> str:
-    """Reconstruct individual questions into a single question text.
-    
-    Format: "title: description|||JUDGE_TYPE|||judgeType" separated by "|||QUESTION_SEPARATOR|||"
-    """
-    if not questions:
-      return ''
+    def update_workshop_jsonpath_settings(
+        self,
+        workshop_id: str,
+        input_jsonpath: str | None = None,
+        output_jsonpath: str | None = None,
+    ) -> Workshop | None:
+        """Update the JSONPath settings for trace display in a workshop.
 
-    QUESTION_DELIMITER = '|||QUESTION_SEPARATOR|||'
-    JUDGE_TYPE_DELIMITER = '|||JUDGE_TYPE|||'
-    question_parts = []
-    for i, question in enumerate(questions):
-      # Update the ID to be sequential
-      question['id'] = f'q_{i + 1}'
-      judge_type = question.get('judge_type', 'likert')
-      question_parts.append(f'{question["title"]}: {question["description"]}{JUDGE_TYPE_DELIMITER}{judge_type}')
+        Args:
+          workshop_id: The workshop ID
+          input_jsonpath: JSONPath expression for extracting trace input display (or None to clear)
+          output_jsonpath: JSONPath expression for extracting trace output display (or None to clear)
 
-    return QUESTION_DELIMITER.join(question_parts)
+        Returns:
+          Updated Workshop model or None if workshop not found
+        """
+        db_workshop = self.db.query(WorkshopDB).filter(WorkshopDB.id == workshop_id).first()
+        if not db_workshop:
+            return None
 
-  def get_rubric(self, workshop_id: str) -> Optional[Rubric]:
-    """Get the rubric for a workshop."""
-    db_rubric = self.db.query(RubricDB).filter(RubricDB.workshop_id == workshop_id).first()
+        # Update the JSONPath fields (empty string is treated same as None)
+        db_workshop.input_jsonpath = input_jsonpath if input_jsonpath and input_jsonpath.strip() else None
+        db_workshop.output_jsonpath = output_jsonpath if output_jsonpath and output_jsonpath.strip() else None
 
-    if not db_rubric:
-      return None
+        self.db.commit()
+        self.db.refresh(db_workshop)
 
-    return Rubric(
-      id=db_rubric.id,
-      workshop_id=db_rubric.workshop_id,
-      question=db_rubric.question,
-      created_by=db_rubric.created_by,
-      created_at=db_rubric.created_at,
-      judge_type=db_rubric.judge_type or 'likert',
-      binary_labels=db_rubric.binary_labels,
-      rating_scale=db_rubric.rating_scale or 5,
-    )
+        return self.get_workshop(workshop_id)
 
-  def derive_judge_prompt_from_rubric(self, workshop_id: str, question_index: int = 0) -> Optional[str]:
-    """Generate a judge prompt for a single rubric criterion.
+    def update_workshop_phase(self, workshop_id: str, new_phase: WorkshopPhase) -> Workshop | None:
+        """Update the current phase of a workshop."""
+        db_workshop = self.db.query(WorkshopDB).filter(WorkshopDB.id == workshop_id).first()
+        if not db_workshop:
+            return None
 
-    Uses the same templates as the frontend (Likert/Binary), with the rubric
-    criterion substituted in. Uses {{ inputs }}/{{ outputs }} for MLflow compatibility.
+        db_workshop.current_phase = new_phase
+        self.db.commit()
+        self.db.refresh(db_workshop)
 
-    Args:
-        workshop_id: The workshop ID
-        question_index: Index of the rubric question to use (default: 0, the first question)
+        return Workshop(
+            id=db_workshop.id,
+            name=db_workshop.name,
+            description=db_workshop.description,
+            facilitator_id=db_workshop.facilitator_id,
+            status=db_workshop.status,
+            current_phase=db_workshop.current_phase,
+            completed_phases=db_workshop.completed_phases or [],
+            discovery_started=db_workshop.discovery_started or False,
+            annotation_started=db_workshop.annotation_started or False,
+            active_discovery_trace_ids=db_workshop.active_discovery_trace_ids or [],
+            active_annotation_trace_ids=db_workshop.active_annotation_trace_ids or [],
+            created_at=db_workshop.created_at,
+        )
 
-    Returns:
-        A judge prompt string for the specified criterion, or None if no rubric exists.
-    """
-    rubric = self.get_rubric(workshop_id)
-    if not rubric:
-      return None
+    def update_phase_started(
+        self,
+        workshop_id: str,
+        discovery_started: bool | None = None,
+        annotation_started: bool | None = None,
+    ) -> Workshop | None:
+        """Update the phase started flags for a workshop."""
+        db_workshop = self.db.query(WorkshopDB).filter(WorkshopDB.id == workshop_id).first()
+        if not db_workshop:
+            return None
 
-    # Parse rubric questions
-    questions = self._parse_rubric_questions(rubric.question)
-    if not questions:
-      # Single question rubric (legacy format)
-      questions = [{
-        'id': 'q_1',
-        'title': rubric.question.split(':')[0].strip() if ':' in rubric.question else 'Response Quality',
-        'description': rubric.question,
-        'judge_type': rubric.judge_type or 'likert',
-      }]
+        if discovery_started is not None:
+            db_workshop.discovery_started = discovery_started
+        if annotation_started is not None:
+            db_workshop.annotation_started = annotation_started
 
-    # Get the specific question (default to first if index out of bounds)
-    if question_index >= len(questions):
-      question_index = 0
-    question = questions[question_index]
+        self.db.commit()
+        self.db.refresh(db_workshop)
 
-    title = question.get('title', 'Response Quality')
-    description = question.get('description', '')
-    judge_type = question.get('judge_type', rubric.judge_type or 'likert')
+        return Workshop(
+            id=db_workshop.id,
+            name=db_workshop.name,
+            description=db_workshop.description,
+            facilitator_id=db_workshop.facilitator_id,
+            status=db_workshop.status,
+            current_phase=db_workshop.current_phase,
+            completed_phases=db_workshop.completed_phases or [],
+            discovery_started=db_workshop.discovery_started or False,
+            annotation_started=db_workshop.annotation_started or False,
+            active_discovery_trace_ids=db_workshop.active_discovery_trace_ids or [],
+            active_annotation_trace_ids=db_workshop.active_annotation_trace_ids or [],
+            created_at=db_workshop.created_at,
+        )
 
-    # Build rubric content: title + description
-    rubric_content = f"**{title}**"
-    if description:
-      rubric_content += f"\n{description}"
+    def update_active_discovery_traces(self, workshop_id: str, trace_ids: list[str]) -> Workshop | None:
+        """Update the active discovery trace IDs for a workshop."""
+        db_workshop = self.db.query(WorkshopDB).filter(WorkshopDB.id == workshop_id).first()
+        if not db_workshop:
+            return None
 
-    # Use the same templates as the frontend (JudgeTypeSelector.tsx)
-    if judge_type == 'binary':
-      # Binary template
-      return f"""You are an expert evaluator performing a quality check on an AI assistant's response.
+        db_workshop.active_discovery_trace_ids = trace_ids
+        self.db.commit()
+        self.db.refresh(db_workshop)
+
+        return self._workshop_from_db(db_workshop)
+
+    def update_active_annotation_traces(self, workshop_id: str, trace_ids: list[str]) -> Workshop | None:
+        """Update the active annotation trace IDs for a workshop."""
+        db_workshop = self.db.query(WorkshopDB).filter(WorkshopDB.id == workshop_id).first()
+        if not db_workshop:
+            return None
+
+        db_workshop.active_annotation_trace_ids = trace_ids
+        self.db.commit()
+        self.db.refresh(db_workshop)
+
+        return self._workshop_from_db(db_workshop)
+
+    def update_discovery_randomize_setting(self, workshop_id: str, randomize: bool) -> Workshop | None:
+        """Update the discovery trace randomization setting for a workshop."""
+        db_workshop = self.db.query(WorkshopDB).filter(WorkshopDB.id == workshop_id).first()
+        if not db_workshop:
+            return None
+
+        db_workshop.discovery_randomize_traces = randomize
+        self.db.commit()
+        self.db.refresh(db_workshop)
+
+        return self._workshop_from_db(db_workshop)
+
+    def update_annotation_randomize_setting(self, workshop_id: str, randomize: bool) -> Workshop | None:
+        """Update the annotation trace randomization setting for a workshop."""
+        db_workshop = self.db.query(WorkshopDB).filter(WorkshopDB.id == workshop_id).first()
+        if not db_workshop:
+            return None
+
+        db_workshop.annotation_randomize_traces = randomize
+        self.db.commit()
+        self.db.refresh(db_workshop)
+
+        return self._workshop_from_db(db_workshop)
+
+    def update_auto_evaluation_job(
+        self, workshop_id: str, job_id: str, prompt: str, model: str | None = None
+    ) -> Workshop | None:
+        """Update the auto-evaluation job ID, derived prompt, and model for a workshop."""
+        db_workshop = self.db.query(WorkshopDB).filter(WorkshopDB.id == workshop_id).first()
+        if not db_workshop:
+            return None
+
+        db_workshop.auto_evaluation_job_id = job_id
+        db_workshop.auto_evaluation_prompt = prompt
+        if model:
+            db_workshop.auto_evaluation_model = model
+        self.db.commit()
+        self.db.refresh(db_workshop)
+
+        return self._workshop_from_db(db_workshop)
+
+    def get_auto_evaluation_job_id(self, workshop_id: str) -> str | None:
+        """Get the auto-evaluation job ID for a workshop."""
+        db_workshop = self.db.query(WorkshopDB).filter(WorkshopDB.id == workshop_id).first()
+        if not db_workshop:
+            return None
+        return db_workshop.auto_evaluation_job_id
+
+    def get_auto_evaluation_prompt(self, workshop_id: str) -> str | None:
+        """Get the auto-evaluation derived prompt for a workshop."""
+        db_workshop = self.db.query(WorkshopDB).filter(WorkshopDB.id == workshop_id).first()
+        if not db_workshop:
+            return None
+        return db_workshop.auto_evaluation_prompt
+
+    def get_auto_evaluation_model(self, workshop_id: str) -> str | None:
+        """Get the auto-evaluation model for a workshop."""
+        db_workshop = self.db.query(WorkshopDB).filter(WorkshopDB.id == workshop_id).first()
+        if not db_workshop:
+            return None
+        return getattr(db_workshop, "auto_evaluation_model", None)
+
+    # Trace operations
+    def add_traces(self, workshop_id: str, traces: list[TraceUpload]) -> list[Trace]:
+        """Add traces to a workshop."""
+        db_traces = []
+
+        for trace_data in traces:
+            trace_id = str(uuid.uuid4())
+            db_trace = TraceDB(
+                id=trace_id,
+                workshop_id=workshop_id,
+                input=trace_data.input,
+                output=trace_data.output,
+                context=trace_data.context,
+                trace_metadata=trace_data.trace_metadata,
+                mlflow_trace_id=trace_data.mlflow_trace_id,
+                mlflow_experiment_id=trace_data.mlflow_experiment_id,
+            )
+            self.db.add(db_trace)
+            db_traces.append(db_trace)
+
+        self.db.commit()
+
+        # Refresh and create response objects after commit
+        created_traces = []
+        for db_trace in db_traces:
+            self.db.refresh(db_trace)
+            created_traces.append(
+                Trace(
+                    id=db_trace.id,
+                    workshop_id=db_trace.workshop_id,
+                    input=db_trace.input,
+                    output=db_trace.output,
+                    context=db_trace.context,
+                    trace_metadata=db_trace.trace_metadata,
+                    mlflow_trace_id=db_trace.mlflow_trace_id,
+                    created_at=db_trace.created_at,
+                )
+            )
+
+        return created_traces
+
+    def get_traces(self, workshop_id: str) -> list[Trace]:
+        """Get all traces for a workshop in chronological order."""
+        db_traces = self.db.query(TraceDB).filter(TraceDB.workshop_id == workshop_id).order_by(TraceDB.created_at).all()
+
+        return [self._trace_from_db(db_trace) for db_trace in db_traces]
+
+    def get_traces_by_experiment(self, workshop_id: str, experiment_id: str) -> list[Trace]:
+        """Get all traces for a workshop that were ingested from a specific MLflow experiment."""
+        db_traces = (
+            self.db.query(TraceDB)
+            .filter(TraceDB.workshop_id == workshop_id, TraceDB.mlflow_experiment_id == experiment_id)
+            .all()
+        )
+
+        return [self._trace_from_db(db_trace) for db_trace in db_traces]
+
+    def get_active_discovery_traces(self, workshop_id: str, user_id: str) -> list[Trace]:
+        """Get only the active discovery traces for a workshop.
+
+        If randomization is enabled for the workshop, each user sees traces in a different
+        randomized order (deterministic per user based on user_id seed).
+        If randomization is disabled (default), all users see traces in the same chronological order.
+
+        Args:
+            workshop_id: The workshop ID
+            user_id: The user ID (required for personalized trace ordering when randomization is enabled)
+
+        Returns:
+            List of traces in appropriate order
+
+        Raises:
+            ValueError: If user_id is not provided
+        """
+        import time
+
+        if not user_id:
+            raise ValueError("user_id is required for fetching discovery traces")
+
+        start_time = time.time()
+
+        # Get workshop data (cached)
+        workshop = self.get_workshop(workshop_id)
+        if not workshop or not workshop.active_discovery_trace_ids:
+            return []
+
+        active_trace_ids = workshop.active_discovery_trace_ids
+
+        # Check if randomization is enabled for this workshop
+        randomize_enabled = getattr(workshop, "discovery_randomize_traces", False) or False
+
+        if not randomize_enabled:
+            # Randomization OFF: Return traces in chronological order (same for all users)
+            # Fetch traces in the order they appear in active_discovery_trace_ids
+            db_traces = self.db.query(TraceDB).filter(TraceDB.id.in_(active_trace_ids)).all()
+
+            # Create ordered result - preserve the chronological order from active_discovery_trace_ids
+            trace_map = {t.id: t for t in db_traces}
+            result = []
+            for tid in active_trace_ids:
+                if tid in trace_map:
+                    result.append(self._trace_from_db(trace_map[tid]))
+
+            # Log performance metrics
+            load_time = time.time() - start_time
+            if load_time > 0.1:
+                print(
+                    f"⚠️ Slow trace load: {load_time:.3f}s for {len(result)} traces (user: {user_id[:8]}..., no randomization)"
+                )
+
+            return result
+
+        # Randomization ON: Get or create user-specific trace order
+        user_order = self.get_user_trace_order(workshop_id, user_id)
+
+        if not user_order:
+            # Create new user trace order with randomized discovery traces
+            user_order = self.create_user_trace_order(workshop_id, user_id)
+            # Generate randomized order for this user
+            user_order.discovery_traces = self._generate_randomized_trace_order(active_trace_ids, user_id)
+            self.update_user_trace_order(user_order)
+        elif not user_order.discovery_traces or set(user_order.discovery_traces) != set(active_trace_ids):
+            # Update if trace set has changed (e.g., new traces added)
+            # Preserve existing order for traces already seen, add new ones randomly
+            existing_traces = [tid for tid in user_order.discovery_traces if tid in active_trace_ids]
+            new_traces = [tid for tid in active_trace_ids if tid not in user_order.discovery_traces]
+
+            # Randomize only the new traces
+            randomized_new_traces = self._generate_randomized_trace_order(new_traces, user_id)
+
+            # Combine: existing traces first (in their original order), then new randomized traces
+            user_order.discovery_traces = existing_traces + randomized_new_traces
+            self.update_user_trace_order(user_order)
+
+        # Use the user's personalized trace order
+        ordered_ids = user_order.discovery_traces
+
+        # Optimized trace fetching - single query with IN clause
+        if not ordered_ids:
+            return []
+
+        db_traces = self.db.query(TraceDB).filter(TraceDB.id.in_(ordered_ids)).all()
+
+        # Create ordered result efficiently - preserve the user-specific order
+        trace_map = {t.id: t for t in db_traces}
+        result = []
+        for tid in ordered_ids:
+            if tid in trace_map:
+                result.append(self._trace_from_db(trace_map[tid]))
+
+        # Log performance metrics
+        load_time = time.time() - start_time
+        if load_time > 0.1:  # Log slow requests
+            print(f"⚠️ Slow trace load: {load_time:.3f}s for {len(result)} traces (user: {user_id[:8]}..., randomized)")
+
+        return result
+
+    def _generate_randomized_trace_order(self, trace_ids: list[str], user_id: str) -> list[str]:
+        """Generate a randomized order of trace IDs for a specific user.
+
+        Uses the user_id combined with the sorted trace IDs as a seed to ensure:
+        1. Consistent randomization per user for the same set of traces
+        2. Different randomization when the trace set changes
+
+        Args:
+            trace_ids: List of trace IDs to randomize
+            user_id: User ID to use as random seed
+
+        Returns:
+            Randomized list of trace IDs
+        """
+        import hashlib
+        import random
+
+        if not trace_ids:
+            return []
+
+        # Create a deterministic seed from user_id + sorted trace IDs
+        # This ensures that the same user sees the same order for the same set of traces,
+        # but different traces (e.g., newly added ones) will have different randomization
+        sorted_trace_ids = sorted(trace_ids)
+        seed_string = f"{user_id}::{','.join(sorted_trace_ids)}"
+        seed = int(hashlib.md5(seed_string.encode()).hexdigest(), 16) % (2**31)
+
+        # Create a new random instance with the user-specific seed
+        rng = random.Random(seed)
+
+        # Create a copy and shuffle it
+        randomized_ids = trace_ids.copy()
+        rng.shuffle(randomized_ids)
+
+        return randomized_ids
+
+    def get_active_annotation_traces(self, workshop_id: str, user_id: str) -> list[Trace]:
+        """Get only the active annotation traces for a workshop.
+
+        If randomization is enabled for the workshop, each user sees traces in a different
+        randomized order (deterministic per user based on user_id seed).
+        If randomization is disabled (default), all users see traces in the same chronological order.
+
+        Args:
+            workshop_id: The workshop ID
+            user_id: The user ID (required for personalized trace ordering when randomization is enabled)
+
+        Returns:
+            List of traces in appropriate order
+
+        Raises:
+            ValueError: If user_id is not provided
+        """
+        import time
+
+        if not user_id:
+            raise ValueError("user_id is required for fetching annotation traces")
+
+        start_time = time.time()
+
+        workshop = self.get_workshop(workshop_id)
+        if not workshop or not workshop.active_annotation_trace_ids:
+            return []
+
+        active_trace_ids = workshop.active_annotation_trace_ids
+
+        # Check if randomization is enabled for this workshop
+        randomize_enabled = getattr(workshop, "annotation_randomize_traces", False) or False
+
+        if not randomize_enabled:
+            # Randomization OFF: Return traces in chronological order (same for all users)
+            # Fetch traces in the order they appear in active_annotation_trace_ids
+            db_traces = self.db.query(TraceDB).filter(TraceDB.id.in_(active_trace_ids)).all()
+
+            # Create ordered result - preserve the chronological order from active_annotation_trace_ids
+            trace_map = {t.id: t for t in db_traces}
+            result = []
+            for tid in active_trace_ids:
+                if tid in trace_map:
+                    result.append(self._trace_from_db(trace_map[tid]))
+
+            # Log performance metrics
+            load_time = time.time() - start_time
+            if load_time > 0.1:
+                print(
+                    f"⚠️ Slow annotation trace load: {load_time:.3f}s for {len(result)} traces (user: {user_id[:8]}..., no randomization)"
+                )
+
+            return result
+
+        # Randomization ON: Get or create user-specific trace order
+        user_order = self.get_user_trace_order(workshop_id, user_id)
+
+        if not user_order:
+            # Create new user trace order with randomized annotation traces
+            user_order = self.create_user_trace_order(workshop_id, user_id)
+            # Generate randomized order for this user
+            user_order.annotation_traces = self._generate_randomized_trace_order(active_trace_ids, user_id)
+            self.update_user_trace_order(user_order)
+        elif not user_order.annotation_traces or set(user_order.annotation_traces) != set(active_trace_ids):
+            # Update if trace set has changed (e.g., new traces added)
+            # Preserve existing order for traces already seen, add new ones randomly
+            existing_traces = [tid for tid in user_order.annotation_traces if tid in active_trace_ids]
+            new_traces = [tid for tid in active_trace_ids if tid not in user_order.annotation_traces]
+
+            # Randomize only the new traces
+            randomized_new_traces = self._generate_randomized_trace_order(new_traces, user_id)
+
+            # Combine: existing traces first (in their original order), then new randomized traces
+            user_order.annotation_traces = existing_traces + randomized_new_traces
+            self.update_user_trace_order(user_order)
+
+        # Use the user's personalized trace order
+        ordered_ids = user_order.annotation_traces
+
+        # Optimized trace fetching - single query with IN clause
+        if not ordered_ids:
+            return []
+
+        db_traces = self.db.query(TraceDB).filter(TraceDB.id.in_(ordered_ids)).all()
+
+        # Create ordered result efficiently - preserve the user-specific order
+        trace_map = {t.id: t for t in db_traces}
+        result = []
+        for tid in ordered_ids:
+            if tid in trace_map:
+                result.append(self._trace_from_db(trace_map[tid]))
+
+        # Log performance metrics
+        load_time = time.time() - start_time
+        if load_time > 0.1:  # Log slow requests
+            print(
+                f"⚠️ Slow annotation trace load: {load_time:.3f}s for {len(result)} traces (user: {user_id[:8]}..., randomized)"
+            )
+
+        return result
+
+    # Discovery finding operations
+    def add_finding(self, workshop_id: str, finding_data: DiscoveryFindingCreate) -> DiscoveryFinding:
+        """Add or update a discovery finding (upsert) with automatic retry on failure.
+
+        Retries are handled transparently in the backend - the frontend only sees
+        success or failure after all retries are exhausted.
+
+        Works with both SQLite and PostgreSQL (Lakebase) backends.
+
+        Handles:
+        - IntegrityError: Race conditions when multiple users save simultaneously
+        - OperationalError: Database locked/busy (SQLite) or deadlocks (PostgreSQL)
+        - General exceptions: Network issues, timeouts, etc.
+        """
+        import time
+
+        from sqlalchemy.exc import IntegrityError, OperationalError
+
+        finding_id = str(uuid.uuid4())
+        max_retries = 3
+        base_delay = 0.2  # Base delay in seconds
+
+        logger.info(
+            f"📝 add_finding called: workshop_id={workshop_id}, trace_id={finding_data.trace_id}, user_id={finding_data.user_id}"
+        )
+
+        last_error = None
+        for attempt in range(max_retries):
+            try:
+                # First, try to find existing record to preserve its ID
+                # Note: with_for_update() is not used for cross-database compatibility
+                # (SQLite uses file-level locking; PostgreSQL supports row-level but this works for both)
+                existing_finding = (
+                    self.db.query(DiscoveryFindingDB)
+                    .filter(
+                        DiscoveryFindingDB.workshop_id == workshop_id,
+                        DiscoveryFindingDB.trace_id == finding_data.trace_id,
+                        DiscoveryFindingDB.user_id == finding_data.user_id,
+                    )
+                    .first()
+                )
+
+                if existing_finding:
+                    # Update existing finding
+                    logger.info(f"🔄 Updating existing finding: id={existing_finding.id}")
+                    existing_finding.insight = finding_data.insight
+                    self.db.commit()
+                    self.db.refresh(existing_finding)
+                    db_finding = existing_finding
+                    logger.info(f"✅ Finding updated successfully: id={db_finding.id}")
+                else:
+                    # Create new finding
+                    logger.info(f"🆕 Creating new finding (attempt {attempt + 1}/{max_retries})")
+                    db_finding = DiscoveryFindingDB(
+                        id=finding_id,
+                        workshop_id=workshop_id,
+                        trace_id=finding_data.trace_id,
+                        user_id=finding_data.user_id,
+                        insight=finding_data.insight,
+                    )
+                    self.db.add(db_finding)
+                    self.db.commit()
+                    self.db.refresh(db_finding)
+                    logger.info(f"✅ Finding created successfully: id={db_finding.id}")
+
+                return DiscoveryFinding(
+                    id=db_finding.id,
+                    workshop_id=db_finding.workshop_id,
+                    trace_id=db_finding.trace_id,
+                    user_id=db_finding.user_id,
+                    insight=db_finding.insight,
+                    created_at=db_finding.created_at,
+                )
+
+            except IntegrityError as e:
+                # Handle race condition - another request inserted the same record
+                last_error = e
+                logger.warning(f"⚠️ IntegrityError on finding save (attempt {attempt + 1}/{max_retries}): {e}")
+                self.db.rollback()
+                if attempt < max_retries - 1:
+                    delay = base_delay * (2**attempt)  # Exponential backoff: 0.2, 0.4, 0.8s
+                    logger.info(f"🔄 Retrying in {delay:.1f}s...")
+                    time.sleep(delay)
+                    continue
+                # On final attempt, try to fetch and update the existing record
+                logger.info("🔄 Final attempt: fetching existing finding to update")
+                try:
+                    existing = (
+                        self.db.query(DiscoveryFindingDB)
+                        .filter(
+                            DiscoveryFindingDB.workshop_id == workshop_id,
+                            DiscoveryFindingDB.trace_id == finding_data.trace_id,
+                            DiscoveryFindingDB.user_id == finding_data.user_id,
+                        )
+                        .first()
+                    )
+                    if existing:
+                        existing.insight = finding_data.insight
+                        self.db.commit()
+                        self.db.refresh(existing)
+                        logger.info(f"✅ Finding updated after conflict: id={existing.id}")
+                        return DiscoveryFinding(
+                            id=existing.id,
+                            workshop_id=existing.workshop_id,
+                            trace_id=existing.trace_id,
+                            user_id=existing.user_id,
+                            insight=existing.insight,
+                            created_at=existing.created_at,
+                        )
+                except Exception as final_error:
+                    logger.error(f"❌ Final recovery attempt also failed: {final_error}")
+                logger.error(f"❌ Failed to save finding after all retries: {e}")
+                raise e
+
+            except OperationalError as e:
+                # Handle database contention errors (locked/busy for SQLite, deadlocks for PostgreSQL)
+                last_error = e
+                error_msg = str(e).lower()
+                if "locked" in error_msg or "busy" in error_msg or "deadlock" in error_msg:
+                    logger.warning(f"⚠️ Database contention on finding save (attempt {attempt + 1}/{max_retries}): {e}")
+                else:
+                    logger.warning(f"⚠️ OperationalError on finding save (attempt {attempt + 1}/{max_retries}): {e}")
+                self.db.rollback()
+                if attempt < max_retries - 1:
+                    delay = base_delay * (2**attempt) + 0.5  # Extra delay for database contention
+                    logger.info(f"🔄 Retrying in {delay:.1f}s...")
+                    time.sleep(delay)
+                    continue
+                raise e
+
+            except Exception as e:
+                last_error = e
+                logger.error(f"❌ Error saving finding (attempt {attempt + 1}/{max_retries}): {e}")
+                self.db.rollback()
+                if attempt < max_retries - 1:
+                    delay = base_delay * (2**attempt)
+                    logger.info(f"🔄 Retrying in {delay:.1f}s...")
+                    time.sleep(delay)
+                    continue
+                raise e
+
+        # This shouldn't be reached, but just in case
+        logger.error(f"❌ Failed to save finding after all {max_retries} retries (loop exhausted)")
+        raise last_error or Exception("Failed to save finding after all retries")
+
+    def get_findings(self, workshop_id: str, user_id: str | None = None) -> list[DiscoveryFinding]:
+        """Get discovery findings for a workshop, optionally filtered by user."""
+        query = self.db.query(DiscoveryFindingDB).filter(DiscoveryFindingDB.workshop_id == workshop_id)
+
+        # Filter by user_id if provided
+        if user_id:
+            query = query.filter(DiscoveryFindingDB.user_id == user_id)
+
+        db_findings = query.all()
+
+        return [
+            DiscoveryFinding(
+                id=db_finding.id,
+                workshop_id=db_finding.workshop_id,
+                trace_id=db_finding.trace_id,
+                user_id=db_finding.user_id,
+                insight=db_finding.insight,
+                created_at=db_finding.created_at,
+            )
+            for db_finding in db_findings
+        ]
+
+    def get_findings_with_user_details(self, workshop_id: str, user_id: str | None = None) -> list[dict[str, Any]]:
+        """Get discovery findings with user details for facilitator view."""
+        query = (
+            self.db.query(DiscoveryFindingDB, UserDB)
+            .join(UserDB, DiscoveryFindingDB.user_id == UserDB.id)
+            .filter(DiscoveryFindingDB.workshop_id == workshop_id)
+        )
+
+        # Filter by user_id if provided
+        if user_id:
+            query = query.filter(DiscoveryFindingDB.user_id == user_id)
+
+        results = query.all()
+
+        return [
+            {
+                "id": finding.id,
+                "workshop_id": finding.workshop_id,
+                "trace_id": finding.trace_id,
+                "user_id": finding.user_id,
+                "user_name": user.name,
+                "user_email": user.email,
+                "insight": finding.insight,
+                "created_at": finding.created_at,
+            }
+            for finding, user in results
+        ]
+
+    # Participant notes operations
+    def add_participant_note(self, workshop_id: str, note_data: ParticipantNoteCreate) -> ParticipantNote:
+        """Add a new participant note (always appends, never overwrites)."""
+        db_note = ParticipantNoteDB(
+            id=str(uuid.uuid4()),
+            workshop_id=workshop_id,
+            user_id=note_data.user_id,
+            trace_id=note_data.trace_id,
+            content=note_data.content,
+            phase=getattr(note_data, "phase", "discovery") or "discovery",
+        )
+        self.db.add(db_note)
+        self.db.commit()
+        self.db.refresh(db_note)
+
+        # Get user name for the response
+        user = self.db.query(UserDB).filter(UserDB.id == db_note.user_id).first()
+
+        return ParticipantNote(
+            id=db_note.id,
+            workshop_id=db_note.workshop_id,
+            user_id=db_note.user_id,
+            trace_id=db_note.trace_id,
+            content=db_note.content,
+            phase=getattr(db_note, "phase", "discovery") or "discovery",
+            user_name=user.name if user else None,
+            created_at=db_note.created_at,
+            updated_at=db_note.updated_at or db_note.created_at,
+        )
+
+    def get_participant_notes(
+        self, workshop_id: str, user_id: str | None = None, phase: str | None = None
+    ) -> list[ParticipantNote]:
+        """Get participant notes for a workshop, optionally filtered by user and/or phase."""
+        query = (
+            self.db.query(ParticipantNoteDB, UserDB)
+            .outerjoin(UserDB, ParticipantNoteDB.user_id == UserDB.id)
+            .filter(ParticipantNoteDB.workshop_id == workshop_id)
+        )
+
+        if user_id:
+            query = query.filter(ParticipantNoteDB.user_id == user_id)
+
+        if phase:
+            query = query.filter(ParticipantNoteDB.phase == phase)
+
+        results = query.order_by(ParticipantNoteDB.created_at.desc()).all()
+
+        return [
+            ParticipantNote(
+                id=note.id,
+                workshop_id=note.workshop_id,
+                user_id=note.user_id,
+                trace_id=note.trace_id,
+                content=note.content,
+                phase=getattr(note, "phase", "discovery") or "discovery",
+                user_name=user.name if user else None,
+                created_at=note.created_at,
+                updated_at=note.updated_at or note.created_at,
+            )
+            for note, user in results
+        ]
+
+    def delete_participant_note(self, note_id: str) -> bool:
+        """Delete a participant note by ID."""
+        note = self.db.query(ParticipantNoteDB).filter(ParticipantNoteDB.id == note_id).first()
+        if note:
+            self.db.delete(note)
+            self.db.commit()
+            return True
+        return False
+
+    # Rubric operations
+    def create_rubric(self, workshop_id: str, rubric_data: RubricCreate) -> Rubric:
+        """Create or update a rubric for a workshop."""
+        # Check if rubric already exists
+        existing_rubric = self.db.query(RubricDB).filter(RubricDB.workshop_id == workshop_id).first()
+
+        if existing_rubric:
+            # Update existing rubric
+            existing_rubric.question = rubric_data.question
+            existing_rubric.created_by = rubric_data.created_by
+            # Update judge type fields
+            if rubric_data.judge_type:
+                existing_rubric.judge_type = rubric_data.judge_type
+            if rubric_data.binary_labels:
+                existing_rubric.binary_labels = rubric_data.binary_labels
+            if rubric_data.rating_scale:
+                existing_rubric.rating_scale = rubric_data.rating_scale
+            self.db.commit()
+            self.db.refresh(existing_rubric)
+            db_rubric = existing_rubric
+        else:
+            # Create new rubric
+            rubric_id = str(uuid.uuid4())
+            db_rubric = RubricDB(
+                id=rubric_id,
+                workshop_id=workshop_id,
+                question=rubric_data.question,
+                created_by=rubric_data.created_by,
+                judge_type=rubric_data.judge_type or "likert",
+                binary_labels=rubric_data.binary_labels,
+                rating_scale=rubric_data.rating_scale or 5,
+            )
+            self.db.add(db_rubric)
+            self.db.commit()
+            self.db.refresh(db_rubric)
+
+        # Auto-derive and save judge_name from the first rubric question title
+        # This ensures the backend always has the correct judge name for MLflow feedback
+        workshop_db = self.db.query(WorkshopDB).filter(WorkshopDB.id == workshop_id).first()
+        if workshop_db and (not workshop_db.judge_name or workshop_db.judge_name == "workshop_judge"):
+            # Parse the rubric question to get the first title
+            questions = self._parse_rubric_questions(rubric_data.question)
+            if questions and questions[0].get("title"):
+                title = questions[0]["title"]
+                # Convert to snake_case and append _judge
+                import re
+
+                snake_case = re.sub(r"[^a-z0-9]+", "_", title.lower()).strip("_")
+                derived_judge_name = f"{snake_case}_judge"
+                workshop_db.judge_name = derived_judge_name
+                self.db.commit()
+                logger.info("Auto-derived judge_name '%s' from rubric title '%s'", derived_judge_name, title)
+
+        return Rubric(
+            id=db_rubric.id,
+            workshop_id=db_rubric.workshop_id,
+            question=db_rubric.question,
+            created_by=db_rubric.created_by,
+            created_at=db_rubric.created_at,
+        )
+
+    def update_rubric_question(
+        self, workshop_id: str, question_id: str, title: str, description: str, judge_type: str | None = None
+    ) -> Rubric | None:
+        """Update a specific question in the rubric.
+
+        Args:
+            workshop_id: Workshop ID
+            question_id: The ID of the question to update (e.g., "q_1", "q_2")
+            title: New question title
+            description: New question description
+            judge_type: Optional judge type ('likert', 'binary', 'freeform')
+        """
+        # Get existing rubric
+        existing_rubric = self.db.query(RubricDB).filter(RubricDB.workshop_id == workshop_id).first()
+
+        if not existing_rubric:
+            return None
+
+        # Parse existing questions
+        questions = self._parse_rubric_questions(existing_rubric.question)
+
+        # Find and update the specific question
+        question_found = False
+        for i, question in enumerate(questions):
+            if question.get("id") == question_id:
+                questions[i]["title"] = title
+                questions[i]["description"] = description
+                # Update judge_type if provided
+                if judge_type:
+                    questions[i]["judge_type"] = judge_type
+                question_found = True
+                break
+
+        if not question_found:
+            return None
+
+        # Reconstruct the question field
+        updated_question = self._reconstruct_rubric_questions(questions)
+
+        # Update the rubric
+        existing_rubric.question = updated_question
+        self.db.commit()
+        self.db.refresh(existing_rubric)
+
+        return Rubric(
+            id=existing_rubric.id,
+            workshop_id=existing_rubric.workshop_id,
+            question=existing_rubric.question,
+            created_by=existing_rubric.created_by,
+            created_at=existing_rubric.created_at,
+        )
+
+    def delete_rubric_question(self, workshop_id: str, question_id: str) -> Rubric | None:
+        """Delete a specific question from the rubric.
+
+        Note: This does NOT delete any annotation data from the database.
+        Old annotation ratings remain in DB but won't be displayed in the UI
+        because they reference question IDs that no longer exist in the rubric.
+
+        Args:
+            workshop_id: Workshop ID
+            question_id: The ID of the question to delete (e.g., "q_1", "q_2")
+        """
+        # Get existing rubric
+        existing_rubric = self.db.query(RubricDB).filter(RubricDB.workshop_id == workshop_id).first()
+
+        if not existing_rubric:
+            return None
+
+        # Parse existing questions
+        questions = self._parse_rubric_questions(existing_rubric.question)
+
+        # Remove the specific question
+        questions = [q for q in questions if q.get("id") != question_id]
+
+        if not questions:
+            # If no questions left, delete the entire rubric
+            self.db.delete(existing_rubric)
+            self.db.commit()
+            return None
+
+        # Reconstruct the question field
+        updated_question = self._reconstruct_rubric_questions(questions)
+
+        # Update the rubric
+        existing_rubric.question = updated_question
+        self.db.commit()
+        self.db.refresh(existing_rubric)
+
+        return Rubric(
+            id=existing_rubric.id,
+            workshop_id=existing_rubric.workshop_id,
+            question=existing_rubric.question,
+            created_by=existing_rubric.created_by,
+            created_at=existing_rubric.created_at,
+        )
+
+    def _parse_rubric_questions(self, question_text: str) -> list:
+        """Parse the rubric question text into individual questions.
+
+        Format: "title: description|||JUDGE_TYPE|||judgeType" separated by "|||QUESTION_SEPARATOR|||"
+        """
+        questions = []
+        if not question_text:
+            return questions
+
+        # Use a special delimiter to separate questions (supports newlines within descriptions)
+        QUESTION_DELIMITER = "|||QUESTION_SEPARATOR|||"
+        JUDGE_TYPE_DELIMITER = "|||JUDGE_TYPE|||"
+        question_parts = question_text.split(QUESTION_DELIMITER)
+
+        for i, part in enumerate(question_parts):
+            part = part.strip()
+            if not part:
+                continue
+
+            # Check if question has judge type embedded
+            content = part
+            judge_type = "likert"  # default
+
+            if JUDGE_TYPE_DELIMITER in part:
+                content_part, type_part = part.split(JUDGE_TYPE_DELIMITER, 1)
+                content = content_part.strip()
+                parsed_type = type_part.strip()
+                if parsed_type in ("likert", "binary", "freeform"):
+                    judge_type = parsed_type
+
+            # Split only at the first colon to separate title from description
+            if ":" in content:
+                title, description = content.split(":", 1)
+                questions.append(
+                    {
+                        "id": f"q_{i + 1}",
+                        "title": title.strip(),
+                        "description": description.strip(),
+                        "judge_type": judge_type,
+                    }
+                )
+
+        return questions
+
+    def _reconstruct_rubric_questions(self, questions: list) -> str:
+        """Reconstruct individual questions into a single question text.
+
+        Format: "title: description|||JUDGE_TYPE|||judgeType" separated by "|||QUESTION_SEPARATOR|||"
+        """
+        if not questions:
+            return ""
+
+        QUESTION_DELIMITER = "|||QUESTION_SEPARATOR|||"
+        JUDGE_TYPE_DELIMITER = "|||JUDGE_TYPE|||"
+        question_parts = []
+        for i, question in enumerate(questions):
+            # Update the ID to be sequential
+            question["id"] = f"q_{i + 1}"
+            judge_type = question.get("judge_type", "likert")
+            question_parts.append(f"{question['title']}: {question['description']}{JUDGE_TYPE_DELIMITER}{judge_type}")
+
+        return QUESTION_DELIMITER.join(question_parts)
+
+    def get_rubric(self, workshop_id: str) -> Rubric | None:
+        """Get the rubric for a workshop."""
+        db_rubric = self.db.query(RubricDB).filter(RubricDB.workshop_id == workshop_id).first()
+
+        if not db_rubric:
+            return None
+
+        return Rubric(
+            id=db_rubric.id,
+            workshop_id=db_rubric.workshop_id,
+            question=db_rubric.question,
+            created_by=db_rubric.created_by,
+            created_at=db_rubric.created_at,
+            judge_type=db_rubric.judge_type or "likert",
+            binary_labels=db_rubric.binary_labels,
+            rating_scale=db_rubric.rating_scale or 5,
+        )
+
+    def derive_judge_prompt_from_rubric(self, workshop_id: str, question_index: int = 0) -> str | None:
+        """Generate a judge prompt for a single rubric criterion.
+
+        Uses the same templates as the frontend (Likert/Binary), with the rubric
+        criterion substituted in. Uses {{ inputs }}/{{ outputs }} for MLflow compatibility.
+
+        Args:
+            workshop_id: The workshop ID
+            question_index: Index of the rubric question to use (default: 0, the first question)
+
+        Returns:
+            A judge prompt string for the specified criterion, or None if no rubric exists.
+        """
+        rubric = self.get_rubric(workshop_id)
+        if not rubric:
+            return None
+
+        # Parse rubric questions
+        questions = self._parse_rubric_questions(rubric.question)
+        if not questions:
+            # Single question rubric (legacy format)
+            questions = [
+                {
+                    "id": "q_1",
+                    "title": rubric.question.split(":")[0].strip() if ":" in rubric.question else "Response Quality",
+                    "description": rubric.question,
+                    "judge_type": rubric.judge_type or "likert",
+                }
+            ]
+
+        # Get the specific question (default to first if index out of bounds)
+        if question_index >= len(questions):
+            question_index = 0
+        question = questions[question_index]
+
+        title = question.get("title", "Response Quality")
+        description = question.get("description", "")
+        judge_type = question.get("judge_type", rubric.judge_type or "likert")
+
+        # Build rubric content: title + description
+        rubric_content = f"**{title}**"
+        if description:
+            rubric_content += f"\n{description}"
+
+        # Use the same templates as the frontend (JudgeTypeSelector.tsx)
+        if judge_type == "binary":
+            # Binary template
+            return f"""You are an expert evaluator performing a quality check on an AI assistant's response.
 
 ## Evaluation Criterion
 {rubric_content}
@@ -1247,9 +1281,8 @@ Your response MUST start with a single integer rating (0 or 1) on its own line, 
 Example format:
 1
 The response meets the criterion because..."""
-    else:
-      # Likert template (default)
-      return f"""You are an expert evaluator assessing the quality of an AI assistant's response.
+        # Likert template (default)
+        return f"""You are an expert evaluator assessing the quality of an AI assistant's response.
 
 ## Evaluation Criterion
 {rubric_content}
@@ -1270,2361 +1303,2467 @@ Rate the response on a scale of 1-5 where:
 
 Provide your rating as a single number (1-5) followed by a brief explanation."""
 
-  def get_rubric_questions_for_evaluation(self, workshop_id: str) -> List[Dict[str, Any]]:
-    """Get all rubric questions with their judge prompts for multi-judge evaluation.
+    def get_rubric_questions_for_evaluation(self, workshop_id: str) -> list[dict[str, Any]]:
+        """Get all rubric questions with their judge prompts for multi-judge evaluation.
 
-    Returns a list of dicts, each containing:
-    - judge_name: The derived judge name (e.g., "helpful_judge")
-    - judge_prompt: The prompt for this specific criterion
-    - judge_type: 'likert', 'binary', or 'freeform'
-    - question_id: The question ID (e.g., "q_1")
-    - title: The question title
-    """
-    rubric = self.get_rubric(workshop_id)
-    if not rubric:
-      return []
+        Returns a list of dicts, each containing:
+        - judge_name: The derived judge name (e.g., "helpful_judge")
+        - judge_prompt: The prompt for this specific criterion
+        - judge_type: 'likert', 'binary', or 'freeform'
+        - question_id: The question ID (e.g., "q_1")
+        - title: The question title
+        """
+        rubric = self.get_rubric(workshop_id)
+        if not rubric:
+            return []
 
-    questions = self._parse_rubric_questions(rubric.question)
-    if not questions:
-      # Single question rubric (legacy format)
-      questions = [{
-        'id': 'q_1',
-        'title': rubric.question.split(':')[0].strip() if ':' in rubric.question else 'Response Quality',
-        'description': rubric.question,
-        'judge_type': rubric.judge_type or 'likert',
-      }]
+        questions = self._parse_rubric_questions(rubric.question)
+        if not questions:
+            # Single question rubric (legacy format)
+            questions = [
+                {
+                    "id": "q_1",
+                    "title": rubric.question.split(":")[0].strip() if ":" in rubric.question else "Response Quality",
+                    "description": rubric.question,
+                    "judge_type": rubric.judge_type or "likert",
+                }
+            ]
 
-    result = []
-    for question in questions:
-      title = question.get('title', 'Response Quality')
-      description = question.get('description', '')
-      judge_type = question.get('judge_type', 'likert')
-      question_id = question.get('id', 'q_1')
+        result = []
+        for question in questions:
+            title = question.get("title", "Response Quality")
+            description = question.get("description", "")
+            judge_type = question.get("judge_type", "likert")
+            question_id = question.get("id", "q_1")
 
-      # Derive judge name from title
-      import re
-      snake_case = re.sub(r'[^a-z0-9]+', '_', title.lower()).strip('_')
-      judge_name = f"{snake_case}_judge"
+            # Derive judge name from title
+            import re
 
-      # Build prompt for this single criterion
-      prompt_parts = []
-      prompt_parts.append("You are an expert evaluator. Your task is to evaluate the quality of AI-generated responses based on a specific criterion.")
-      prompt_parts.append("")
-      prompt_parts.append("## Input")
-      prompt_parts.append("Request: {{ inputs }}")
-      prompt_parts.append("Response: {{ outputs }}")
-      prompt_parts.append("")
-      prompt_parts.append("## Evaluation Criterion")
-      prompt_parts.append(f"**Title:** {title}")
-      if description:
-        prompt_parts.append(f"**Description:** {description}")
-      prompt_parts.append("")
+            snake_case = re.sub(r"[^a-z0-9]+", "_", title.lower()).strip("_")
+            judge_name = f"{snake_case}_judge"
 
-      # Add rating instructions based on judge type
-      # NOTE: Do NOT add custom output format instructions here - MLflow InstructionsJudge
-      # expects JSON output with "result" and "rationale" fields, handled automatically
-      if judge_type == 'binary':
-        binary_labels = rubric.binary_labels or {'pass': 'Pass', 'fail': 'Fail'}
-        pass_label = binary_labels.get('pass', 'Pass')
-        fail_label = binary_labels.get('fail', 'Fail')
-        prompt_parts.append("## Rating Instructions")
-        prompt_parts.append("Provide a binary rating:")
-        prompt_parts.append(f"- 1 ({pass_label}): The response meets the criterion")
-        prompt_parts.append(f"- 0 ({fail_label}): The response does not meet the criterion")
-      else:
-        # Likert scale
-        rating_scale = rubric.rating_scale or 5
-        prompt_parts.append("## Rating Instructions")
-        prompt_parts.append(f"Rate the response on a scale of 1 to {rating_scale}:")
-        prompt_parts.append("- 1: Very poor - Does not meet the criterion at all")
-        prompt_parts.append("- 2: Poor - Barely meets the criterion")
-        prompt_parts.append("- 3: Acceptable - Partially meets the criterion")
-        prompt_parts.append("- 4: Good - Mostly meets the criterion")
-        prompt_parts.append("- 5: Excellent - Fully meets the criterion")
+            # Build prompt for this single criterion
+            prompt_parts = []
+            prompt_parts.append(
+                "You are an expert evaluator. Your task is to evaluate the quality of AI-generated responses based on a specific criterion."
+            )
+            prompt_parts.append("")
+            prompt_parts.append("## Input")
+            prompt_parts.append("Request: {{ inputs }}")
+            prompt_parts.append("Response: {{ outputs }}")
+            prompt_parts.append("")
+            prompt_parts.append("## Evaluation Criterion")
+            prompt_parts.append(f"**Title:** {title}")
+            if description:
+                prompt_parts.append(f"**Description:** {description}")
+            prompt_parts.append("")
 
-      result.append({
-        'judge_name': judge_name,
-        'judge_prompt': "\n".join(prompt_parts),
-        'judge_type': judge_type,
-        'question_id': question_id,
-        'title': title,
-      })
+            # Add rating instructions based on judge type
+            # NOTE: Do NOT add custom output format instructions here - MLflow InstructionsJudge
+            # expects JSON output with "result" and "rationale" fields, handled automatically
+            if judge_type == "binary":
+                binary_labels = rubric.binary_labels or {"pass": "Pass", "fail": "Fail"}
+                pass_label = binary_labels.get("pass", "Pass")
+                fail_label = binary_labels.get("fail", "Fail")
+                prompt_parts.append("## Rating Instructions")
+                prompt_parts.append("Provide a binary rating:")
+                prompt_parts.append(f"- 1 ({pass_label}): The response meets the criterion")
+                prompt_parts.append(f"- 0 ({fail_label}): The response does not meet the criterion")
+            else:
+                # Likert scale
+                rating_scale = rubric.rating_scale or 5
+                prompt_parts.append("## Rating Instructions")
+                prompt_parts.append(f"Rate the response on a scale of 1 to {rating_scale}:")
+                prompt_parts.append("- 1: Very poor - Does not meet the criterion at all")
+                prompt_parts.append("- 2: Poor - Barely meets the criterion")
+                prompt_parts.append("- 3: Acceptable - Partially meets the criterion")
+                prompt_parts.append("- 4: Good - Mostly meets the criterion")
+                prompt_parts.append("- 5: Excellent - Fully meets the criterion")
 
-    return result
+            result.append(
+                {
+                    "judge_name": judge_name,
+                    "judge_prompt": "\n".join(prompt_parts),
+                    "judge_type": judge_type,
+                    "question_id": question_id,
+                    "title": title,
+                }
+            )
 
-  # Annotation operations
-  def add_annotation(self, workshop_id: str, annotation_data: AnnotationCreate) -> Annotation:
-    """Add an annotation. If a duplicate exists, update the existing one."""
-    logger.info(f"📝 add_annotation called: trace_id={annotation_data.trace_id}, user_id={annotation_data.user_id}, rating={annotation_data.rating}, ratings={annotation_data.ratings}")
-    
-    # Get rubric to determine judge type for validation
-    rubric = self.get_rubric(workshop_id)
-    default_judge_type = rubric.judge_type if rubric else 'likert'
-    logger.info(f"🔍 Default judge type: {default_judge_type}")
-    
-    # Parse rubric questions to get per-question judge types
-    # Frontend uses format: {rubric_id}_{index} (e.g., "1daa749b-d147-45e3-a667-fa3eca40269b_0")
-    # Backend parses as: q_1, q_2, etc.
-    # We need to match by index, not by ID
-    question_judge_types_by_id = {}  # For direct ID matches (q_1, q_2, etc.)
-    question_judge_types_by_index = {}  # For index-based matches (rubric_id_0, rubric_id_1, etc.)
-    parsed_questions = []
-    
-    if rubric and rubric.question:
-      parsed_questions = self._parse_rubric_questions(rubric.question)
-      for index, question in enumerate(parsed_questions):
-        question_id = question.get('id')  # e.g., "q_1"
-        question_judge_type = question.get('judge_type', default_judge_type)
-        
-        # Store by backend ID (q_1, q_2, etc.)
-        if question_id:
-          question_judge_types_by_id[question_id] = question_judge_type
-        
-        # Store by index for frontend format matching
-        question_judge_types_by_index[index] = question_judge_type
-        
-        # Also store by frontend format: {rubric_id}_{index}
-        frontend_id = f"{rubric.id}_{index}"
-        question_judge_types_by_id[frontend_id] = question_judge_type
-      
-      logger.info(f"📋 Question judge types by ID: {question_judge_types_by_id}")
-      logger.info(f"📋 Question judge types by index: {question_judge_types_by_index}")
-      logger.info(f"📋 Parsed {len(parsed_questions)} questions from rubric")
-    
-    # Validate and normalize ratings based on judge type
-    validated_rating = None
-    validated_ratings = None
-    
-    if annotation_data.rating is not None:
-      validated_rating = self._validate_and_normalize_rating(annotation_data.rating, default_judge_type)
-      logger.info(f"✅ Validated legacy rating: {annotation_data.rating} -> {validated_rating}")
-    
-    # Process ratings - handle both None and empty dict cases
-    # Note: ratings can be None (not provided), {} (empty), or {'q1': 0} (with 0 values)
-    if annotation_data.ratings is not None:
-      validated_ratings = {}
-      for question_id, rating_value in annotation_data.ratings.items():
-        # Explicitly check for None (0 is a valid value, so we need to check is not None)
-        if rating_value is not None:
-          # Get judge type for this specific question
-          # Try direct ID match first (works for both q_1 format and rubric_id_0 format)
-          question_judge_type = question_judge_types_by_id.get(question_id)
-          
-          # If not found, try to extract index from frontend format (rubric_id_index)
-          if question_judge_type is None and '_' in question_id:
-            try:
-              # Extract index from format like "1daa749b-d147-45e3-a667-fa3eca40269b_0"
-              index_str = question_id.split('_')[-1]
-              index = int(index_str)
-              question_judge_type = question_judge_types_by_index.get(index)
-            except (ValueError, IndexError):
-              pass
-          
-          # Fallback to default if still not found
-          if question_judge_type is None:
-            question_judge_type = default_judge_type
-            logger.warning(f"⚠️ Could not find judge type for question_id={question_id}, using default={default_judge_type}")
-          
-          logger.info(f"🔍 Validating {question_id} with judge_type={question_judge_type}, rating_value={rating_value}")
-          # Validate the rating (including 0 for binary Fail)
-          validated_value = self._validate_and_normalize_rating(rating_value, question_judge_type)
-          # Only add if validation succeeded (returns a number, including 0)
-          # Note: 0 is a valid value, so we check is not None (0 is not None)
-          if validated_value is not None:
-            validated_ratings[question_id] = validated_value
-            logger.info(f"✅ Validated rating for {question_id}: {rating_value} -> {validated_value} (judge_type={question_judge_type})")
-          else:
-            logger.error(f"❌ Validation returned None for {question_id}: rating_value={rating_value}, judge_type={question_judge_type}")
-            # For debugging: try to understand why validation failed
-            logger.error(f"   rating_value type: {type(rating_value)}, value: {repr(rating_value)}")
-        else:
-          # rating_value is None - skip this question
-          logger.debug(f"⏭️ Skipping {question_id}: rating_value is None")
-      logger.info(f"📊 Final validated_ratings: {validated_ratings}")
-    
-    # Check if annotation already exists for this user and trace
-    # Use retry logic to handle concurrent write conflicts transparently
-    # Retries are automatic and invisible to the frontend
-    from sqlalchemy.exc import IntegrityError, OperationalError
-    import time
-    import random
+        return result
 
-    # Increased retry parameters for better handling of concurrent writes
-    # Works with both SQLite (file-level locking) and PostgreSQL (MVCC with potential deadlocks)
-    max_retries = 7  # Increased from 3 to handle more concurrent users
-    base_delay = 0.3  # Base delay in seconds (increased from 0.2)
-    max_delay = 5.0  # Maximum delay between retries
-    annotation_id = str(uuid.uuid4())
-    
-    last_error = None
-    for attempt in range(max_retries):
-      try:
-        # Note: with_for_update() is not used for cross-database compatibility
-        # (SQLite uses file-level locking; PostgreSQL supports row-level but this works for both)
-        existing_annotation = (
-          self.db.query(AnnotationDB)
-          .filter(AnnotationDB.user_id == annotation_data.user_id, AnnotationDB.trace_id == annotation_data.trace_id)
-          .first()
+    # Annotation operations
+    def add_annotation(self, workshop_id: str, annotation_data: AnnotationCreate) -> Annotation:
+        """Add an annotation. If a duplicate exists, update the existing one."""
+        logger.info(
+            f"📝 add_annotation called: trace_id={annotation_data.trace_id}, user_id={annotation_data.user_id}, rating={annotation_data.rating}, ratings={annotation_data.ratings}"
         )
 
-        if existing_annotation:
-          logger.info(f"🔄 Updating existing annotation: id={existing_annotation.id}, current ratings={existing_annotation.ratings}")
-          # Update existing annotation - only update fields that are provided
-          if validated_rating is not None:
-            existing_annotation.rating = validated_rating
-            logger.info(f"  → Updated rating: {validated_rating}")
-          # Always update ratings if provided and validated
-          # validated_ratings will be None if ratings was not provided, or a dict if it was
-          if annotation_data.ratings is not None and validated_ratings is not None:
-            # Only update if we have validated ratings
-            # Note: validated_ratings can be {} if all validations failed, but we still update to clear
-            # However, if we received ratings but got empty dict, log a warning
-            if len(validated_ratings) == 0 and len(annotation_data.ratings) > 0:
-              logger.warning(f"⚠️ All ratings failed validation! Received: {annotation_data.ratings}, but validated_ratings is empty")
-              logger.warning("⚠️ Not updating ratings to avoid clearing existing data")
-            else:
-              existing_annotation.ratings = validated_ratings
-              logger.info(f"  → Updated ratings: {existing_annotation.ratings}")
-          elif annotation_data.ratings is not None:
-            # Ratings were provided but validation failed completely - log error
-            logger.error(f"❌ Ratings provided but validation failed completely: {annotation_data.ratings}")
-          if annotation_data.comment is not None:
-            existing_annotation.comment = annotation_data.comment
-            logger.info("  → Updated comment")
-          self.db.commit()
-          self.db.refresh(existing_annotation)
-          logger.info(f"✅ Annotation updated in DB: id={existing_annotation.id}, ratings={existing_annotation.ratings}")
-          self._sync_annotation_with_mlflow(workshop_id, existing_annotation)
+        # Get rubric to determine judge type for validation
+        rubric = self.get_rubric(workshop_id)
+        default_judge_type = rubric.judge_type if rubric else "likert"
+        logger.info(f"🔍 Default judge type: {default_judge_type}")
 
-          return Annotation(
-            id=existing_annotation.id,
-            workshop_id=existing_annotation.workshop_id,
-            trace_id=existing_annotation.trace_id,
-            user_id=existing_annotation.user_id,
-            rating=existing_annotation.rating,
-            ratings=existing_annotation.ratings,
-            comment=existing_annotation.comment,
-            mlflow_trace_id=existing_annotation.trace.mlflow_trace_id,
-            created_at=existing_annotation.created_at,
-          )
-        else:
-          # Create new annotation
-          logger.info(f"🆕 Creating new annotation (attempt {attempt + 1}/{max_retries})")
-          db_annotation = AnnotationDB(
-            id=annotation_id,
-            workshop_id=workshop_id,
-            trace_id=annotation_data.trace_id,
-            user_id=annotation_data.user_id,
-            rating=validated_rating,
-            ratings=validated_ratings,
-            comment=annotation_data.comment,
-          )
-          logger.info(f"📝 New annotation object: rating={validated_rating}, ratings={validated_ratings}")
-          self.db.add(db_annotation)
-          self.db.commit()
-          self.db.refresh(db_annotation)
-          logger.info(f"✅ Annotation created in DB: id={db_annotation.id}, ratings={db_annotation.ratings}")
-          self._sync_annotation_with_mlflow(workshop_id, db_annotation)
+        # Parse rubric questions to get per-question judge types
+        # Frontend uses format: {rubric_id}_{index} (e.g., "1daa749b-d147-45e3-a667-fa3eca40269b_0")
+        # Backend parses as: q_1, q_2, etc.
+        # We need to match by index, not by ID
+        question_judge_types_by_id = {}  # For direct ID matches (q_1, q_2, etc.)
+        question_judge_types_by_index = {}  # For index-based matches (rubric_id_0, rubric_id_1, etc.)
+        parsed_questions = []
 
-          return Annotation(
-            id=db_annotation.id,
-            workshop_id=db_annotation.workshop_id,
-            trace_id=db_annotation.trace_id,
-            user_id=db_annotation.user_id,
-            rating=db_annotation.rating,
-            ratings=db_annotation.ratings,
-            comment=db_annotation.comment,
-            mlflow_trace_id=db_annotation.trace.mlflow_trace_id if db_annotation.trace else None,
-            created_at=db_annotation.created_at,
-          )
-            
-      except IntegrityError as e:
-        # Handle race condition - another request inserted the same record
-        last_error = e
-        logger.warning(f"⚠️ IntegrityError on annotation save (attempt {attempt + 1}/{max_retries}): {e}")
-        self.db.rollback()
-        # Expire all objects to ensure clean state for retry
-        self.db.expire_all()
-        if attempt < max_retries - 1:
-          # Exponential backoff with jitter to prevent thundering herd
-          delay = min(base_delay * (2 ** attempt) + random.uniform(0, 0.5), max_delay)
-          logger.info(f"🔄 Retrying in {delay:.2f}s...")
-          time.sleep(delay)
-          continue
-        else:
-          # On final attempt, try to fetch and update the existing record
-          logger.info("🔄 Final attempt: fetching existing annotation to update")
-          try:
-            existing = self.db.query(AnnotationDB).filter(
-              AnnotationDB.user_id == annotation_data.user_id,
-              AnnotationDB.trace_id == annotation_data.trace_id
-            ).first()
-            if existing:
-              if validated_rating is not None:
-                existing.rating = validated_rating
-              if validated_ratings is not None:
-                existing.ratings = validated_ratings
-              if annotation_data.comment is not None:
-                existing.comment = annotation_data.comment
-              self.db.commit()
-              self.db.refresh(existing)
-              logger.info(f"✅ Annotation updated after conflict: id={existing.id}")
-              self._sync_annotation_with_mlflow(workshop_id, existing)
-              return Annotation(
-                id=existing.id,
-                workshop_id=existing.workshop_id,
-                trace_id=existing.trace_id,
-                user_id=existing.user_id,
-                rating=existing.rating,
-                ratings=existing.ratings,
-                comment=existing.comment,
-                mlflow_trace_id=existing.trace.mlflow_trace_id if existing.trace else None,
-                created_at=existing.created_at,
-              )
-          except Exception as final_error:
-            logger.error(f"❌ Final recovery attempt also failed: {final_error}")
-          raise e
-          
-      except OperationalError as e:
-        # Handle database contention errors (locked/busy for SQLite, deadlocks for PostgreSQL)
-        last_error = e
-        error_msg = str(e).lower()
-        if 'locked' in error_msg or 'busy' in error_msg or 'deadlock' in error_msg:
-          logger.warning(f"⚠️ Database contention on annotation save (attempt {attempt + 1}/{max_retries}): {e}")
-        else:
-          logger.warning(f"⚠️ OperationalError on annotation save (attempt {attempt + 1}/{max_retries}): {e}")
-        self.db.rollback()
-        # Expire all objects to ensure clean state for retry
-        self.db.expire_all()
-        if attempt < max_retries - 1:
-          # Extra delay for database contention with jitter to prevent thundering herd
-          delay = min(base_delay * (2 ** attempt) + 0.5 + random.uniform(0, 1.0), max_delay)
-          logger.info(f"🔄 Retrying in {delay:.2f}s...")
-          time.sleep(delay)
-          continue
-        raise e
-        
-      except Exception as e:
-        last_error = e
-        logger.error(f"❌ Error saving annotation (attempt {attempt + 1}/{max_retries}): {e}")
-        self.db.rollback()
-        # Expire all objects to ensure clean state for retry
-        self.db.expire_all()
-        if attempt < max_retries - 1:
-          # Exponential backoff with jitter
-          delay = min(base_delay * (2 ** attempt) + random.uniform(0, 0.5), max_delay)
-          logger.info(f"🔄 Retrying in {delay:.2f}s...")
-          time.sleep(delay)
-          continue
-        raise e
-    
-    # This shouldn't be reached, but just in case
-    logger.error(f"❌ Failed to save annotation after all {max_retries} retries (loop exhausted)")
-    raise last_error or Exception("Failed to save annotation after all retries")
+        if rubric and rubric.question:
+            parsed_questions = self._parse_rubric_questions(rubric.question)
+            for index, question in enumerate(parsed_questions):
+                question_id = question.get("id")  # e.g., "q_1"
+                question_judge_type = question.get("judge_type", default_judge_type)
 
-  def _validate_and_normalize_rating(self, rating: any, judge_type: str) -> Optional[int]:
-    """Validate and normalize a rating based on judge type.
-    
-    Returns:
-      - For binary: 0 or 1 (normalizes any truthy value to 1, falsy to 0)
-      - For Likert: 1-5 (clamps to valid range)
-      - None if rating is invalid
-    """
-    logger.debug(f"🔍 _validate_and_normalize_rating: rating={rating} (type={type(rating)}), judge_type={judge_type}")
-    
-    if rating is None:
-      logger.debug("  → Rating is None, returning None")
-      return None
-    
-    # Convert to int if possible
-    try:
-      rating_int = int(float(rating))
-      logger.debug(f"  → Converted to int: {rating_int}")
-    except (ValueError, TypeError) as e:
-      logger.warning(f"  → Failed to convert to int: {e}")
-      return None
-    
-    if judge_type == 'binary':
-      # Binary: only 0 or 1 are valid
-      if rating_int == 0:
-        logger.debug("  → Binary rating 0 (Fail) - returning 0")
-        return 0
-      elif rating_int == 1:
-        logger.debug("  → Binary rating 1 (Pass) - returning 1")
-        return 1
-      else:
-        # Normalize: any non-zero becomes 1, but log a warning
-        logger.warning(f"Invalid binary rating {rating_int}, normalizing to 1")
-        return 1
-    else:
-      # Likert: 1-5 are valid
-      if 1 <= rating_int <= 5:
-        return rating_int
-      else:
+                # Store by backend ID (q_1, q_2, etc.)
+                if question_id:
+                    question_judge_types_by_id[question_id] = question_judge_type
+
+                # Store by index for frontend format matching
+                question_judge_types_by_index[index] = question_judge_type
+
+                # Also store by frontend format: {rubric_id}_{index}
+                frontend_id = f"{rubric.id}_{index}"
+                question_judge_types_by_id[frontend_id] = question_judge_type
+
+            logger.info(f"📋 Question judge types by ID: {question_judge_types_by_id}")
+            logger.info(f"📋 Question judge types by index: {question_judge_types_by_index}")
+            logger.info(f"📋 Parsed {len(parsed_questions)} questions from rubric")
+
+        # Validate and normalize ratings based on judge type
+        validated_rating = None
+        validated_ratings = None
+
+        if annotation_data.rating is not None:
+            validated_rating = self._validate_and_normalize_rating(annotation_data.rating, default_judge_type)
+            logger.info(f"✅ Validated legacy rating: {annotation_data.rating} -> {validated_rating}")
+
+        # Process ratings - handle both None and empty dict cases
+        # Note: ratings can be None (not provided), {} (empty), or {'q1': 0} (with 0 values)
+        if annotation_data.ratings is not None:
+            validated_ratings = {}
+            for question_id, rating_value in annotation_data.ratings.items():
+                # Explicitly check for None (0 is a valid value, so we need to check is not None)
+                if rating_value is not None:
+                    # Get judge type for this specific question
+                    # Try direct ID match first (works for both q_1 format and rubric_id_0 format)
+                    question_judge_type = question_judge_types_by_id.get(question_id)
+
+                    # If not found, try to extract index from frontend format (rubric_id_index)
+                    if question_judge_type is None and "_" in question_id:
+                        try:
+                            # Extract index from format like "1daa749b-d147-45e3-a667-fa3eca40269b_0"
+                            index_str = question_id.split("_")[-1]
+                            index = int(index_str)
+                            question_judge_type = question_judge_types_by_index.get(index)
+                        except (ValueError, IndexError):
+                            pass
+
+                    # Fallback to default if still not found
+                    if question_judge_type is None:
+                        question_judge_type = default_judge_type
+                        logger.warning(
+                            f"⚠️ Could not find judge type for question_id={question_id}, using default={default_judge_type}"
+                        )
+
+                    logger.info(
+                        f"🔍 Validating {question_id} with judge_type={question_judge_type}, rating_value={rating_value}"
+                    )
+                    # Validate the rating (including 0 for binary Fail)
+                    validated_value = self._validate_and_normalize_rating(rating_value, question_judge_type)
+                    # Only add if validation succeeded (returns a number, including 0)
+                    # Note: 0 is a valid value, so we check is not None (0 is not None)
+                    if validated_value is not None:
+                        validated_ratings[question_id] = validated_value
+                        logger.info(
+                            f"✅ Validated rating for {question_id}: {rating_value} -> {validated_value} (judge_type={question_judge_type})"
+                        )
+                    else:
+                        logger.error(
+                            f"❌ Validation returned None for {question_id}: rating_value={rating_value}, judge_type={question_judge_type}"
+                        )
+                        # For debugging: try to understand why validation failed
+                        logger.error(f"   rating_value type: {type(rating_value)}, value: {rating_value!r}")
+                else:
+                    # rating_value is None - skip this question
+                    logger.debug(f"⏭️ Skipping {question_id}: rating_value is None")
+            logger.info(f"📊 Final validated_ratings: {validated_ratings}")
+
+        # Check if annotation already exists for this user and trace
+        # Use retry logic to handle concurrent write conflicts transparently
+        # Retries are automatic and invisible to the frontend
+        import random
+        import time
+
+        from sqlalchemy.exc import IntegrityError, OperationalError
+
+        # Increased retry parameters for better handling of concurrent writes
+        # Works with both SQLite (file-level locking) and PostgreSQL (MVCC with potential deadlocks)
+        max_retries = 7  # Increased from 3 to handle more concurrent users
+        base_delay = 0.3  # Base delay in seconds (increased from 0.2)
+        max_delay = 5.0  # Maximum delay between retries
+        annotation_id = str(uuid.uuid4())
+
+        last_error = None
+        for attempt in range(max_retries):
+            try:
+                # Note: with_for_update() is not used for cross-database compatibility
+                # (SQLite uses file-level locking; PostgreSQL supports row-level but this works for both)
+                existing_annotation = (
+                    self.db.query(AnnotationDB)
+                    .filter(
+                        AnnotationDB.user_id == annotation_data.user_id,
+                        AnnotationDB.trace_id == annotation_data.trace_id,
+                    )
+                    .first()
+                )
+
+                if existing_annotation:
+                    logger.info(
+                        f"🔄 Updating existing annotation: id={existing_annotation.id}, current ratings={existing_annotation.ratings}"
+                    )
+                    # Update existing annotation - only update fields that are provided
+                    if validated_rating is not None:
+                        existing_annotation.rating = validated_rating
+                        logger.info(f"  → Updated rating: {validated_rating}")
+                    # Always update ratings if provided and validated
+                    # validated_ratings will be None if ratings was not provided, or a dict if it was
+                    if annotation_data.ratings is not None and validated_ratings is not None:
+                        # Only update if we have validated ratings
+                        # Note: validated_ratings can be {} if all validations failed, but we still update to clear
+                        # However, if we received ratings but got empty dict, log a warning
+                        if len(validated_ratings) == 0 and len(annotation_data.ratings) > 0:
+                            logger.warning(
+                                f"⚠️ All ratings failed validation! Received: {annotation_data.ratings}, but validated_ratings is empty"
+                            )
+                            logger.warning("⚠️ Not updating ratings to avoid clearing existing data")
+                        else:
+                            existing_annotation.ratings = validated_ratings
+                            logger.info(f"  → Updated ratings: {existing_annotation.ratings}")
+                    elif annotation_data.ratings is not None:
+                        # Ratings were provided but validation failed completely - log error
+                        logger.error(f"❌ Ratings provided but validation failed completely: {annotation_data.ratings}")
+                    if annotation_data.comment is not None:
+                        existing_annotation.comment = annotation_data.comment
+                        logger.info("  → Updated comment")
+                    self.db.commit()
+                    self.db.refresh(existing_annotation)
+                    logger.info(
+                        f"✅ Annotation updated in DB: id={existing_annotation.id}, ratings={existing_annotation.ratings}"
+                    )
+                    self._sync_annotation_with_mlflow(workshop_id, existing_annotation)
+
+                    return Annotation(
+                        id=existing_annotation.id,
+                        workshop_id=existing_annotation.workshop_id,
+                        trace_id=existing_annotation.trace_id,
+                        user_id=existing_annotation.user_id,
+                        rating=existing_annotation.rating,
+                        ratings=existing_annotation.ratings,
+                        comment=existing_annotation.comment,
+                        mlflow_trace_id=existing_annotation.trace.mlflow_trace_id,
+                        created_at=existing_annotation.created_at,
+                    )
+                # Create new annotation
+                logger.info(f"🆕 Creating new annotation (attempt {attempt + 1}/{max_retries})")
+                db_annotation = AnnotationDB(
+                    id=annotation_id,
+                    workshop_id=workshop_id,
+                    trace_id=annotation_data.trace_id,
+                    user_id=annotation_data.user_id,
+                    rating=validated_rating,
+                    ratings=validated_ratings,
+                    comment=annotation_data.comment,
+                )
+                logger.info(f"📝 New annotation object: rating={validated_rating}, ratings={validated_ratings}")
+                self.db.add(db_annotation)
+                self.db.commit()
+                self.db.refresh(db_annotation)
+                logger.info(f"✅ Annotation created in DB: id={db_annotation.id}, ratings={db_annotation.ratings}")
+                self._sync_annotation_with_mlflow(workshop_id, db_annotation)
+
+                return Annotation(
+                    id=db_annotation.id,
+                    workshop_id=db_annotation.workshop_id,
+                    trace_id=db_annotation.trace_id,
+                    user_id=db_annotation.user_id,
+                    rating=db_annotation.rating,
+                    ratings=db_annotation.ratings,
+                    comment=db_annotation.comment,
+                    mlflow_trace_id=db_annotation.trace.mlflow_trace_id if db_annotation.trace else None,
+                    created_at=db_annotation.created_at,
+                )
+
+            except IntegrityError as e:
+                # Handle race condition - another request inserted the same record
+                last_error = e
+                logger.warning(f"⚠️ IntegrityError on annotation save (attempt {attempt + 1}/{max_retries}): {e}")
+                self.db.rollback()
+                # Expire all objects to ensure clean state for retry
+                self.db.expire_all()
+                if attempt < max_retries - 1:
+                    # Exponential backoff with jitter to prevent thundering herd
+                    delay = min(base_delay * (2**attempt) + random.uniform(0, 0.5), max_delay)
+                    logger.info(f"🔄 Retrying in {delay:.2f}s...")
+                    time.sleep(delay)
+                    continue
+                # On final attempt, try to fetch and update the existing record
+                logger.info("🔄 Final attempt: fetching existing annotation to update")
+                try:
+                    existing = (
+                        self.db.query(AnnotationDB)
+                        .filter(
+                            AnnotationDB.user_id == annotation_data.user_id,
+                            AnnotationDB.trace_id == annotation_data.trace_id,
+                        )
+                        .first()
+                    )
+                    if existing:
+                        if validated_rating is not None:
+                            existing.rating = validated_rating
+                        if validated_ratings is not None:
+                            existing.ratings = validated_ratings
+                        if annotation_data.comment is not None:
+                            existing.comment = annotation_data.comment
+                        self.db.commit()
+                        self.db.refresh(existing)
+                        logger.info(f"✅ Annotation updated after conflict: id={existing.id}")
+                        self._sync_annotation_with_mlflow(workshop_id, existing)
+                        return Annotation(
+                            id=existing.id,
+                            workshop_id=existing.workshop_id,
+                            trace_id=existing.trace_id,
+                            user_id=existing.user_id,
+                            rating=existing.rating,
+                            ratings=existing.ratings,
+                            comment=existing.comment,
+                            mlflow_trace_id=existing.trace.mlflow_trace_id if existing.trace else None,
+                            created_at=existing.created_at,
+                        )
+                except Exception as final_error:
+                    logger.error(f"❌ Final recovery attempt also failed: {final_error}")
+                raise e
+
+            except OperationalError as e:
+                # Handle database contention errors (locked/busy for SQLite, deadlocks for PostgreSQL)
+                last_error = e
+                error_msg = str(e).lower()
+                if "locked" in error_msg or "busy" in error_msg or "deadlock" in error_msg:
+                    logger.warning(
+                        f"⚠️ Database contention on annotation save (attempt {attempt + 1}/{max_retries}): {e}"
+                    )
+                else:
+                    logger.warning(f"⚠️ OperationalError on annotation save (attempt {attempt + 1}/{max_retries}): {e}")
+                self.db.rollback()
+                # Expire all objects to ensure clean state for retry
+                self.db.expire_all()
+                if attempt < max_retries - 1:
+                    # Extra delay for database contention with jitter to prevent thundering herd
+                    delay = min(base_delay * (2**attempt) + 0.5 + random.uniform(0, 1.0), max_delay)
+                    logger.info(f"🔄 Retrying in {delay:.2f}s...")
+                    time.sleep(delay)
+                    continue
+                raise e
+
+            except Exception as e:
+                last_error = e
+                logger.error(f"❌ Error saving annotation (attempt {attempt + 1}/{max_retries}): {e}")
+                self.db.rollback()
+                # Expire all objects to ensure clean state for retry
+                self.db.expire_all()
+                if attempt < max_retries - 1:
+                    # Exponential backoff with jitter
+                    delay = min(base_delay * (2**attempt) + random.uniform(0, 0.5), max_delay)
+                    logger.info(f"🔄 Retrying in {delay:.2f}s...")
+                    time.sleep(delay)
+                    continue
+                raise e
+
+        # This shouldn't be reached, but just in case
+        logger.error(f"❌ Failed to save annotation after all {max_retries} retries (loop exhausted)")
+        raise last_error or Exception("Failed to save annotation after all retries")
+
+    def _validate_and_normalize_rating(self, rating: any, judge_type: str) -> int | None:
+        """Validate and normalize a rating based on judge type.
+
+        Returns:
+          - For binary: 0 or 1 (normalizes any truthy value to 1, falsy to 0)
+          - For Likert: 1-5 (clamps to valid range)
+          - None if rating is invalid
+        """
+        logger.debug(
+            f"🔍 _validate_and_normalize_rating: rating={rating} (type={type(rating)}), judge_type={judge_type}"
+        )
+
+        if rating is None:
+            logger.debug("  → Rating is None, returning None")
+            return None
+
+        # Convert to int if possible
+        try:
+            rating_int = int(float(rating))
+            logger.debug(f"  → Converted to int: {rating_int}")
+        except (ValueError, TypeError) as e:
+            logger.warning(f"  → Failed to convert to int: {e}")
+            return None
+
+        if judge_type == "binary":
+            # Binary: only 0 or 1 are valid
+            if rating_int == 0:
+                logger.debug("  → Binary rating 0 (Fail) - returning 0")
+                return 0
+            if rating_int == 1:
+                logger.debug("  → Binary rating 1 (Pass) - returning 1")
+                return 1
+            # Normalize: any non-zero becomes 1, but log a warning
+            logger.warning(f"Invalid binary rating {rating_int}, normalizing to 1")
+            return 1
+        # Likert: 1-5 are valid
+        if 1 <= rating_int <= 5:
+            return rating_int
         # Clamp to valid range
         clamped = max(1, min(5, rating_int))
         logger.warning(f"Invalid Likert rating {rating_int}, clamping to {clamped}")
         return clamped
 
-  def _derive_judge_name_from_title(self, title: str) -> str:
-    """Convert a question title to a judge name (snake_case + _judge)."""
-    import re
-    # Convert to snake_case: lowercase, replace non-alphanumeric with _, remove leading/trailing _
-    snake_case = re.sub(r'[^a-z0-9]+', '_', title.lower()).strip('_')
-    return f"{snake_case}_judge" if snake_case else "workshop_judge"
+    def _derive_judge_name_from_title(self, title: str) -> str:
+        """Convert a question title to a judge name (snake_case + _judge)."""
+        import re
 
-  def _sync_annotation_with_mlflow(self, workshop_id: str, annotation_db: AnnotationDB) -> dict:
-    """Ensure MLflow trace carries SME tag + feedback once an annotation is captured.
+        # Convert to snake_case: lowercase, replace non-alphanumeric with _, remove leading/trailing _
+        snake_case = re.sub(r"[^a-z0-9]+", "_", title.lower()).strip("_")
+        return f"{snake_case}_judge" if snake_case else "workshop_judge"
 
-    Logs ALL ratings (one per rubric question) as separate MLflow feedback entries,
-    with judge names derived from the rubric question titles.
+    def _sync_annotation_with_mlflow(self, workshop_id: str, annotation_db: AnnotationDB) -> dict:
+        """Ensure MLflow trace carries SME tag + feedback once an annotation is captured.
 
-    Returns:
-      Dict with 'logged' and 'skipped' counts
-    """
-    result = {'logged': 0, 'skipped': 0, 'error': None}
+        Logs ALL ratings (one per rubric question) as separate MLflow feedback entries,
+        with judge names derived from the rubric question titles.
 
-    if not annotation_db or not getattr(annotation_db, 'trace', None):
-      logger.warning("_sync_annotation_with_mlflow: annotation or trace is None")
-      result['error'] = 'annotation or trace is None'
-      return result
+        Returns:
+          Dict with 'logged' and 'skipped' counts
+        """
+        result = {"logged": 0, "skipped": 0, "error": None}
 
-    mlflow_trace_id = getattr(annotation_db.trace, 'mlflow_trace_id', None)
-    if not mlflow_trace_id:
-      logger.warning(f"⚠️ _sync_annotation_with_mlflow: trace {annotation_db.trace_id[:8] if annotation_db.trace_id else 'None'}... has no mlflow_trace_id")
-      result['error'] = 'no mlflow_trace_id'
-      return result
+        if not annotation_db or not getattr(annotation_db, "trace", None):
+            logger.warning("_sync_annotation_with_mlflow: annotation or trace is None")
+            result["error"] = "annotation or trace is None"
+            return result
 
-    logger.info(f"🔄 _sync_annotation_with_mlflow: syncing annotation to MLflow trace {mlflow_trace_id[:20]}...")
+        mlflow_trace_id = getattr(annotation_db.trace, "mlflow_trace_id", None)
+        if not mlflow_trace_id:
+            logger.warning(
+                f"⚠️ _sync_annotation_with_mlflow: trace {annotation_db.trace_id[:8] if annotation_db.trace_id else 'None'}... has no mlflow_trace_id"
+            )
+            result["error"] = "no mlflow_trace_id"
+            return result
 
-    config = (
-      self.db.query(MLflowIntakeConfigDB)
-      .filter(MLflowIntakeConfigDB.workshop_id == workshop_id)
-      .first()
-    )
-    if not config or not config.databricks_host or not config.experiment_id:
-      logger.debug('Skipping MLflow sync: config missing for workshop %s', workshop_id)
-      result['error'] = 'config missing'
-      return result
+        logger.info(f"🔄 _sync_annotation_with_mlflow: syncing annotation to MLflow trace {mlflow_trace_id[:20]}...")
 
-    databricks_token = token_storage.get_token(workshop_id)
-    if not databricks_token:
-      databricks_token = self.get_databricks_token(workshop_id)
-      if databricks_token:
-        token_storage.store_token(workshop_id, databricks_token)
-    if not databricks_token:
-      logger.debug('Skipping MLflow sync: token missing for workshop %s', workshop_id)
-      result['error'] = 'token missing'
-      return result
+        config = self.db.query(MLflowIntakeConfigDB).filter(MLflowIntakeConfigDB.workshop_id == workshop_id).first()
+        if not config or not config.databricks_host or not config.experiment_id:
+            logger.debug("Skipping MLflow sync: config missing for workshop %s", workshop_id)
+            result["error"] = "config missing"
+            return result
 
-    try:
-      import mlflow
-      from mlflow.entities import AssessmentSource, AssessmentSourceType
-    except ImportError:
-      logger.warning('MLflow is not available; cannot sync annotation feedback.')
-      result['error'] = 'mlflow not available'
-      return result
+        databricks_token = token_storage.get_token(workshop_id)
+        if not databricks_token:
+            databricks_token = self.get_databricks_token(workshop_id)
+            if databricks_token:
+                token_storage.store_token(workshop_id, databricks_token)
+        if not databricks_token:
+            logger.debug("Skipping MLflow sync: token missing for workshop %s", workshop_id)
+            result["error"] = "token missing"
+            return result
 
-    os.environ['DATABRICKS_HOST'] = config.databricks_host.rstrip('/')
-    os.environ['DATABRICKS_TOKEN'] = databricks_token
-    os.environ.pop('DATABRICKS_CLIENT_ID', None)
-    os.environ.pop('DATABRICKS_CLIENT_SECRET', None)
-
-    mlflow.set_tracking_uri('databricks')
-
-    try:
-      mlflow.set_experiment(experiment_id=config.experiment_id)
-    except Exception as exc:
-      logger.warning('Failed to set MLflow experiment %s: %s', config.experiment_id, exc)
-      result['error'] = f'failed to set experiment: {exc}'
-      return result
-
-    set_trace_tag = getattr(mlflow, 'set_trace_tag', None)
-    # Tag with 'align' label for alignment after human annotation
-    tags = {
-      'label': 'align',
-      'workshop_id': workshop_id,
-    }
-    if set_trace_tag:
-      for key, value in tags.items():
-        # Use retry logic for tagging - bind variables via default args
-        def _set_tag(_tid=mlflow_trace_id, _key=key, _val=value, _set_fn=set_trace_tag):
-          _set_fn(trace_id=_tid, key=_key, value=_val)
-          return True
-
-        _retry_mlflow_operation(
-          _set_tag,
-          max_retries=3,
-          description=f"set_trace_tag({key}) for {mlflow_trace_id[:12]}..."
-        )
-    else:
-      logger.debug('mlflow.set_trace_tag not available; skip tagging for trace %s', mlflow_trace_id)
-
-    # Get rubric questions to map question IDs to titles for judge names
-    rubric_db = self.db.query(RubricDB).filter(RubricDB.workshop_id == workshop_id).first()
-    question_titles_by_index = {}
-    if rubric_db and rubric_db.question:
-      # Parse rubric questions to get titles
-      # Support both new delimiter (|||QUESTION_SEPARATOR|||) and legacy delimiter (---) 
-      QUESTION_DELIMITER_NEW = '|||QUESTION_SEPARATOR|||'
-      QUESTION_DELIMITER_LEGACY = '---'
-      
-      if QUESTION_DELIMITER_NEW in rubric_db.question:
-        questions = rubric_db.question.split(QUESTION_DELIMITER_NEW)
-      else:
-        questions = rubric_db.question.split(QUESTION_DELIMITER_LEGACY)
-      
-      for idx, q in enumerate(questions):
-        q = q.strip()
-        if not q:
-          continue
-        # Extract title (before first colon, or before |||JUDGE_TYPE|||)
-        if '|||JUDGE_TYPE|||' in q:
-          content_part = q.split('|||JUDGE_TYPE|||')[0]
-        else:
-          content_part = q
-        colon_idx = content_part.find(':')
-        title = content_part[:colon_idx].strip() if colon_idx > 0 else content_part.strip()
-        question_titles_by_index[idx] = title
-        logger.debug(f"Parsed rubric question {idx}: title='{title}'")
-
-    rationale = annotation_db.comment.strip() if annotation_db.comment else None
-    source = AssessmentSource(
-      source_type=AssessmentSourceType.HUMAN,
-      source_id=annotation_db.user_id or workshop_id,
-    )
-
-    # Check existing assessments on this trace to avoid duplicates and hitting the 50 limit
-    # Track by (name, source_id) tuple so different users can have assessments with the same name
-    existing_assessments = set()  # Set of (name, source_id) tuples
-    current_user_id = annotation_db.user_id or workshop_id
-    try:
-      trace = mlflow.get_trace(mlflow_trace_id)
-      if trace and hasattr(trace, 'info') and hasattr(trace.info, 'assessments'):
-        for assessment in (trace.info.assessments or []):
-          # Track existing human assessments by (name, source_id) - allows multiple users
-          if hasattr(assessment, 'source') and assessment.source:
-            if hasattr(assessment.source, 'source_type') and assessment.source.source_type == AssessmentSourceType.HUMAN:
-              if hasattr(assessment, 'name'):
-                source_id = getattr(assessment.source, 'source_id', None)
-                existing_assessments.add((assessment.name, source_id))
-      logger.info(f"📊 Trace {mlflow_trace_id[:12]}... has existing HUMAN assessments: {existing_assessments}")
-      logger.info(f"📊 Current user: {current_user_id}")
-    except Exception as e:
-      logger.warning(f"Could not fetch existing assessments for trace {mlflow_trace_id}: {e}")
-    
-    # Log ALL ratings from the ratings dict (one per rubric question)
-    logger.info(f"📊 MLflow sync: annotation has ratings={annotation_db.ratings}")
-    logger.info(f"📊 MLflow sync: question_titles_by_index={question_titles_by_index}")
-    
-    if annotation_db.ratings:
-      logged_count = 0
-      skipped_count = 0
-      for question_id, rating_value in annotation_db.ratings.items():
-        if rating_value is None:
-          logger.debug(f"Skipping question_id={question_id} (rating is None)")
-          continue
-        
-        # Extract index from question_id
-        # Supports two formats:
-        # - "q_1", "q_2", etc. (1-based, old format)
-        # - "{rubric_id}_0", "{rubric_id}_1", etc. (0-based, new format)
         try:
-          index_str = question_id.split('_')[-1]
-          index = int(index_str)
-          
-          # If format is "q_N" (1-based), convert to 0-based
-          # If format is "{uuid}_N" (0-based), use as-is
-          if question_id.startswith('q_'):
-            index = index - 1  # Convert 1-based to 0-based
-          # else: already 0-based (rubric_id_N format)
-          
-          logger.debug(f"Parsed question_id={question_id} → index={index}")
-        except (ValueError, IndexError) as e:
-          logger.warning(f"Failed to parse question_id={question_id}: {e}, defaulting to index=0")
-          index = 0
-        
-        # Get question title and derive judge name
-        question_title = question_titles_by_index.get(index, f"question_{index + 1}")
-        judge_name = self._derive_judge_name_from_title(question_title)
-        logger.info(f"📊 Question {question_id}: index={index} → title='{question_title}' → judge_name='{judge_name}'")
-        
-        # Skip if THIS USER already has a HUMAN assessment with this judge name on this trace
-        # Different users can have their own assessments with the same judge name
-        if (judge_name, current_user_id) in existing_assessments:
-          logger.info(f"✓ Skipping {judge_name} for user {current_user_id} - already exists on trace {mlflow_trace_id[:12]}...")
-          skipped_count += 1
-          continue
-        
-        # Use retry logic for MLflow API call
-        rationale_for_this = rationale if logged_count == 0 else None
-        # Bind loop variables via default args to avoid closure issues
-        def _log_feedback(_tid=mlflow_trace_id, _name=judge_name, _val=rating_value, _src=source, _rat=rationale_for_this):
-          mlflow.log_feedback(
-            trace_id=_tid,
-            name=_name,
-            value=_val,
-            source=_src,
-            rationale=_rat,
-          )
-          return True
+            import mlflow
+            from mlflow.entities import AssessmentSource, AssessmentSourceType
+        except ImportError:
+            logger.warning("MLflow is not available; cannot sync annotation feedback.")
+            result["error"] = "mlflow not available"
+            return result
 
-        api_result = _retry_mlflow_operation(
-          _log_feedback,
-          max_retries=3,
-          description=f"log_feedback({judge_name}) for trace {mlflow_trace_id[:12]}..."
-        )
-        if api_result:
-          logged_count += 1
-          logger.info(f"Logged MLflow feedback: {judge_name}={rating_value} for trace {mlflow_trace_id}")
+        os.environ["DATABRICKS_HOST"] = config.databricks_host.rstrip("/")
+        os.environ["DATABRICKS_TOKEN"] = databricks_token
+        os.environ.pop("DATABRICKS_CLIENT_ID", None)
+        os.environ.pop("DATABRICKS_CLIENT_SECRET", None)
 
-      if logged_count > 0 or skipped_count > 0:
-        logger.info(f"MLflow sync for trace {mlflow_trace_id[:12]}...: logged={logged_count}, skipped={skipped_count}")
-        return {'logged': logged_count, 'skipped': skipped_count, 'error': None}
+        mlflow.set_tracking_uri("databricks")
 
-    # Fallback: log legacy single rating if no ratings dict
-    if annotation_db.rating is not None:
-      # Get the workshop's judge_name as fallback
-      workshop_db = self.db.query(WorkshopDB).filter(WorkshopDB.id == workshop_id).first()
-      judge_name = workshop_db.judge_name if workshop_db and workshop_db.judge_name else 'workshop_judge'
-
-      # Skip if THIS USER already has this assessment
-      if (judge_name, current_user_id) in existing_assessments:
-        logger.info(f"✓ Skipping legacy {judge_name} for user {current_user_id} - already exists on trace {mlflow_trace_id[:12]}...")
-        return {'logged': 0, 'skipped': 1, 'error': None}
-
-      # Use retry logic for legacy rating
-      rating_val = annotation_db.rating
-      def _log_legacy_feedback(_tid=mlflow_trace_id, _name=judge_name, _val=rating_val, _src=source, _rat=rationale):
-        mlflow.log_feedback(
-          trace_id=_tid,
-          name=_name,
-          value=_val,
-          source=_src,
-          rationale=_rat,
-        )
-        return True
-
-      api_result = _retry_mlflow_operation(
-        _log_legacy_feedback,
-        max_retries=3,
-        description=f"log_feedback(legacy {judge_name}) for trace {mlflow_trace_id[:12]}..."
-      )
-      if api_result:
-        logger.info(f"Logged MLflow legacy feedback: {judge_name}={rating_val} for trace {mlflow_trace_id}")
-        return {'logged': 1, 'skipped': 0, 'error': None}
-
-    return {'logged': 0, 'skipped': 0, 'error': 'no ratings to sync'}
-
-  def resync_annotations_to_mlflow(self, workshop_id: str) -> Dict[str, Any]:
-    """Re-sync all annotations to MLflow with judge names derived from rubric questions.
-
-    This is useful when rubric question titles change after annotations were created.
-    Creates new MLflow feedback entries with the correct judge names (one per rubric question).
-    """
-    workshop_db = self.db.query(WorkshopDB).filter(WorkshopDB.id == workshop_id).first()
-    if not workshop_db:
-      return {'error': 'Workshop not found', 'synced': 0}
-
-    # Get rubric questions to derive judge names
-    rubric_db = self.db.query(RubricDB).filter(RubricDB.workshop_id == workshop_id).first()
-    judge_names = []
-    question_titles = []
-    if rubric_db and rubric_db.question:
-      logger.info(f"📋 Rubric raw question text (first 500 chars): {rubric_db.question[:500]}")
-      # Support both new delimiter (|||QUESTION_SEPARATOR|||) and legacy delimiter (---)
-      QUESTION_DELIMITER_NEW = '|||QUESTION_SEPARATOR|||'
-      QUESTION_DELIMITER_LEGACY = '---'
-
-      if QUESTION_DELIMITER_NEW in rubric_db.question:
-        questions = rubric_db.question.split(QUESTION_DELIMITER_NEW)
-      else:
-        questions = rubric_db.question.split(QUESTION_DELIMITER_LEGACY)
-
-      for q in questions:
-        q = q.strip()
-        if not q:
-          continue
-        if '|||JUDGE_TYPE|||' in q:
-          content_part = q.split('|||JUDGE_TYPE|||')[0]
-        else:
-          content_part = q
-        colon_idx = content_part.find(':')
-        title = content_part[:colon_idx].strip() if colon_idx > 0 else content_part.strip()
-        question_titles.append(title)
-        judge_names.append(self._derive_judge_name_from_title(title))
-
-    # Get all annotations
-    annotations = self.get_annotations(workshop_id)
-
-    synced_count = 0
-    total_logged = 0
-    total_skipped_existing = 0
-    skipped_no_mlflow_id = 0
-    skipped_no_trace = 0
-    skipped_no_ratings = 0
-    sync_errors = []
-    errors = []
-
-    # Log summary of what's in annotations for debugging
-    ratings_keys_found = set()
-    for annotation in annotations:
-      if annotation.ratings:
-        ratings_keys_found.update(annotation.ratings.keys())
-    logger.info(f"📊 Found rating keys across all annotations: {ratings_keys_found}")
-    logger.info(f"📊 Expected judge names: {judge_names}")
-    logger.info(f"📊 Expected question titles: {question_titles}")
-
-    for annotation in annotations:
-      try:
-        # Get the annotation DB record to access trace relationship
-        annotation_db = self.db.query(AnnotationDB).filter(AnnotationDB.id == annotation.id).first()
-        if not annotation_db:
-          skipped_no_trace += 1
-          continue
-
-        # Check if trace has mlflow_trace_id
-        if not annotation_db.trace or not annotation_db.trace.mlflow_trace_id:
-          skipped_no_mlflow_id += 1
-          logger.warning(f"⚠️ Annotation {annotation_db.id[:8]}... has no mlflow_trace_id, skipping MLflow sync")
-          continue
-
-        # Check if annotation has ratings
-        if not annotation_db.ratings and annotation_db.rating is None:
-          skipped_no_ratings += 1
-          logger.warning(f"⚠️ Annotation {annotation_db.id[:8]}... has no ratings, skipping MLflow sync")
-          continue
-
-        logger.info(f"📊 Syncing annotation: trace_id={annotation_db.trace_id[:8]}..., mlflow_id={annotation_db.trace.mlflow_trace_id[:20]}..., ratings={annotation_db.ratings}, legacy_rating={annotation_db.rating}")
-        sync_result = self._sync_annotation_with_mlflow(workshop_id, annotation_db)
-        if sync_result:
-          total_logged += sync_result.get('logged', 0)
-          total_skipped_existing += sync_result.get('skipped', 0)
-          if sync_result.get('error'):
-            sync_errors.append(f"Annotation {annotation.id}: {sync_result['error']}")
-          if sync_result.get('logged', 0) > 0 or sync_result.get('skipped', 0) > 0:
-            synced_count += 1
-      except Exception as e:
-        errors.append(f"Annotation {annotation.id}: {str(e)}")
-        logger.warning('Failed to resync annotation %s: %s', annotation.id, e)
-
-    return {
-      'synced': synced_count,
-      'total': len(annotations),
-      'total_logged': total_logged,
-      'total_skipped_existing': total_skipped_existing,
-      'skipped_no_mlflow_id': skipped_no_mlflow_id,
-      'skipped_no_trace': skipped_no_trace,
-      'skipped_no_ratings': skipped_no_ratings,
-      'judge_names': judge_names,
-      'question_titles': question_titles,
-      'ratings_keys_found': list(ratings_keys_found),
-      'sync_errors': sync_errors if sync_errors else None,
-      'errors': errors if errors else None
-    }
-
-  def sync_evaluations_to_mlflow(self, workshop_id: str, judge_name: str, evaluations: List[Dict[str, Any]]) -> Dict[str, Any]:
-    """Sync AI evaluation results to MLflow as Feedback entries.
-    
-    This logs AI/LLM judge predictions alongside human annotations so SIMBA can use them.
-    
-    Args:
-      workshop_id: The workshop ID
-      judge_name: The judge name (e.g., 'configure_judge_judge')
-      evaluations: List of evaluation results with trace_id/workshop_uuid and predicted_rating
-    
-    Returns:
-      Dict with 'synced' count and any 'errors'
-    """
-    config = (
-      self.db.query(MLflowIntakeConfigDB)
-      .filter(MLflowIntakeConfigDB.workshop_id == workshop_id)
-      .first()
-    )
-    if not config or not config.databricks_host or not config.experiment_id:
-      logger.warning('Skipping MLflow eval sync: config missing for workshop %s', workshop_id)
-      return {'synced': 0, 'error': 'MLflow config missing'}
-
-    databricks_token = token_storage.get_token(workshop_id)
-    if not databricks_token:
-      databricks_token = self.get_databricks_token(workshop_id)
-      if databricks_token:
-        token_storage.store_token(workshop_id, databricks_token)
-    if not databricks_token:
-      logger.warning('Skipping MLflow eval sync: token missing for workshop %s', workshop_id)
-      return {'synced': 0, 'error': 'Databricks token missing'}
-
-    try:
-      import mlflow
-      from mlflow.entities import AssessmentSource, AssessmentSourceType
-    except ImportError:
-      logger.warning('MLflow is not available; cannot sync evaluation feedback.')
-      return {'synced': 0, 'error': 'MLflow not available'}
-
-    os.environ['DATABRICKS_HOST'] = config.databricks_host.rstrip('/')
-    os.environ['DATABRICKS_TOKEN'] = databricks_token
-    os.environ.pop('DATABRICKS_CLIENT_ID', None)
-    os.environ.pop('DATABRICKS_CLIENT_SECRET', None)
-
-    mlflow.set_tracking_uri('databricks')
-
-    try:
-      mlflow.set_experiment(experiment_id=config.experiment_id)
-    except Exception as exc:
-      logger.warning('Failed to set MLflow experiment %s: %s', config.experiment_id, exc)
-      return {'synced': 0, 'error': f'Failed to set experiment: {exc}'}
-
-    # Create AI/LLM assessment source
-    source = AssessmentSource(
-      source_type=AssessmentSourceType.AI_GENERATED,
-      source_id=f"llm_judge_{judge_name}",
-    )
-
-    # Build mapping from workshop_uuid to mlflow_trace_id
-    traces = self.get_traces(workshop_id)
-    trace_id_map = {}
-    for trace in traces:
-      if trace.mlflow_trace_id:
-        trace_id_map[trace.id] = trace.mlflow_trace_id
-
-    synced_count = 0
-    skipped_count = 0
-    errors = []
-    
-    # Cache of existing assessments per trace to avoid repeated API calls
-    existing_assessments_cache: Dict[str, set] = {}
-    
-    for eval_result in evaluations:
-      # Get MLflow trace ID from either trace_id (if it's MLflow format) or workshop_uuid
-      mlflow_trace_id = None
-      
-      # If trace_id starts with 'tr-', it's an MLflow trace ID
-      if eval_result.get('trace_id', '').startswith('tr-'):
-        mlflow_trace_id = eval_result['trace_id']
-      # Otherwise, use workshop_uuid to look up the MLflow trace ID
-      elif eval_result.get('workshop_uuid'):
-        mlflow_trace_id = trace_id_map.get(eval_result['workshop_uuid'])
-      elif eval_result.get('trace_id'):
-        mlflow_trace_id = trace_id_map.get(eval_result['trace_id'])
-      
-      if not mlflow_trace_id:
-        logger.debug(f"Skipping eval sync: no MLflow trace ID for {eval_result.get('trace_id') or eval_result.get('workshop_uuid')}")
-        continue
-      
-      predicted_rating = eval_result.get('predicted_rating')
-      if predicted_rating is None:
-        logger.debug(f"Skipping eval sync: no predicted_rating for trace {mlflow_trace_id}")
-        continue
-      
-      # Check for existing AI assessments to avoid duplicates and 50 limit
-      if mlflow_trace_id not in existing_assessments_cache:
-        existing_ai = set()
         try:
-          trace = mlflow.get_trace(mlflow_trace_id)
-          if trace and hasattr(trace, 'info') and hasattr(trace.info, 'assessments'):
-            for assessment in (trace.info.assessments or []):
-              if hasattr(assessment, 'source') and assessment.source:
-                if hasattr(assessment.source, 'source_type') and assessment.source.source_type == AssessmentSourceType.AI_GENERATED:
-                  if hasattr(assessment, 'name'):
-                    existing_ai.add(assessment.name)
+            mlflow.set_experiment(experiment_id=config.experiment_id)
+        except Exception as exc:
+            logger.warning("Failed to set MLflow experiment %s: %s", config.experiment_id, exc)
+            result["error"] = f"failed to set experiment: {exc}"
+            return result
+
+        set_trace_tag = getattr(mlflow, "set_trace_tag", None)
+        # Tag with 'align' label for alignment after human annotation
+        tags = {
+            "label": "align",
+            "workshop_id": workshop_id,
+        }
+        if set_trace_tag:
+            for key, value in tags.items():
+                # Use retry logic for tagging - bind variables via default args
+                def _set_tag(_tid=mlflow_trace_id, _key=key, _val=value, _set_fn=set_trace_tag):
+                    _set_fn(trace_id=_tid, key=_key, value=_val)
+                    return True
+
+                _retry_mlflow_operation(
+                    _set_tag, max_retries=3, description=f"set_trace_tag({key}) for {mlflow_trace_id[:12]}..."
+                )
+        else:
+            logger.debug("mlflow.set_trace_tag not available; skip tagging for trace %s", mlflow_trace_id)
+
+        # Get rubric questions to map question IDs to titles for judge names
+        rubric_db = self.db.query(RubricDB).filter(RubricDB.workshop_id == workshop_id).first()
+        question_titles_by_index = {}
+        if rubric_db and rubric_db.question:
+            # Parse rubric questions to get titles
+            # Support both new delimiter (|||QUESTION_SEPARATOR|||) and legacy delimiter (---)
+            QUESTION_DELIMITER_NEW = "|||QUESTION_SEPARATOR|||"
+            QUESTION_DELIMITER_LEGACY = "---"
+
+            if QUESTION_DELIMITER_NEW in rubric_db.question:
+                questions = rubric_db.question.split(QUESTION_DELIMITER_NEW)
+            else:
+                questions = rubric_db.question.split(QUESTION_DELIMITER_LEGACY)
+
+            for idx, q in enumerate(questions):
+                q = q.strip()
+                if not q:
+                    continue
+                # Extract title (before first colon, or before |||JUDGE_TYPE|||)
+                if "|||JUDGE_TYPE|||" in q:
+                    content_part = q.split("|||JUDGE_TYPE|||")[0]
+                else:
+                    content_part = q
+                colon_idx = content_part.find(":")
+                title = content_part[:colon_idx].strip() if colon_idx > 0 else content_part.strip()
+                question_titles_by_index[idx] = title
+                logger.debug(f"Parsed rubric question {idx}: title='{title}'")
+
+        rationale = annotation_db.comment.strip() if annotation_db.comment else None
+        source = AssessmentSource(
+            source_type=AssessmentSourceType.HUMAN,
+            source_id=annotation_db.user_id or workshop_id,
+        )
+
+        # Check existing assessments on this trace to avoid duplicates and hitting the 50 limit
+        # Track by (name, source_id) tuple so different users can have assessments with the same name
+        existing_assessments = set()  # Set of (name, source_id) tuples
+        current_user_id = annotation_db.user_id or workshop_id
+        try:
+            trace = mlflow.get_trace(mlflow_trace_id)
+            if trace and hasattr(trace, "info") and hasattr(trace.info, "assessments"):
+                for assessment in trace.info.assessments or []:
+                    # Track existing human assessments by (name, source_id) - allows multiple users
+                    if hasattr(assessment, "source") and assessment.source:
+                        if (
+                            hasattr(assessment.source, "source_type")
+                            and assessment.source.source_type == AssessmentSourceType.HUMAN
+                        ):
+                            if hasattr(assessment, "name"):
+                                source_id = getattr(assessment.source, "source_id", None)
+                                existing_assessments.add((assessment.name, source_id))
+            logger.info(f"📊 Trace {mlflow_trace_id[:12]}... has existing HUMAN assessments: {existing_assessments}")
+            logger.info(f"📊 Current user: {current_user_id}")
         except Exception as e:
-          logger.debug(f"Could not fetch existing AI assessments for trace {mlflow_trace_id}: {e}")
-        existing_assessments_cache[mlflow_trace_id] = existing_ai
-      
-      if judge_name in existing_assessments_cache[mlflow_trace_id]:
-        logger.debug(f"Skipping AI eval: {judge_name} already exists on trace {mlflow_trace_id[:12]}...")
-        skipped_count += 1
-        continue
-      
-      # Use retry logic for AI evaluation feedback
-      reasoning = eval_result.get('reasoning')
-      rating_float = float(predicted_rating)
-      def _log_ai_feedback(_tid=mlflow_trace_id, _name=judge_name, _val=rating_float, _src=source, _rat=reasoning):
-        mlflow.log_feedback(
-          trace_id=_tid,
-          name=_name,
-          value=_val,
-          source=_src,
-          rationale=_rat,
+            logger.warning(f"Could not fetch existing assessments for trace {mlflow_trace_id}: {e}")
+
+        # Log ALL ratings from the ratings dict (one per rubric question)
+        logger.info(f"📊 MLflow sync: annotation has ratings={annotation_db.ratings}")
+        logger.info(f"📊 MLflow sync: question_titles_by_index={question_titles_by_index}")
+
+        if annotation_db.ratings:
+            logged_count = 0
+            skipped_count = 0
+            for question_id, rating_value in annotation_db.ratings.items():
+                if rating_value is None:
+                    logger.debug(f"Skipping question_id={question_id} (rating is None)")
+                    continue
+
+                # Extract index from question_id
+                # Supports two formats:
+                # - "q_1", "q_2", etc. (1-based, old format)
+                # - "{rubric_id}_0", "{rubric_id}_1", etc. (0-based, new format)
+                try:
+                    index_str = question_id.split("_")[-1]
+                    index = int(index_str)
+
+                    # If format is "q_N" (1-based), convert to 0-based
+                    # If format is "{uuid}_N" (0-based), use as-is
+                    if question_id.startswith("q_"):
+                        index = index - 1  # Convert 1-based to 0-based
+                    # else: already 0-based (rubric_id_N format)
+
+                    logger.debug(f"Parsed question_id={question_id} → index={index}")
+                except (ValueError, IndexError) as e:
+                    logger.warning(f"Failed to parse question_id={question_id}: {e}, defaulting to index=0")
+                    index = 0
+
+                # Get question title and derive judge name
+                question_title = question_titles_by_index.get(index, f"question_{index + 1}")
+                judge_name = self._derive_judge_name_from_title(question_title)
+                logger.info(
+                    f"📊 Question {question_id}: index={index} → title='{question_title}' → judge_name='{judge_name}'"
+                )
+
+                # Skip if THIS USER already has a HUMAN assessment with this judge name on this trace
+                # Different users can have their own assessments with the same judge name
+                if (judge_name, current_user_id) in existing_assessments:
+                    logger.info(
+                        f"✓ Skipping {judge_name} for user {current_user_id} - already exists on trace {mlflow_trace_id[:12]}..."
+                    )
+                    skipped_count += 1
+                    continue
+
+                # Use retry logic for MLflow API call
+                rationale_for_this = rationale if logged_count == 0 else None
+
+                # Bind loop variables via default args to avoid closure issues
+                def _log_feedback(
+                    _tid=mlflow_trace_id, _name=judge_name, _val=rating_value, _src=source, _rat=rationale_for_this
+                ):
+                    mlflow.log_feedback(
+                        trace_id=_tid,
+                        name=_name,
+                        value=_val,
+                        source=_src,
+                        rationale=_rat,
+                    )
+                    return True
+
+                api_result = _retry_mlflow_operation(
+                    _log_feedback,
+                    max_retries=3,
+                    description=f"log_feedback({judge_name}) for trace {mlflow_trace_id[:12]}...",
+                )
+                if api_result:
+                    logged_count += 1
+                    logger.info(f"Logged MLflow feedback: {judge_name}={rating_value} for trace {mlflow_trace_id}")
+
+            if logged_count > 0 or skipped_count > 0:
+                logger.info(
+                    f"MLflow sync for trace {mlflow_trace_id[:12]}...: logged={logged_count}, skipped={skipped_count}"
+                )
+                return {"logged": logged_count, "skipped": skipped_count, "error": None}
+
+        # Fallback: log legacy single rating if no ratings dict
+        if annotation_db.rating is not None:
+            # Get the workshop's judge_name as fallback
+            workshop_db = self.db.query(WorkshopDB).filter(WorkshopDB.id == workshop_id).first()
+            judge_name = workshop_db.judge_name if workshop_db and workshop_db.judge_name else "workshop_judge"
+
+            # Skip if THIS USER already has this assessment
+            if (judge_name, current_user_id) in existing_assessments:
+                logger.info(
+                    f"✓ Skipping legacy {judge_name} for user {current_user_id} - already exists on trace {mlflow_trace_id[:12]}..."
+                )
+                return {"logged": 0, "skipped": 1, "error": None}
+
+            # Use retry logic for legacy rating
+            rating_val = annotation_db.rating
+
+            def _log_legacy_feedback(
+                _tid=mlflow_trace_id, _name=judge_name, _val=rating_val, _src=source, _rat=rationale
+            ):
+                mlflow.log_feedback(
+                    trace_id=_tid,
+                    name=_name,
+                    value=_val,
+                    source=_src,
+                    rationale=_rat,
+                )
+                return True
+
+            api_result = _retry_mlflow_operation(
+                _log_legacy_feedback,
+                max_retries=3,
+                description=f"log_feedback(legacy {judge_name}) for trace {mlflow_trace_id[:12]}...",
+            )
+            if api_result:
+                logger.info(f"Logged MLflow legacy feedback: {judge_name}={rating_val} for trace {mlflow_trace_id}")
+                return {"logged": 1, "skipped": 0, "error": None}
+
+        return {"logged": 0, "skipped": 0, "error": "no ratings to sync"}
+
+    def resync_annotations_to_mlflow(self, workshop_id: str) -> dict[str, Any]:
+        """Re-sync all annotations to MLflow with judge names derived from rubric questions.
+
+        This is useful when rubric question titles change after annotations were created.
+        Creates new MLflow feedback entries with the correct judge names (one per rubric question).
+        """
+        workshop_db = self.db.query(WorkshopDB).filter(WorkshopDB.id == workshop_id).first()
+        if not workshop_db:
+            return {"error": "Workshop not found", "synced": 0}
+
+        # Get rubric questions to derive judge names
+        rubric_db = self.db.query(RubricDB).filter(RubricDB.workshop_id == workshop_id).first()
+        judge_names = []
+        question_titles = []
+        if rubric_db and rubric_db.question:
+            logger.info(f"📋 Rubric raw question text (first 500 chars): {rubric_db.question[:500]}")
+            # Support both new delimiter (|||QUESTION_SEPARATOR|||) and legacy delimiter (---)
+            QUESTION_DELIMITER_NEW = "|||QUESTION_SEPARATOR|||"
+            QUESTION_DELIMITER_LEGACY = "---"
+
+            if QUESTION_DELIMITER_NEW in rubric_db.question:
+                questions = rubric_db.question.split(QUESTION_DELIMITER_NEW)
+            else:
+                questions = rubric_db.question.split(QUESTION_DELIMITER_LEGACY)
+
+            for q in questions:
+                q = q.strip()
+                if not q:
+                    continue
+                if "|||JUDGE_TYPE|||" in q:
+                    content_part = q.split("|||JUDGE_TYPE|||")[0]
+                else:
+                    content_part = q
+                colon_idx = content_part.find(":")
+                title = content_part[:colon_idx].strip() if colon_idx > 0 else content_part.strip()
+                question_titles.append(title)
+                judge_names.append(self._derive_judge_name_from_title(title))
+
+        # Get all annotations
+        annotations = self.get_annotations(workshop_id)
+
+        synced_count = 0
+        total_logged = 0
+        total_skipped_existing = 0
+        skipped_no_mlflow_id = 0
+        skipped_no_trace = 0
+        skipped_no_ratings = 0
+        sync_errors = []
+        errors = []
+
+        # Log summary of what's in annotations for debugging
+        ratings_keys_found = set()
+        for annotation in annotations:
+            if annotation.ratings:
+                ratings_keys_found.update(annotation.ratings.keys())
+        logger.info(f"📊 Found rating keys across all annotations: {ratings_keys_found}")
+        logger.info(f"📊 Expected judge names: {judge_names}")
+        logger.info(f"📊 Expected question titles: {question_titles}")
+
+        for annotation in annotations:
+            try:
+                # Get the annotation DB record to access trace relationship
+                annotation_db = self.db.query(AnnotationDB).filter(AnnotationDB.id == annotation.id).first()
+                if not annotation_db:
+                    skipped_no_trace += 1
+                    continue
+
+                # Check if trace has mlflow_trace_id
+                if not annotation_db.trace or not annotation_db.trace.mlflow_trace_id:
+                    skipped_no_mlflow_id += 1
+                    logger.warning(
+                        f"⚠️ Annotation {annotation_db.id[:8]}... has no mlflow_trace_id, skipping MLflow sync"
+                    )
+                    continue
+
+                # Check if annotation has ratings
+                if not annotation_db.ratings and annotation_db.rating is None:
+                    skipped_no_ratings += 1
+                    logger.warning(f"⚠️ Annotation {annotation_db.id[:8]}... has no ratings, skipping MLflow sync")
+                    continue
+
+                logger.info(
+                    f"📊 Syncing annotation: trace_id={annotation_db.trace_id[:8]}..., mlflow_id={annotation_db.trace.mlflow_trace_id[:20]}..., ratings={annotation_db.ratings}, legacy_rating={annotation_db.rating}"
+                )
+                sync_result = self._sync_annotation_with_mlflow(workshop_id, annotation_db)
+                if sync_result:
+                    total_logged += sync_result.get("logged", 0)
+                    total_skipped_existing += sync_result.get("skipped", 0)
+                    if sync_result.get("error"):
+                        sync_errors.append(f"Annotation {annotation.id}: {sync_result['error']}")
+                    if sync_result.get("logged", 0) > 0 or sync_result.get("skipped", 0) > 0:
+                        synced_count += 1
+            except Exception as e:
+                errors.append(f"Annotation {annotation.id}: {e!s}")
+                logger.warning("Failed to resync annotation %s: %s", annotation.id, e)
+
+        return {
+            "synced": synced_count,
+            "total": len(annotations),
+            "total_logged": total_logged,
+            "total_skipped_existing": total_skipped_existing,
+            "skipped_no_mlflow_id": skipped_no_mlflow_id,
+            "skipped_no_trace": skipped_no_trace,
+            "skipped_no_ratings": skipped_no_ratings,
+            "judge_names": judge_names,
+            "question_titles": question_titles,
+            "ratings_keys_found": list(ratings_keys_found),
+            "sync_errors": sync_errors if sync_errors else None,
+            "errors": errors if errors else None,
+        }
+
+    def sync_evaluations_to_mlflow(
+        self, workshop_id: str, judge_name: str, evaluations: list[dict[str, Any]]
+    ) -> dict[str, Any]:
+        """Sync AI evaluation results to MLflow as Feedback entries.
+
+        This logs AI/LLM judge predictions alongside human annotations so SIMBA can use them.
+
+        Args:
+          workshop_id: The workshop ID
+          judge_name: The judge name (e.g., 'configure_judge_judge')
+          evaluations: List of evaluation results with trace_id/workshop_uuid and predicted_rating
+
+        Returns:
+          Dict with 'synced' count and any 'errors'
+        """
+        config = self.db.query(MLflowIntakeConfigDB).filter(MLflowIntakeConfigDB.workshop_id == workshop_id).first()
+        if not config or not config.databricks_host or not config.experiment_id:
+            logger.warning("Skipping MLflow eval sync: config missing for workshop %s", workshop_id)
+            return {"synced": 0, "error": "MLflow config missing"}
+
+        databricks_token = token_storage.get_token(workshop_id)
+        if not databricks_token:
+            databricks_token = self.get_databricks_token(workshop_id)
+            if databricks_token:
+                token_storage.store_token(workshop_id, databricks_token)
+        if not databricks_token:
+            logger.warning("Skipping MLflow eval sync: token missing for workshop %s", workshop_id)
+            return {"synced": 0, "error": "Databricks token missing"}
+
+        try:
+            import mlflow
+            from mlflow.entities import AssessmentSource, AssessmentSourceType
+        except ImportError:
+            logger.warning("MLflow is not available; cannot sync evaluation feedback.")
+            return {"synced": 0, "error": "MLflow not available"}
+
+        os.environ["DATABRICKS_HOST"] = config.databricks_host.rstrip("/")
+        os.environ["DATABRICKS_TOKEN"] = databricks_token
+        os.environ.pop("DATABRICKS_CLIENT_ID", None)
+        os.environ.pop("DATABRICKS_CLIENT_SECRET", None)
+
+        mlflow.set_tracking_uri("databricks")
+
+        try:
+            mlflow.set_experiment(experiment_id=config.experiment_id)
+        except Exception as exc:
+            logger.warning("Failed to set MLflow experiment %s: %s", config.experiment_id, exc)
+            return {"synced": 0, "error": f"Failed to set experiment: {exc}"}
+
+        # Create AI/LLM assessment source
+        source = AssessmentSource(
+            source_type=AssessmentSourceType.AI_GENERATED,
+            source_id=f"llm_judge_{judge_name}",
         )
+
+        # Build mapping from workshop_uuid to mlflow_trace_id
+        traces = self.get_traces(workshop_id)
+        trace_id_map = {}
+        for trace in traces:
+            if trace.mlflow_trace_id:
+                trace_id_map[trace.id] = trace.mlflow_trace_id
+
+        synced_count = 0
+        skipped_count = 0
+        errors = []
+
+        # Cache of existing assessments per trace to avoid repeated API calls
+        existing_assessments_cache: dict[str, set] = {}
+
+        for eval_result in evaluations:
+            # Get MLflow trace ID from either trace_id (if it's MLflow format) or workshop_uuid
+            mlflow_trace_id = None
+
+            # If trace_id starts with 'tr-', it's an MLflow trace ID
+            if eval_result.get("trace_id", "").startswith("tr-"):
+                mlflow_trace_id = eval_result["trace_id"]
+            # Otherwise, use workshop_uuid to look up the MLflow trace ID
+            elif eval_result.get("workshop_uuid"):
+                mlflow_trace_id = trace_id_map.get(eval_result["workshop_uuid"])
+            elif eval_result.get("trace_id"):
+                mlflow_trace_id = trace_id_map.get(eval_result["trace_id"])
+
+            if not mlflow_trace_id:
+                logger.debug(
+                    f"Skipping eval sync: no MLflow trace ID for {eval_result.get('trace_id') or eval_result.get('workshop_uuid')}"
+                )
+                continue
+
+            predicted_rating = eval_result.get("predicted_rating")
+            if predicted_rating is None:
+                logger.debug(f"Skipping eval sync: no predicted_rating for trace {mlflow_trace_id}")
+                continue
+
+            # Check for existing AI assessments to avoid duplicates and 50 limit
+            if mlflow_trace_id not in existing_assessments_cache:
+                existing_ai = set()
+                try:
+                    trace = mlflow.get_trace(mlflow_trace_id)
+                    if trace and hasattr(trace, "info") and hasattr(trace.info, "assessments"):
+                        for assessment in trace.info.assessments or []:
+                            if hasattr(assessment, "source") and assessment.source:
+                                if (
+                                    hasattr(assessment.source, "source_type")
+                                    and assessment.source.source_type == AssessmentSourceType.AI_GENERATED
+                                ):
+                                    if hasattr(assessment, "name"):
+                                        existing_ai.add(assessment.name)
+                except Exception as e:
+                    logger.debug(f"Could not fetch existing AI assessments for trace {mlflow_trace_id}: {e}")
+                existing_assessments_cache[mlflow_trace_id] = existing_ai
+
+            if judge_name in existing_assessments_cache[mlflow_trace_id]:
+                logger.debug(f"Skipping AI eval: {judge_name} already exists on trace {mlflow_trace_id[:12]}...")
+                skipped_count += 1
+                continue
+
+            # Use retry logic for AI evaluation feedback
+            reasoning = eval_result.get("reasoning")
+            rating_float = float(predicted_rating)
+
+            def _log_ai_feedback(
+                _tid=mlflow_trace_id, _name=judge_name, _val=rating_float, _src=source, _rat=reasoning
+            ):
+                mlflow.log_feedback(
+                    trace_id=_tid,
+                    name=_name,
+                    value=_val,
+                    source=_src,
+                    rationale=_rat,
+                )
+                return True
+
+            result = _retry_mlflow_operation(
+                _log_ai_feedback,
+                max_retries=3,
+                description=f"log_ai_feedback({judge_name}) for trace {mlflow_trace_id[:12]}...",
+            )
+            if result:
+                synced_count += 1
+                logger.info(f"Logged MLflow AI feedback: {judge_name}={predicted_rating} for trace {mlflow_trace_id}")
+            else:
+                error_msg = f"Failed to log AI feedback for trace {mlflow_trace_id} after retries"
+                errors.append(error_msg)
+
+        logger.info(
+            f"Synced {synced_count} AI evaluations to MLflow for judge '{judge_name}' (skipped {skipped_count} existing)"
+        )
+        return {
+            "synced": synced_count,
+            "skipped": skipped_count,
+            "total": len(evaluations),
+            "judge_name": judge_name,
+            "errors": errors if errors else None,
+        }
+
+    def tag_traces_for_evaluation(
+        self, workshop_id: str, trace_ids: list[str], tag_type: str = "eval"
+    ) -> dict[str, Any]:
+        """Tag MLflow traces with a label for auto-evaluation.
+
+        Args:
+            workshop_id: The workshop ID
+            trace_ids: List of workshop trace IDs to tag
+            tag_type: The tag value (default 'eval')
+
+        Returns:
+            Dict with 'tagged' count and 'failed' list
+        """
+        # Get MLflow config
+        config = self.db.query(MLflowIntakeConfigDB).filter(MLflowIntakeConfigDB.workshop_id == workshop_id).first()
+        if not config:
+            logger.warning("Skipping MLflow tagging: config missing for workshop %s", workshop_id)
+            return {"tagged": 0, "failed": trace_ids, "error": "MLflow config missing"}
+
+        # Get token from token storage
+        databricks_token = token_storage.get_token(workshop_id)
+        if not databricks_token:
+            logger.warning("Skipping MLflow tagging: token missing for workshop %s", workshop_id)
+            return {"tagged": 0, "failed": trace_ids, "error": "Databricks token missing"}
+
+        try:
+            import mlflow
+        except ImportError:
+            logger.warning("MLflow is not available; cannot tag traces.")
+            return {"tagged": 0, "failed": trace_ids, "error": "MLflow not available"}
+
+        # Set up MLflow credentials
+        os.environ["DATABRICKS_HOST"] = config.databricks_host.rstrip("/")
+        os.environ["DATABRICKS_TOKEN"] = databricks_token
+        os.environ.pop("DATABRICKS_CLIENT_ID", None)
+        os.environ.pop("DATABRICKS_CLIENT_SECRET", None)
+
+        mlflow.set_tracking_uri("databricks")
+
+        try:
+            mlflow.set_experiment(experiment_id=config.experiment_id)
+        except Exception as exc:
+            logger.warning("Failed to set MLflow experiment %s: %s", config.experiment_id, exc)
+            return {"tagged": 0, "failed": trace_ids, "error": f"Failed to set experiment: {exc}"}
+
+        # Get set_trace_tag function
+        set_trace_tag = getattr(mlflow, "set_trace_tag", None)
+        if not set_trace_tag:
+            logger.warning("mlflow.set_trace_tag not available")
+            return {"tagged": 0, "failed": trace_ids, "error": "set_trace_tag not available"}
+
+        # Get traces from database to get their MLflow trace IDs
+        db_traces = self.db.query(TraceDB).filter(TraceDB.workshop_id == workshop_id, TraceDB.id.in_(trace_ids)).all()
+
+        trace_id_map = {t.id: t.mlflow_trace_id for t in db_traces if t.mlflow_trace_id}
+
+        tagged = []
+        failed = []
+
+        for trace_id in trace_ids:
+            mlflow_trace_id = trace_id_map.get(trace_id)
+            if not mlflow_trace_id:
+                logger.debug(f"No MLflow trace ID for workshop trace {trace_id}")
+                failed.append(trace_id)
+                continue
+
+            # Use retry logic for tagging - bind variables via default args
+            def _tag_trace(_tid=mlflow_trace_id, _tag=tag_type, _wid=workshop_id, _set_tag=set_trace_tag):
+                _set_tag(trace_id=_tid, key="label", value=_tag)
+                _set_tag(trace_id=_tid, key="workshop_id", value=_wid)
+                return True
+
+            result = _retry_mlflow_operation(
+                _tag_trace, max_retries=3, description=f"tag_trace for {mlflow_trace_id[:12]}..."
+            )
+            if result:
+                tagged.append(trace_id)
+                logger.debug(f"Tagged trace {mlflow_trace_id} with label={tag_type}")
+            else:
+                failed.append(trace_id)
+
+        logger.info(f"Tagged {len(tagged)} traces for {tag_type}, {len(failed)} failed")
+        return {"tagged": len(tagged), "failed": failed}
+
+    def get_annotations(self, workshop_id: str, user_id: str | None = None) -> list[Annotation]:
+        """Get annotations for a workshop, optionally filtered by user."""
+        query = self.db.query(AnnotationDB).join(TraceDB).filter(AnnotationDB.workshop_id == workshop_id)
+
+        # Filter by user_id if provided
+        if user_id:
+            query = query.filter(AnnotationDB.user_id == user_id)
+
+        db_annotations = query.all()
+
+        return [
+            Annotation(
+                id=db_annotation.id,
+                workshop_id=db_annotation.workshop_id,
+                trace_id=db_annotation.trace_id,
+                user_id=db_annotation.user_id,
+                rating=db_annotation.rating,
+                ratings=db_annotation.ratings,  # Include multiple ratings
+                comment=db_annotation.comment,
+                mlflow_trace_id=db_annotation.trace.mlflow_trace_id,
+                created_at=db_annotation.created_at,
+            )
+            for db_annotation in db_annotations
+        ]
+
+    def get_annotations_with_user_details(self, workshop_id: str, user_id: str | None = None) -> list[dict[str, Any]]:
+        """Get annotations with user details for facilitator view."""
+        query = (
+            self.db.query(AnnotationDB, UserDB)
+            .join(UserDB, AnnotationDB.user_id == UserDB.id)
+            .filter(AnnotationDB.workshop_id == workshop_id)
+        )
+
+        # Filter by user_id if provided
+        if user_id:
+            query = query.filter(AnnotationDB.user_id == user_id)
+
+        results = query.all()
+
+        return [
+            {
+                "id": annotation.id,
+                "workshop_id": annotation.workshop_id,
+                "trace_id": annotation.trace_id,
+                "user_id": annotation.user_id,
+                "user_name": user.name,
+                "user_email": user.email,
+                "user_role": user.role,  # Include user role for SME/participant distinction
+                "rating": annotation.rating,
+                "ratings": annotation.ratings,  # Include per-metric ratings dictionary
+                "comment": annotation.comment,
+                "mlflow_trace_id": getattr(annotation, "mlflow_trace_id", None),
+                "created_at": annotation.created_at,
+            }
+            for annotation, user in results
+        ]
+
+    # User management operations
+    def create_user(self, user: User) -> User:
+        """Create a new user in the database."""
+        db_user = UserDB(
+            id=user.id,
+            email=user.email,
+            name=user.name,
+            role=user.role,
+            workshop_id=user.workshop_id,
+            status=user.status,
+            password_hash=user.password_hash,
+            created_at=user.created_at,
+            last_active=user.last_active,
+        )
+        self.db.add(db_user)
+        self.db.commit()
+        self.db.refresh(db_user)
+        return user
+
+    def create_user_with_password(self, user_data: UserCreate) -> User:
+        """Create a new user with password."""
+        # Normalize email to lowercase for consistency
+        normalized_email = user_data.email.lower()
+
+        # Generate default password if not provided
+        if not user_data.password:
+            user_data.password = generate_default_password(normalized_email)
+
+        # Hash the password
+        password_hash = hash_password(user_data.password)
+
+        # Create user with PENDING status
+        user = User(
+            id=str(uuid.uuid4()),
+            email=normalized_email,
+            name=user_data.name,
+            role=user_data.role,
+            workshop_id=user_data.workshop_id,
+            status=UserStatus.PENDING,
+            password_hash=password_hash,
+        )
+
+        return self.create_user(user)
+
+    def authenticate_user(self, email: str, password: str) -> User | None:
+        """Authenticate a user with email and password. SMEs and participants only need email."""
+        # Case-insensitive email comparison
+        db_user = self.db.query(UserDB).filter(UserDB.email.ilike(email)).first()
+        if not db_user:
+            return None
+
+        # For SMEs and participants, skip password verification (email-only login)
+        if db_user.role in ["sme", "participant"]:
+            pass  # No password verification needed
+        # For facilitators, require password verification
+        elif db_user.role == "facilitator":
+            if not verify_password(password, db_user.password_hash or ""):
+                return None
+        else:
+            # Unknown role, require password for security
+            if not verify_password(password, db_user.password_hash or ""):
+                return None
+
+        return User(
+            id=db_user.id,
+            email=db_user.email,
+            name=db_user.name,
+            role=db_user.role,
+            workshop_id=db_user.workshop_id,
+            status=db_user.status,
+            password_hash=db_user.password_hash,
+            created_at=db_user.created_at,
+            last_active=db_user.last_active,
+        )
+
+    def authenticate_facilitator_from_yaml(self, email: str, password: str) -> dict[str, Any] | None:
+        """Authenticate a facilitator using YAML configuration."""
+        facilitator_config = get_facilitator_config(email)
+        if not facilitator_config:
+            return None
+
+        if facilitator_config.get("password") != password:
+            return None
+
+        return facilitator_config
+
+    def get_or_create_facilitator_user(self, facilitator_data: dict[str, Any]) -> User:
+        """Get or create a facilitator user from YAML config."""
+        # Normalize email to lowercase for consistency
+        email = facilitator_data["email"].lower()
+
+        # Check if user already exists
+        existing_user = self.get_user_by_email(email)
+        if existing_user:
+            return existing_user
+
+        # Create new facilitator user
+        password_hash = hash_password(facilitator_data["password"])
+
+        user = User(
+            id=str(uuid.uuid4()),
+            email=email,
+            name=facilitator_data["name"],
+            role=UserRole.FACILITATOR,
+            workshop_id=None,  # Facilitators aren't tied to a single workshop
+            password_hash=password_hash,
+        )
+
+        return self.create_user(user)
+
+    def get_user_by_email(self, email: str) -> User | None:
+        """Get user by email address."""
+        # Case-insensitive email comparison
+        db_user = self.db.query(UserDB).filter(UserDB.email.ilike(email)).first()
+        if not db_user:
+            return None
+
+        return User(
+            id=db_user.id,
+            email=db_user.email,
+            name=db_user.name,
+            role=db_user.role,
+            workshop_id=db_user.workshop_id,
+            status=db_user.status,
+            password_hash=db_user.password_hash,
+            created_at=db_user.created_at,
+            last_active=db_user.last_active,
+        )
+
+    def create_facilitator_config(self, config_data: FacilitatorConfigCreate) -> FacilitatorConfig:
+        """Create a facilitator configuration."""
+        password_hash = hash_password(config_data.password)
+
+        db_config = FacilitatorConfigDB(
+            id=str(uuid.uuid4()),
+            email=config_data.email,
+            password_hash=password_hash,
+            name=config_data.name,
+            description=config_data.description,
+        )
+
+        self.db.add(db_config)
+        self.db.commit()
+        self.db.refresh(db_config)
+
+        return FacilitatorConfig(
+            email=db_config.email,
+            password_hash=db_config.password_hash,
+            name=db_config.name,
+            description=db_config.description,
+            created_at=db_config.created_at,
+        )
+
+    def get_facilitator_config(self, email: str) -> FacilitatorConfig | None:
+        """Get facilitator configuration by email."""
+        # Case-insensitive email comparison
+        db_config = self.db.query(FacilitatorConfigDB).filter(FacilitatorConfigDB.email.ilike(email)).first()
+
+        if not db_config:
+            return None
+
+        return FacilitatorConfig(
+            email=db_config.email,
+            password_hash=db_config.password_hash,
+            name=db_config.name,
+            description=db_config.description,
+            created_at=db_config.created_at,
+        )
+
+    def list_facilitator_configs(self) -> list[FacilitatorConfig]:
+        """List all facilitator configurations."""
+        db_configs = self.db.query(FacilitatorConfigDB).all()
+
+        return [
+            FacilitatorConfig(
+                email=config.email,
+                password_hash=config.password_hash,
+                name=config.name,
+                description=config.description,
+                created_at=config.created_at,
+            )
+            for config in db_configs
+        ]
+
+    def get_user(self, user_id: str) -> User | None:
+        """Get a user by ID."""
+        db_user = self.db.query(UserDB).filter(UserDB.id == user_id).first()
+        if not db_user:
+            return None
+
+        return User(
+            id=db_user.id,
+            email=db_user.email,
+            name=db_user.name,
+            role=db_user.role,
+            workshop_id=db_user.workshop_id,
+            status=db_user.status,
+            created_at=db_user.created_at,
+            last_active=db_user.last_active,
+        )
+
+    def update_user(self, user: User) -> User:
+        """Update an existing user."""
+        db_user = self.db.query(UserDB).filter(UserDB.id == user.id).first()
+        if not db_user:
+            raise ValueError(f"User {user.id} not found")
+
+        db_user.email = user.email
+        db_user.name = user.name
+        db_user.role = user.role
+        db_user.workshop_id = user.workshop_id
+        db_user.status = user.status
+        db_user.last_active = user.last_active
+
+        self.db.commit()
+        self.db.refresh(db_user)
+        return user
+
+    def activate_user_on_login(self, user_id: str) -> None:
+        """Activate a user when they log in for the first time."""
+        db_user = self.db.query(UserDB).filter(UserDB.id == user_id).first()
+        if db_user and db_user.status == "pending":
+            db_user.status = "active"
+            db_user.last_active = datetime.now()
+            self.db.commit()
+
+    def list_users(self, workshop_id: str | None = None, role: UserRole | None = None) -> list[User]:
+        """List users, optionally filtered by workshop or role."""
+        if workshop_id:
+            # For workshop-specific queries, use the workshop_participants table
+            return self.list_workshop_users(workshop_id, role)
+
+        # For general user queries, use the users table
+        query = self.db.query(UserDB)
+
+        if role:
+            query = query.filter(UserDB.role == role)
+
+        db_users = query.all()
+
+        return [
+            User(
+                id=db_user.id,
+                email=db_user.email,
+                name=db_user.name,
+                role=db_user.role,
+                workshop_id=db_user.workshop_id,
+                status=db_user.status,
+                created_at=db_user.created_at,
+                last_active=db_user.last_active,
+            )
+            for db_user in db_users
+        ]
+
+    def list_workshop_users(self, workshop_id: str, role: UserRole | None = None) -> list[User]:
+        """List all users in a specific workshop by joining workshop_participants and users tables."""
+        query = (
+            self.db.query(UserDB, WorkshopParticipantDB)
+            .join(WorkshopParticipantDB, UserDB.id == WorkshopParticipantDB.user_id)
+            .filter(WorkshopParticipantDB.workshop_id == workshop_id)
+        )
+
+        if role:
+            query = query.filter(WorkshopParticipantDB.role == role)
+
+        results = query.all()
+
+        return [
+            User(
+                id=db_user.id,
+                email=db_user.email,
+                name=db_user.name,
+                role=db_participant.role,  # Use the role from WorkshopParticipantDB
+                workshop_id=workshop_id,  # Use the workshop_id parameter
+                status=db_user.status,
+                created_at=db_user.created_at,
+                last_active=db_user.last_active,
+            )
+            for db_user, db_participant in results
+        ]
+
+    # Workshop participant operations
+    def add_workshop_participant(self, participant: WorkshopParticipant) -> WorkshopParticipant:
+        """Add a participant to a workshop."""
+        participant_id = str(uuid.uuid4())
+        db_participant = WorkshopParticipantDB(
+            id=participant_id,
+            user_id=participant.user_id,
+            workshop_id=participant.workshop_id,
+            role=participant.role,
+            assigned_traces=participant.assigned_traces,
+            annotation_quota=participant.annotation_quota,
+            joined_at=participant.joined_at,
+        )
+        self.db.add(db_participant)
+        self.db.commit()
+        self.db.refresh(db_participant)
+
+        return WorkshopParticipant(
+            user_id=db_participant.user_id,
+            workshop_id=db_participant.workshop_id,
+            role=db_participant.role,
+            assigned_traces=db_participant.assigned_traces or [],
+            annotation_quota=db_participant.annotation_quota,
+            joined_at=db_participant.joined_at,
+        )
+
+    def get_workshop_participants(self, workshop_id: str) -> list[WorkshopParticipant]:
+        """Get all participants in a workshop."""
+        db_participants = (
+            self.db.query(WorkshopParticipantDB).filter(WorkshopParticipantDB.workshop_id == workshop_id).all()
+        )
+
+        return [
+            WorkshopParticipant(
+                user_id=db_participant.user_id,
+                workshop_id=db_participant.workshop_id,
+                role=db_participant.role,
+                assigned_traces=db_participant.assigned_traces or [],
+                annotation_quota=db_participant.annotation_quota,
+                joined_at=db_participant.joined_at,
+            )
+            for db_participant in db_participants
+        ]
+
+    def get_workshop_participant(self, workshop_id: str, user_id: str) -> WorkshopParticipant | None:
+        """Get a specific workshop participant."""
+        db_participant = (
+            self.db.query(WorkshopParticipantDB)
+            .filter(and_(WorkshopParticipantDB.workshop_id == workshop_id, WorkshopParticipantDB.user_id == user_id))
+            .first()
+        )
+
+        if not db_participant:
+            return None
+
+        return WorkshopParticipant(
+            user_id=db_participant.user_id,
+            workshop_id=db_participant.workshop_id,
+            role=db_participant.role,
+            assigned_traces=db_participant.assigned_traces or [],
+            annotation_quota=db_participant.annotation_quota,
+            joined_at=db_participant.joined_at,
+        )
+
+    def update_workshop_participant(self, participant: WorkshopParticipant) -> WorkshopParticipant:
+        """Update a workshop participant."""
+        # TODO: pretty sure this does nothing (no commit, no update)?
+        # db_participant = (
+        (
+            self.db.query(WorkshopParticipantDB)
+            .filter(
+                and_(
+                    WorkshopParticipantDB.workshop_id == participant.workshop_id,
+                    WorkshopParticipantDB.user_id == participant.user_id,
+                )
+            )
+            .first()
+        )
+
+    def remove_user_from_workshop(self, workshop_id: str, user_id: str) -> bool:
+        """Remove a user from a workshop (but keep them in the system)."""
+        db_participant = (
+            self.db.query(WorkshopParticipantDB)
+            .filter(and_(WorkshopParticipantDB.workshop_id == workshop_id, WorkshopParticipantDB.user_id == user_id))
+            .first()
+        )
+
+        if not db_participant:
+            return False
+
+        self.db.delete(db_participant)
+        self.db.commit()
         return True
 
-      result = _retry_mlflow_operation(
-        _log_ai_feedback,
-        max_retries=3,
-        description=f"log_ai_feedback({judge_name}) for trace {mlflow_trace_id[:12]}..."
-      )
-      if result:
-        synced_count += 1
-        logger.info(f"Logged MLflow AI feedback: {judge_name}={predicted_rating} for trace {mlflow_trace_id}")
-      else:
-        error_msg = f"Failed to log AI feedback for trace {mlflow_trace_id} after retries"
-        errors.append(error_msg)
+    def update_user_role_in_workshop(self, workshop_id: str, user_id: str, new_role: str) -> User | None:
+        """Update a user's role in a workshop (SME <-> Participant)."""
+        from server.models import UserRole
 
-    logger.info(f"Synced {synced_count} AI evaluations to MLflow for judge '{judge_name}' (skipped {skipped_count} existing)")
-    return {
-      'synced': synced_count,
-      'skipped': skipped_count,
-      'total': len(evaluations),
-      'judge_name': judge_name,
-      'errors': errors if errors else None
-    }
+        # Update the workshop participant record
+        db_participant = (
+            self.db.query(WorkshopParticipantDB)
+            .filter(and_(WorkshopParticipantDB.workshop_id == workshop_id, WorkshopParticipantDB.user_id == user_id))
+            .first()
+        )
 
-  def tag_traces_for_evaluation(self, workshop_id: str, trace_ids: List[str], tag_type: str = 'eval') -> Dict[str, Any]:
-    """Tag MLflow traces with a label for auto-evaluation.
+        if db_participant:
+            # Map string to UserRole enum
+            role_enum = UserRole.SME if new_role == "sme" else UserRole.PARTICIPANT
+            db_participant.role = role_enum
 
-    Args:
-        workshop_id: The workshop ID
-        trace_ids: List of workshop trace IDs to tag
-        tag_type: The tag value (default 'eval')
+        # Also update the user's global role
+        db_user = self.db.query(UserDB).filter(UserDB.id == user_id).first()
+        if db_user:
+            role_enum = UserRole.SME if new_role == "sme" else UserRole.PARTICIPANT
+            db_user.role = role_enum
 
-    Returns:
-        Dict with 'tagged' count and 'failed' list
-    """
-    # Get MLflow config
-    config = (
-      self.db.query(MLflowIntakeConfigDB)
-      .filter(MLflowIntakeConfigDB.workshop_id == workshop_id)
-      .first()
-    )
-    if not config:
-      logger.warning('Skipping MLflow tagging: config missing for workshop %s', workshop_id)
-      return {'tagged': 0, 'failed': trace_ids, 'error': 'MLflow config missing'}
+        self.db.commit()
 
-    # Get token from token storage
-    databricks_token = token_storage.get_token(workshop_id)
-    if not databricks_token:
-      logger.warning('Skipping MLflow tagging: token missing for workshop %s', workshop_id)
-      return {'tagged': 0, 'failed': trace_ids, 'error': 'Databricks token missing'}
+        # Return updated user
+        return self.get_user(user_id)
 
-    try:
-      import mlflow
-    except ImportError:
-      logger.warning('MLflow is not available; cannot tag traces.')
-      return {'tagged': 0, 'failed': trace_ids, 'error': 'MLflow not available'}
+    # User Discovery Completion operations
+    def mark_user_discovery_complete(self, workshop_id: str, user_id: str) -> None:
+        """Mark a user as having completed discovery for a workshop."""
+        # Check if already completed
+        existing = (
+            self.db.query(UserDiscoveryCompletionDB)
+            .filter(
+                and_(
+                    UserDiscoveryCompletionDB.workshop_id == workshop_id,
+                    UserDiscoveryCompletionDB.user_id == user_id,
+                )
+            )
+            .first()
+        )
 
-    # Set up MLflow credentials
-    os.environ['DATABRICKS_HOST'] = config.databricks_host.rstrip('/')
-    os.environ['DATABRICKS_TOKEN'] = databricks_token
-    os.environ.pop('DATABRICKS_CLIENT_ID', None)
-    os.environ.pop('DATABRICKS_CLIENT_SECRET', None)
+        if not existing:
+            completion = UserDiscoveryCompletionDB(workshop_id=workshop_id, user_id=user_id)
+            self.db.add(completion)
+            self.db.commit()
 
-    mlflow.set_tracking_uri('databricks')
+    def is_user_discovery_complete(self, workshop_id: str, user_id: str) -> bool:
+        """Check if a user has completed discovery for a workshop."""
+        completion = (
+            self.db.query(UserDiscoveryCompletionDB)
+            .filter(
+                and_(
+                    UserDiscoveryCompletionDB.workshop_id == workshop_id,
+                    UserDiscoveryCompletionDB.user_id == user_id,
+                )
+            )
+            .first()
+        )
+        return completion is not None
 
-    try:
-      mlflow.set_experiment(experiment_id=config.experiment_id)
-    except Exception as exc:
-      logger.warning('Failed to set MLflow experiment %s: %s', config.experiment_id, exc)
-      return {'tagged': 0, 'failed': trace_ids, 'error': f'Failed to set experiment: {exc}'}
+    def get_discovery_completion_status(self, workshop_id: str) -> dict[str, Any]:
+        """Get discovery completion status for all users in a workshop."""
+        # Get all workshop participants (SMEs and participants, not facilitators) with user details
+        participants = (
+            self.db.query(WorkshopParticipantDB, UserDB)
+            .join(UserDB, WorkshopParticipantDB.user_id == UserDB.id)
+            .filter(
+                and_(
+                    WorkshopParticipantDB.workshop_id == workshop_id,
+                    WorkshopParticipantDB.role.in_(["sme", "participant"]),
+                )
+            )
+            .all()
+        )
 
-    # Get set_trace_tag function
-    set_trace_tag = getattr(mlflow, 'set_trace_tag', None)
-    if not set_trace_tag:
-      logger.warning('mlflow.set_trace_tag not available')
-      return {'tagged': 0, 'failed': trace_ids, 'error': 'set_trace_tag not available'}
+        # Get completion status for each participant
+        completion_status = {}
+        for participant, user in participants:
+            is_complete = self.is_user_discovery_complete(workshop_id, participant.user_id)
+            completion_status[participant.user_id] = {
+                "user_id": participant.user_id,
+                "user_name": user.name,
+                "user_email": user.email,
+                "role": participant.role,
+                "completed": is_complete,
+            }
 
-    # Get traces from database to get their MLflow trace IDs
-    db_traces = self.db.query(TraceDB).filter(
-      TraceDB.workshop_id == workshop_id,
-      TraceDB.id.in_(trace_ids)
-    ).all()
+        # Calculate summary
+        total_participants = len(participants)
+        completed_participants = sum(1 for status in completion_status.values() if status["completed"])
 
-    trace_id_map = {t.id: t.mlflow_trace_id for t in db_traces if t.mlflow_trace_id}
+        return {
+            "total_participants": total_participants,
+            "completed_participants": completed_participants,
+            "completion_percentage": (completed_participants / total_participants * 100)
+            if total_participants > 0
+            else 0,
+            "all_completed": completed_participants == total_participants and total_participants > 0,
+            "participant_status": completion_status,
+        }
 
-    tagged = []
-    failed = []
+    def get_traces_by_workshop(self, workshop_id: str) -> list[Trace]:
+        """Get all traces for a workshop (alias for get_traces)."""
+        return self.get_traces(workshop_id)
 
-    for trace_id in trace_ids:
-      mlflow_trace_id = trace_id_map.get(trace_id)
-      if not mlflow_trace_id:
-        logger.debug(f"No MLflow trace ID for workshop trace {trace_id}")
-        failed.append(trace_id)
-        continue
+    # Testing/debugging operations
+    def clear_findings(self, workshop_id: str) -> None:
+        """Clear all findings for a workshop (for testing)."""
+        self.db.query(DiscoveryFindingDB).filter(DiscoveryFindingDB.workshop_id == workshop_id).delete()
+        self.db.commit()
 
-      # Use retry logic for tagging - bind variables via default args
-      def _tag_trace(_tid=mlflow_trace_id, _tag=tag_type, _wid=workshop_id, _set_tag=set_trace_tag):
-        _set_tag(trace_id=_tid, key='label', value=_tag)
-        _set_tag(trace_id=_tid, key='workshop_id', value=_wid)
-        return True
+    def clear_annotations(self, workshop_id: str) -> None:
+        """Clear all annotations for a workshop (for testing)."""
+        self.db.query(AnnotationDB).filter(AnnotationDB.workshop_id == workshop_id).delete()
+        self.db.commit()
 
-      result = _retry_mlflow_operation(
-        _tag_trace,
-        max_retries=3,
-        description=f"tag_trace for {mlflow_trace_id[:12]}..."
-      )
-      if result:
-        tagged.append(trace_id)
-        logger.debug(f"Tagged trace {mlflow_trace_id} with label={tag_type}")
-      else:
-        failed.append(trace_id)
+    def clear_rubric(self, workshop_id: str) -> None:
+        """Clear the rubric for a workshop (for testing)."""
+        self.db.query(RubricDB).filter(RubricDB.workshop_id == workshop_id).delete()
+        self.db.commit()
 
-    logger.info(f"Tagged {len(tagged)} traces for {tag_type}, {len(failed)} failed")
-    return {'tagged': len(tagged), 'failed': failed}
+    # MLflow Intake Configuration operations
+    def create_mlflow_config(self, workshop_id: str, config_data: MLflowIntakeConfig) -> MLflowIntakeConfig:
+        """Create or update MLflow intake configuration for a workshop (without storing token)."""
+        # Check if config already exists
+        existing_config = (
+            self.db.query(MLflowIntakeConfigDB).filter(MLflowIntakeConfigDB.workshop_id == workshop_id).first()
+        )
 
-  def get_annotations(self, workshop_id: str, user_id: Optional[str] = None) -> List[Annotation]:
-    """Get annotations for a workshop, optionally filtered by user."""
-    query = self.db.query(AnnotationDB).join(TraceDB).filter(AnnotationDB.workshop_id == workshop_id)
+        if existing_config:
+            # Update existing config
+            existing_config.databricks_host = config_data.databricks_host
+            existing_config.experiment_id = config_data.experiment_id
+            existing_config.max_traces = config_data.max_traces
+            existing_config.filter_string = config_data.filter_string
+            existing_config.is_ingested = False
+            existing_config.trace_count = 0
+            existing_config.last_ingestion_time = None
+            existing_config.error_message = None
 
-    # Filter by user_id if provided
-    if user_id:
-      query = query.filter(AnnotationDB.user_id == user_id)
+            self.db.commit()
+            self.db.refresh(existing_config)
 
-    db_annotations = query.all()
+            return MLflowIntakeConfig(
+                databricks_host=existing_config.databricks_host,
+                databricks_token=config_data.databricks_token,  # Return the provided token, not from DB
+                experiment_id=existing_config.experiment_id,
+                max_traces=existing_config.max_traces,
+                filter_string=existing_config.filter_string,
+            )
+        # Create new config
+        config_id = str(uuid.uuid4())
+        db_config = MLflowIntakeConfigDB(
+            id=config_id,
+            workshop_id=workshop_id,
+            databricks_host=config_data.databricks_host,
+            experiment_id=config_data.experiment_id,
+            max_traces=config_data.max_traces,
+            filter_string=config_data.filter_string,
+        )
 
-    return [
-      Annotation(
-        id=db_annotation.id,
-        workshop_id=db_annotation.workshop_id,
-        trace_id=db_annotation.trace_id,
-        user_id=db_annotation.user_id,
-        rating=db_annotation.rating,
-        ratings=db_annotation.ratings,  # Include multiple ratings
-        comment=db_annotation.comment,
-        mlflow_trace_id=db_annotation.trace.mlflow_trace_id,
-        created_at=db_annotation.created_at,
-      )
-      for db_annotation in db_annotations
-    ]
+        self.db.add(db_config)
+        self.db.commit()
+        self.db.refresh(db_config)
 
-  def get_annotations_with_user_details(self, workshop_id: str, user_id: Optional[str] = None) -> List[Dict[str, Any]]:
-    """Get annotations with user details for facilitator view."""
-    query = self.db.query(AnnotationDB, UserDB).join(UserDB, AnnotationDB.user_id == UserDB.id).filter(AnnotationDB.workshop_id == workshop_id)
+        return MLflowIntakeConfig(
+            databricks_host=db_config.databricks_host,
+            databricks_token=config_data.databricks_token,  # Return the provided token, not from DB
+            experiment_id=db_config.experiment_id,
+            max_traces=db_config.max_traces,
+            filter_string=db_config.filter_string,
+        )
 
-    # Filter by user_id if provided
-    if user_id:
-      query = query.filter(AnnotationDB.user_id == user_id)
+    def get_mlflow_config(self, workshop_id: str) -> MLflowIntakeConfig | None:
+        """Get MLflow intake configuration for a workshop (without token)."""
+        db_config = self.db.query(MLflowIntakeConfigDB).filter(MLflowIntakeConfigDB.workshop_id == workshop_id).first()
 
-    results = query.all()
+        if not db_config:
+            return None
 
-    return [
-      {
-        'id': annotation.id,
-        'workshop_id': annotation.workshop_id,
-        'trace_id': annotation.trace_id,
-        'user_id': annotation.user_id,
-        'user_name': user.name,
-        'user_email': user.email,
-        'user_role': user.role,  # Include user role for SME/participant distinction
-        'rating': annotation.rating,
-        'ratings': annotation.ratings,  # Include per-metric ratings dictionary
-        'comment': annotation.comment,
-        'mlflow_trace_id': getattr(annotation, 'mlflow_trace_id', None),
-        'created_at': annotation.created_at,
-      }
-      for annotation, user in results
-    ]
+        return MLflowIntakeConfig(
+            databricks_host=db_config.databricks_host,
+            databricks_token="",  # Token is not stored in database
+            experiment_id=db_config.experiment_id,
+            max_traces=db_config.max_traces,
+            filter_string=db_config.filter_string,
+        )
 
-  # User management operations
-  def create_user(self, user: User) -> User:
-    """Create a new user in the database."""
-    db_user = UserDB(
-      id=user.id,
-      email=user.email,
-      name=user.name,
-      role=user.role,
-      workshop_id=user.workshop_id,
-      status=user.status,
-      password_hash=user.password_hash,
-      created_at=user.created_at,
-      last_active=user.last_active,
-    )
-    self.db.add(db_user)
-    self.db.commit()
-    self.db.refresh(db_user)
-    return user
+    def set_databricks_token(self, workshop_id: str, token: str) -> None:
+        """Persist Databricks token for a workshop."""
+        if not token:
+            return
 
-  def create_user_with_password(self, user_data: UserCreate) -> User:
-    """Create a new user with password."""
-    # Normalize email to lowercase for consistency
-    normalized_email = user_data.email.lower()
-    
-    # Generate default password if not provided
-    if not user_data.password:
-      user_data.password = generate_default_password(normalized_email)
+        db_token = self.db.query(DatabricksTokenDB).filter(DatabricksTokenDB.workshop_id == workshop_id).first()
 
-    # Hash the password
-    password_hash = hash_password(user_data.password)
+        if db_token:
+            db_token.token = token
+            db_token.updated_at = datetime.now()
+        else:
+            db_token = DatabricksTokenDB(workshop_id=workshop_id, token=token)
+            self.db.add(db_token)
 
-    # Create user with PENDING status
-    user = User(
-      id=str(uuid.uuid4()),
-      email=normalized_email,
-      name=user_data.name,
-      role=user_data.role,
-      workshop_id=user_data.workshop_id,
-      status=UserStatus.PENDING,
-      password_hash=password_hash,
-    )
+        self.db.commit()
 
-    return self.create_user(user)
-
-  def authenticate_user(self, email: str, password: str) -> Optional[User]:
-    """Authenticate a user with email and password. SMEs and participants only need email."""
-    # Case-insensitive email comparison
-    db_user = self.db.query(UserDB).filter(UserDB.email.ilike(email)).first()
-    if not db_user:
-      return None
-
-    # For SMEs and participants, skip password verification (email-only login)
-    if db_user.role in ['sme', 'participant']:
-      pass  # No password verification needed
-    # For facilitators, require password verification
-    elif db_user.role == 'facilitator':
-      if not verify_password(password, db_user.password_hash or ''):
-        return None
-    else:
-      # Unknown role, require password for security
-      if not verify_password(password, db_user.password_hash or ''):
+    def get_databricks_token(self, workshop_id: str) -> str | None:
+        """Retrieve persisted Databricks token for a workshop."""
+        db_token = self.db.query(DatabricksTokenDB).filter(DatabricksTokenDB.workshop_id == workshop_id).first()
+        if db_token:
+            return db_token.token
         return None
 
-    return User(
-      id=db_user.id,
-      email=db_user.email,
-      name=db_user.name,
-      role=db_user.role,
-      workshop_id=db_user.workshop_id,
-      status=db_user.status,
-      password_hash=db_user.password_hash,
-      created_at=db_user.created_at,
-      last_active=db_user.last_active,
-    )
+    def update_mlflow_ingestion_status(
+        self, workshop_id: str, trace_count: int, error_message: str | None = None
+    ) -> None:
+        """Update MLflow ingestion status for a workshop."""
+        db_config = self.db.query(MLflowIntakeConfigDB).filter(MLflowIntakeConfigDB.workshop_id == workshop_id).first()
 
-  def authenticate_facilitator_from_yaml(self, email: str, password: str) -> Optional[Dict[str, Any]]:
-    """Authenticate a facilitator using YAML configuration."""
-    facilitator_config = get_facilitator_config(email)
-    if not facilitator_config:
-      return None
+        if db_config:
+            # Update ingestion status based on trace count
+            if trace_count > 0:
+                db_config.is_ingested = True
+            else:
+                db_config.is_ingested = False
+            db_config.trace_count = trace_count
 
-    if facilitator_config.get('password') != password:
-      return None
+            db_config.last_ingestion_time = datetime.now()
+            db_config.error_message = error_message
 
-    return facilitator_config
+            self.db.commit()
 
-  def get_or_create_facilitator_user(self, facilitator_data: Dict[str, Any]) -> User:
-    """Get or create a facilitator user from YAML config."""
-    # Normalize email to lowercase for consistency
-    email = facilitator_data['email'].lower()
+    def get_mlflow_intake_status(self, workshop_id: str) -> MLflowIntakeStatus:
+        """Get MLflow intake status for a workshop."""
+        db_config = self.db.query(MLflowIntakeConfigDB).filter(MLflowIntakeConfigDB.workshop_id == workshop_id).first()
 
-    # Check if user already exists
-    existing_user = self.get_user_by_email(email)
-    if existing_user:
-      return existing_user
+        if not db_config:
+            return MLflowIntakeStatus(workshop_id=workshop_id, is_configured=False, is_ingested=False, trace_count=0)
 
-    # Create new facilitator user
-    password_hash = hash_password(facilitator_data['password'])
-
-    user = User(
-      id=str(uuid.uuid4()),
-      email=email,
-      name=facilitator_data['name'],
-      role=UserRole.FACILITATOR,
-      workshop_id=None,  # Facilitators aren't tied to a single workshop
-      password_hash=password_hash,
-    )
-
-    return self.create_user(user)
-
-  def get_user_by_email(self, email: str) -> Optional[User]:
-    """Get user by email address."""
-    # Case-insensitive email comparison
-    db_user = self.db.query(UserDB).filter(UserDB.email.ilike(email)).first()
-    if not db_user:
-      return None
-
-    return User(
-      id=db_user.id,
-      email=db_user.email,
-      name=db_user.name,
-      role=db_user.role,
-      workshop_id=db_user.workshop_id,
-      status=db_user.status,
-      password_hash=db_user.password_hash,
-      created_at=db_user.created_at,
-      last_active=db_user.last_active,
-    )
-
-  def create_facilitator_config(self, config_data: FacilitatorConfigCreate) -> FacilitatorConfig:
-    """Create a facilitator configuration."""
-    password_hash = hash_password(config_data.password)
-
-    db_config = FacilitatorConfigDB(
-      id=str(uuid.uuid4()),
-      email=config_data.email,
-      password_hash=password_hash,
-      name=config_data.name,
-      description=config_data.description,
-    )
-
-    self.db.add(db_config)
-    self.db.commit()
-    self.db.refresh(db_config)
-
-    return FacilitatorConfig(
-      email=db_config.email,
-      password_hash=db_config.password_hash,
-      name=db_config.name,
-      description=db_config.description,
-      created_at=db_config.created_at,
-    )
-
-  def get_facilitator_config(self, email: str) -> Optional[FacilitatorConfig]:
-    """Get facilitator configuration by email."""
-    # Case-insensitive email comparison
-    db_config = self.db.query(FacilitatorConfigDB).filter(FacilitatorConfigDB.email.ilike(email)).first()
-
-    if not db_config:
-      return None
-
-    return FacilitatorConfig(
-      email=db_config.email,
-      password_hash=db_config.password_hash,
-      name=db_config.name,
-      description=db_config.description,
-      created_at=db_config.created_at,
-    )
-
-  def list_facilitator_configs(self) -> List[FacilitatorConfig]:
-    """List all facilitator configurations."""
-    db_configs = self.db.query(FacilitatorConfigDB).all()
-
-    return [
-      FacilitatorConfig(
-        email=config.email,
-        password_hash=config.password_hash,
-        name=config.name,
-        description=config.description,
-        created_at=config.created_at,
-      )
-      for config in db_configs
-    ]
-
-  def get_user(self, user_id: str) -> Optional[User]:
-    """Get a user by ID."""
-    db_user = self.db.query(UserDB).filter(UserDB.id == user_id).first()
-    if not db_user:
-      return None
-
-    return User(
-      id=db_user.id,
-      email=db_user.email,
-      name=db_user.name,
-      role=db_user.role,
-      workshop_id=db_user.workshop_id,
-      status=db_user.status,
-      created_at=db_user.created_at,
-      last_active=db_user.last_active,
-    )
-
-  def update_user(self, user: User) -> User:
-    """Update an existing user."""
-    db_user = self.db.query(UserDB).filter(UserDB.id == user.id).first()
-    if not db_user:
-      raise ValueError(f'User {user.id} not found')
-
-    db_user.email = user.email
-    db_user.name = user.name
-    db_user.role = user.role
-    db_user.workshop_id = user.workshop_id
-    db_user.status = user.status
-    db_user.last_active = user.last_active
-
-    self.db.commit()
-    self.db.refresh(db_user)
-    return user
-
-  def activate_user_on_login(self, user_id: str) -> None:
-    """Activate a user when they log in for the first time."""
-    db_user = self.db.query(UserDB).filter(UserDB.id == user_id).first()
-    if db_user and db_user.status == 'pending':
-      db_user.status = 'active'
-      db_user.last_active = datetime.now()
-      self.db.commit()
-
-  def list_users(self, workshop_id: Optional[str] = None, role: Optional[UserRole] = None) -> List[User]:
-    """List users, optionally filtered by workshop or role."""
-    if workshop_id:
-      # For workshop-specific queries, use the workshop_participants table
-      return self.list_workshop_users(workshop_id, role)
-
-    # For general user queries, use the users table
-    query = self.db.query(UserDB)
-
-    if role:
-      query = query.filter(UserDB.role == role)
-
-    db_users = query.all()
-
-    return [
-      User(
-        id=db_user.id,
-        email=db_user.email,
-        name=db_user.name,
-        role=db_user.role,
-        workshop_id=db_user.workshop_id,
-        status=db_user.status,
-        created_at=db_user.created_at,
-        last_active=db_user.last_active,
-      )
-      for db_user in db_users
-    ]
-
-  def list_workshop_users(self, workshop_id: str, role: Optional[UserRole] = None) -> List[User]:
-    """List all users in a specific workshop by joining workshop_participants and users tables."""
-    query = (
-      self.db.query(UserDB, WorkshopParticipantDB)
-      .join(WorkshopParticipantDB, UserDB.id == WorkshopParticipantDB.user_id)
-      .filter(WorkshopParticipantDB.workshop_id == workshop_id)
-    )
-
-    if role:
-      query = query.filter(WorkshopParticipantDB.role == role)
-
-    results = query.all()
-
-    return [
-      User(
-        id=db_user.id,
-        email=db_user.email,
-        name=db_user.name,
-        role=db_participant.role,  # Use the role from WorkshopParticipantDB
-        workshop_id=workshop_id,  # Use the workshop_id parameter
-        status=db_user.status,
-        created_at=db_user.created_at,
-        last_active=db_user.last_active,
-      )
-      for db_user, db_participant in results
-    ]
-
-  # Workshop participant operations
-  def add_workshop_participant(self, participant: WorkshopParticipant) -> WorkshopParticipant:
-    """Add a participant to a workshop."""
-    participant_id = str(uuid.uuid4())
-    db_participant = WorkshopParticipantDB(
-      id=participant_id,
-      user_id=participant.user_id,
-      workshop_id=participant.workshop_id,
-      role=participant.role,
-      assigned_traces=participant.assigned_traces,
-      annotation_quota=participant.annotation_quota,
-      joined_at=participant.joined_at,
-    )
-    self.db.add(db_participant)
-    self.db.commit()
-    self.db.refresh(db_participant)
-
-    return WorkshopParticipant(
-      user_id=db_participant.user_id,
-      workshop_id=db_participant.workshop_id,
-      role=db_participant.role,
-      assigned_traces=db_participant.assigned_traces or [],
-      annotation_quota=db_participant.annotation_quota,
-      joined_at=db_participant.joined_at,
-    )
-
-  def get_workshop_participants(self, workshop_id: str) -> List[WorkshopParticipant]:
-    """Get all participants in a workshop."""
-    db_participants = self.db.query(WorkshopParticipantDB).filter(WorkshopParticipantDB.workshop_id == workshop_id).all()
-
-    return [
-      WorkshopParticipant(
-        user_id=db_participant.user_id,
-        workshop_id=db_participant.workshop_id,
-        role=db_participant.role,
-        assigned_traces=db_participant.assigned_traces or [],
-        annotation_quota=db_participant.annotation_quota,
-        joined_at=db_participant.joined_at,
-      )
-      for db_participant in db_participants
-    ]
-
-  def get_workshop_participant(self, workshop_id: str, user_id: str) -> Optional[WorkshopParticipant]:
-    """Get a specific workshop participant."""
-    db_participant = (
-      self.db.query(WorkshopParticipantDB)
-      .filter(and_(WorkshopParticipantDB.workshop_id == workshop_id, WorkshopParticipantDB.user_id == user_id))
-      .first()
-    )
-
-    if not db_participant:
-      return None
-
-    return WorkshopParticipant(
-      user_id=db_participant.user_id,
-      workshop_id=db_participant.workshop_id,
-      role=db_participant.role,
-      assigned_traces=db_participant.assigned_traces or [],
-      annotation_quota=db_participant.annotation_quota,
-      joined_at=db_participant.joined_at,
-    )
-
-  def update_workshop_participant(self, participant: WorkshopParticipant) -> WorkshopParticipant:
-    """Update a workshop participant."""
-    # TODO: pretty sure this does nothing (no commit, no update)?
-    # db_participant = (
-    (
-      self.db.query(WorkshopParticipantDB)
-      .filter(
-        and_(
-          WorkshopParticipantDB.workshop_id == participant.workshop_id,
-          WorkshopParticipantDB.user_id == participant.user_id,
+        config = MLflowIntakeConfig(
+            databricks_host=db_config.databricks_host,
+            databricks_token="",  # Token is not stored in database
+            experiment_id=db_config.experiment_id,
+            max_traces=db_config.max_traces,
+            filter_string=db_config.filter_string,
         )
-      )
-      .first()
-    )
 
-  def remove_user_from_workshop(self, workshop_id: str, user_id: str) -> bool:
-    """Remove a user from a workshop (but keep them in the system)."""
-    db_participant = (
-      self.db.query(WorkshopParticipantDB)
-      .filter(and_(WorkshopParticipantDB.workshop_id == workshop_id, WorkshopParticipantDB.user_id == user_id))
-      .first()
-    )
-
-    if not db_participant:
-      return False
-
-    self.db.delete(db_participant)
-    self.db.commit()
-    return True
-
-  def update_user_role_in_workshop(self, workshop_id: str, user_id: str, new_role: str) -> Optional[User]:
-    """Update a user's role in a workshop (SME <-> Participant)."""
-    from server.models import UserRole
-    
-    # Update the workshop participant record
-    db_participant = (
-      self.db.query(WorkshopParticipantDB)
-      .filter(and_(WorkshopParticipantDB.workshop_id == workshop_id, WorkshopParticipantDB.user_id == user_id))
-      .first()
-    )
-    
-    if db_participant:
-      # Map string to UserRole enum
-      role_enum = UserRole.SME if new_role == 'sme' else UserRole.PARTICIPANT
-      db_participant.role = role_enum
-    
-    # Also update the user's global role
-    db_user = self.db.query(UserDB).filter(UserDB.id == user_id).first()
-    if db_user:
-      role_enum = UserRole.SME if new_role == 'sme' else UserRole.PARTICIPANT
-      db_user.role = role_enum
-      
-    self.db.commit()
-    
-    # Return updated user
-    return self.get_user(user_id)
-
-  # User Discovery Completion operations
-  def mark_user_discovery_complete(self, workshop_id: str, user_id: str) -> None:
-    """Mark a user as having completed discovery for a workshop."""
-    # Check if already completed
-    existing = (
-      self.db.query(UserDiscoveryCompletionDB)
-      .filter(
-        and_(
-          UserDiscoveryCompletionDB.workshop_id == workshop_id,
-          UserDiscoveryCompletionDB.user_id == user_id,
+        return MLflowIntakeStatus(
+            workshop_id=workshop_id,
+            is_configured=True,
+            is_ingested=db_config.is_ingested,
+            trace_count=db_config.trace_count,
+            last_ingestion_time=db_config.last_ingestion_time,
+            error_message=db_config.error_message,
+            config=config,
         )
-      )
-      .first()
-    )
 
-    if not existing:
-      completion = UserDiscoveryCompletionDB(workshop_id=workshop_id, user_id=user_id)
-      self.db.add(completion)
-      self.db.commit()
+    # Judge Tuning operations
+    def create_judge_prompt(self, workshop_id: str, prompt_data: JudgePromptCreate) -> JudgePrompt:
+        """Create a new judge prompt."""
+        # Get current version number - per judge if judge_name is specified in model_parameters
+        existing_prompts = self.db.query(JudgePromptDB).filter(JudgePromptDB.workshop_id == workshop_id).all()
 
-  def is_user_discovery_complete(self, workshop_id: str, user_id: str) -> bool:
-    """Check if a user has completed discovery for a workshop."""
-    completion = (
-      self.db.query(UserDiscoveryCompletionDB)
-      .filter(
-        and_(
-          UserDiscoveryCompletionDB.workshop_id == workshop_id,
-          UserDiscoveryCompletionDB.user_id == user_id,
-        )
-      )
-      .first()
-    )
-    return completion is not None
+        # Extract judge_name from model_parameters if present
+        judge_name = None
+        if prompt_data.model_parameters and isinstance(prompt_data.model_parameters, dict):
+            judge_name = prompt_data.model_parameters.get("judge_name")
 
-  def get_discovery_completion_status(self, workshop_id: str) -> Dict[str, Any]:
-    """Get discovery completion status for all users in a workshop."""
-    # Get all workshop participants (SMEs and participants, not facilitators) with user details
-    participants = (
-      self.db.query(WorkshopParticipantDB, UserDB)
-      .join(UserDB, WorkshopParticipantDB.user_id == UserDB.id)
-      .filter(
-        and_(
-          WorkshopParticipantDB.workshop_id == workshop_id,
-          WorkshopParticipantDB.role.in_(['sme', 'participant']),
-        )
-      )
-      .all()
-    )
-
-    # Get completion status for each participant
-    completion_status = {}
-    for participant, user in participants:
-      is_complete = self.is_user_discovery_complete(workshop_id, participant.user_id)
-      completion_status[participant.user_id] = {
-        'user_id': participant.user_id,
-        'user_name': user.name,
-        'user_email': user.email,
-        'role': participant.role,
-        'completed': is_complete,
-      }
-
-    # Calculate summary
-    total_participants = len(participants)
-    completed_participants = sum(1 for status in completion_status.values() if status['completed'])
-
-    return {
-      'total_participants': total_participants,
-      'completed_participants': completed_participants,
-      'completion_percentage': (completed_participants / total_participants * 100) if total_participants > 0 else 0,
-      'all_completed': completed_participants == total_participants and total_participants > 0,
-      'participant_status': completion_status,
-    }
-
-  def get_traces_by_workshop(self, workshop_id: str) -> List[Trace]:
-    """Get all traces for a workshop (alias for get_traces)."""
-    return self.get_traces(workshop_id)
-
-  # Testing/debugging operations
-  def clear_findings(self, workshop_id: str) -> None:
-    """Clear all findings for a workshop (for testing)."""
-    self.db.query(DiscoveryFindingDB).filter(DiscoveryFindingDB.workshop_id == workshop_id).delete()
-    self.db.commit()
-
-  def clear_annotations(self, workshop_id: str) -> None:
-    """Clear all annotations for a workshop (for testing)."""
-    self.db.query(AnnotationDB).filter(AnnotationDB.workshop_id == workshop_id).delete()
-    self.db.commit()
-
-  def clear_rubric(self, workshop_id: str) -> None:
-    """Clear the rubric for a workshop (for testing)."""
-    self.db.query(RubricDB).filter(RubricDB.workshop_id == workshop_id).delete()
-    self.db.commit()
-
-  # MLflow Intake Configuration operations
-  def create_mlflow_config(self, workshop_id: str, config_data: MLflowIntakeConfig) -> MLflowIntakeConfig:
-    """Create or update MLflow intake configuration for a workshop (without storing token)."""
-    # Check if config already exists
-    existing_config = self.db.query(MLflowIntakeConfigDB).filter(MLflowIntakeConfigDB.workshop_id == workshop_id).first()
-
-    if existing_config:
-      # Update existing config
-      existing_config.databricks_host = config_data.databricks_host
-      existing_config.experiment_id = config_data.experiment_id
-      existing_config.max_traces = config_data.max_traces
-      existing_config.filter_string = config_data.filter_string
-      existing_config.is_ingested = False
-      existing_config.trace_count = 0
-      existing_config.last_ingestion_time = None
-      existing_config.error_message = None
-
-      self.db.commit()
-      self.db.refresh(existing_config)
-
-      return MLflowIntakeConfig(
-        databricks_host=existing_config.databricks_host,
-        databricks_token=config_data.databricks_token,  # Return the provided token, not from DB
-        experiment_id=existing_config.experiment_id,
-        max_traces=existing_config.max_traces,
-        filter_string=existing_config.filter_string,
-      )
-    else:
-      # Create new config
-      config_id = str(uuid.uuid4())
-      db_config = MLflowIntakeConfigDB(
-        id=config_id,
-        workshop_id=workshop_id,
-        databricks_host=config_data.databricks_host,
-        experiment_id=config_data.experiment_id,
-        max_traces=config_data.max_traces,
-        filter_string=config_data.filter_string,
-      )
-
-      self.db.add(db_config)
-      self.db.commit()
-      self.db.refresh(db_config)
-
-      return MLflowIntakeConfig(
-        databricks_host=db_config.databricks_host,
-        databricks_token=config_data.databricks_token,  # Return the provided token, not from DB
-        experiment_id=db_config.experiment_id,
-        max_traces=db_config.max_traces,
-        filter_string=db_config.filter_string,
-      )
-
-  def get_mlflow_config(self, workshop_id: str) -> Optional[MLflowIntakeConfig]:
-    """Get MLflow intake configuration for a workshop (without token)."""
-    db_config = self.db.query(MLflowIntakeConfigDB).filter(MLflowIntakeConfigDB.workshop_id == workshop_id).first()
-
-    if not db_config:
-      return None
-
-    return MLflowIntakeConfig(
-      databricks_host=db_config.databricks_host,
-      databricks_token='',  # Token is not stored in database
-      experiment_id=db_config.experiment_id,
-      max_traces=db_config.max_traces,
-      filter_string=db_config.filter_string,
-    )
-
-  def set_databricks_token(self, workshop_id: str, token: str) -> None:
-    """Persist Databricks token for a workshop."""
-    if not token:
-      return
-
-    db_token = self.db.query(DatabricksTokenDB).filter(DatabricksTokenDB.workshop_id == workshop_id).first()
-
-    if db_token:
-      db_token.token = token
-      db_token.updated_at = datetime.now()
-    else:
-      db_token = DatabricksTokenDB(workshop_id=workshop_id, token=token)
-      self.db.add(db_token)
-
-    self.db.commit()
-
-  def get_databricks_token(self, workshop_id: str) -> Optional[str]:
-    """Retrieve persisted Databricks token for a workshop."""
-    db_token = self.db.query(DatabricksTokenDB).filter(DatabricksTokenDB.workshop_id == workshop_id).first()
-    if db_token:
-      return db_token.token
-    return None
-
-  def update_mlflow_ingestion_status(self, workshop_id: str, trace_count: int, error_message: Optional[str] = None) -> None:
-    """Update MLflow ingestion status for a workshop."""
-    db_config = self.db.query(MLflowIntakeConfigDB).filter(MLflowIntakeConfigDB.workshop_id == workshop_id).first()
-
-    if db_config:
-      # Update ingestion status based on trace count
-      if trace_count > 0:
-        db_config.is_ingested = True
-      else:
-        db_config.is_ingested = False
-      db_config.trace_count = trace_count
-
-      db_config.last_ingestion_time = datetime.now()
-      db_config.error_message = error_message
-
-      self.db.commit()
-
-  def get_mlflow_intake_status(self, workshop_id: str) -> MLflowIntakeStatus:
-    """Get MLflow intake status for a workshop."""
-    db_config = self.db.query(MLflowIntakeConfigDB).filter(MLflowIntakeConfigDB.workshop_id == workshop_id).first()
-
-    if not db_config:
-      return MLflowIntakeStatus(workshop_id=workshop_id, is_configured=False, is_ingested=False, trace_count=0)
-
-    config = MLflowIntakeConfig(
-      databricks_host=db_config.databricks_host,
-      databricks_token='',  # Token is not stored in database
-      experiment_id=db_config.experiment_id,
-      max_traces=db_config.max_traces,
-      filter_string=db_config.filter_string,
-    )
-
-    return MLflowIntakeStatus(
-      workshop_id=workshop_id,
-      is_configured=True,
-      is_ingested=db_config.is_ingested,
-      trace_count=db_config.trace_count,
-      last_ingestion_time=db_config.last_ingestion_time,
-      error_message=db_config.error_message,
-      config=config,
-    )
-
-  # Judge Tuning operations
-  def create_judge_prompt(self, workshop_id: str, prompt_data: JudgePromptCreate) -> JudgePrompt:
-    """Create a new judge prompt."""
-    # Get current version number - per judge if judge_name is specified in model_parameters
-    existing_prompts = self.db.query(JudgePromptDB).filter(JudgePromptDB.workshop_id == workshop_id).all()
-
-    # Extract judge_name from model_parameters if present
-    judge_name = None
-    if prompt_data.model_parameters and isinstance(prompt_data.model_parameters, dict):
-      judge_name = prompt_data.model_parameters.get('judge_name')
-
-    # Calculate version per-judge if judge_name is specified, otherwise global
-    if judge_name:
-      # Filter to prompts for this specific judge
-      judge_specific_prompts = [
-        p for p in existing_prompts
-        if p.model_parameters and isinstance(p.model_parameters, dict) and p.model_parameters.get('judge_name') == judge_name
-      ]
-      next_version = max([p.version for p in judge_specific_prompts], default=0) + 1
-    else:
-      # Global versioning for prompts without judge_name
-      next_version = max([p.version for p in existing_prompts], default=0) + 1
-
-    prompt_id = str(uuid.uuid4())
-    db_prompt = JudgePromptDB(
-      id=prompt_id,
-      workshop_id=workshop_id,
-      prompt_text=prompt_data.prompt_text,
-      version=next_version,
-      few_shot_examples=prompt_data.few_shot_examples or [],
-      model_name=prompt_data.model_name or 'demo',
-      model_parameters=prompt_data.model_parameters,
-      created_by='demo_facilitator',  # In production, get from auth context
-    )
-
-    self.db.add(db_prompt)
-    self.db.commit()
-    self.db.refresh(db_prompt)
-
-    return JudgePrompt(
-      id=db_prompt.id,
-      workshop_id=db_prompt.workshop_id,
-      prompt_text=db_prompt.prompt_text,
-      version=db_prompt.version,
-      few_shot_examples=db_prompt.few_shot_examples,
-      model_name=db_prompt.model_name,
-      model_parameters=db_prompt.model_parameters,
-      created_by=db_prompt.created_by,
-      created_at=db_prompt.created_at,
-      performance_metrics=db_prompt.performance_metrics,
-    )
-
-  def get_judge_prompts(self, workshop_id: str) -> List[JudgePrompt]:
-    """Get all judge prompts for a workshop."""
-    db_prompts = self.db.query(JudgePromptDB).filter(JudgePromptDB.workshop_id == workshop_id).order_by(JudgePromptDB.version.desc()).all()
-
-    return [
-      JudgePrompt(
-        id=db_prompt.id,
-        workshop_id=db_prompt.workshop_id,
-        prompt_text=db_prompt.prompt_text,
-        version=db_prompt.version,
-        few_shot_examples=db_prompt.few_shot_examples,
-        model_name=db_prompt.model_name,
-        model_parameters=db_prompt.model_parameters,
-        created_by=db_prompt.created_by,
-        created_at=db_prompt.created_at,
-        performance_metrics=db_prompt.performance_metrics,
-      )
-      for db_prompt in db_prompts
-    ]
-
-  def get_judge_prompt(self, workshop_id: str, prompt_id: str) -> Optional[JudgePrompt]:
-    """Get a specific judge prompt."""
-    db_prompt = self.db.query(JudgePromptDB).filter(and_(JudgePromptDB.workshop_id == workshop_id, JudgePromptDB.id == prompt_id)).first()
-
-    if not db_prompt:
-      return None
-
-    return JudgePrompt(
-      id=db_prompt.id,
-      workshop_id=db_prompt.workshop_id,
-      prompt_text=db_prompt.prompt_text,
-      version=db_prompt.version,
-      few_shot_examples=db_prompt.few_shot_examples,
-      model_name=db_prompt.model_name,
-      model_parameters=db_prompt.model_parameters,
-      created_by=db_prompt.created_by,
-      created_at=db_prompt.created_at,
-      performance_metrics=db_prompt.performance_metrics,
-    )
-
-  def update_judge_prompt_metrics(self, prompt_id: str, metrics: dict) -> None:
-    """Update performance metrics for a judge prompt."""
-    db_prompt = self.db.query(JudgePromptDB).filter(JudgePromptDB.id == prompt_id).first()
-
-    if db_prompt:
-      db_prompt.performance_metrics = metrics
-      self.db.commit()
-
-  def store_judge_evaluations(self, evaluations: List[JudgeEvaluation]) -> None:
-    """Store judge evaluation results."""
-    # Clear existing evaluations for this prompt
-    if evaluations:
-      self.db.query(JudgeEvaluationDB).filter(JudgeEvaluationDB.prompt_id == evaluations[0].prompt_id).delete()
-
-    # Get rubric to validate ratings if available
-    rubric = None
-    if evaluations:
-      rubric = self.get_rubric(evaluations[0].workshop_id)
-    
-    # Detect judge type: parse questions first (more accurate), then fall back to rubric-level judge_type
-    judge_type_str = 'likert'  # Default
-    if rubric:
-      # First, try to parse rubric questions to get per-question judge types
-      if rubric.question:
-        try:
-          questions = self._parse_rubric_questions(rubric.question)
-          if questions:
-            # Check if any question is binary
-            binary_questions = [q for q in questions if q.get('judge_type') == 'binary']
-            likert_questions = [q for q in questions if q.get('judge_type') == 'likert']
-            
-            if binary_questions and not likert_questions:
-              # All questions are binary
-              judge_type_str = 'binary'
-              logger.info(f"Detected binary judge type from rubric questions ({len(binary_questions)} binary questions) for evaluation validation")
-            elif likert_questions and not binary_questions:
-              # All questions are likert
-              judge_type_str = 'likert'
-            elif binary_questions:
-              # Mixed - but if we have binary questions, prefer binary
-              judge_type_str = 'binary'
-              logger.info(f"Detected binary judge type from rubric questions (mixed types, {len(binary_questions)} binary questions) for evaluation validation")
-        except Exception as parse_error:
-          logger.warning(f"Could not parse rubric questions for judge type detection: {parse_error}")
-      
-      # Fallback to rubric-level judge_type if no questions parsed or all questions are likert
-      if judge_type_str == 'likert' and hasattr(rubric, 'judge_type') and rubric.judge_type:
-        judge_type_enum = rubric.judge_type
-        if isinstance(judge_type_enum, JudgeType):
-          judge_type_str = judge_type_enum.value
+        # Calculate version per-judge if judge_name is specified, otherwise global
+        if judge_name:
+            # Filter to prompts for this specific judge
+            judge_specific_prompts = [
+                p
+                for p in existing_prompts
+                if p.model_parameters
+                and isinstance(p.model_parameters, dict)
+                and p.model_parameters.get("judge_name") == judge_name
+            ]
+            next_version = max([p.version for p in judge_specific_prompts], default=0) + 1
         else:
-          judge_type_str = str(judge_type_enum)
-    
-    is_binary = judge_type_str == 'binary'
-    logger.info(f"Judge type for evaluation validation: {judge_type_str}, is_binary={is_binary}")
+            # Global versioning for prompts without judge_name
+            next_version = max([p.version for p in existing_prompts], default=0) + 1
 
-    # Add new evaluations - ALWAYS save ratings, never reject them
-    for evaluation in evaluations:
-      validated_predicted_rating = evaluation.predicted_rating
+        prompt_id = str(uuid.uuid4())
+        db_prompt = JudgePromptDB(
+            id=prompt_id,
+            workshop_id=workshop_id,
+            prompt_text=prompt_data.prompt_text,
+            version=next_version,
+            few_shot_examples=prompt_data.few_shot_examples or [],
+            model_name=prompt_data.model_name or "demo",
+            model_parameters=prompt_data.model_parameters,
+            created_by="demo_facilitator",  # In production, get from auth context
+        )
 
-      # Log what we're saving for debugging
-      if evaluation == evaluations[0]:
-        logger.info(f"Storing evaluation: trace={evaluation.trace_id[:8]}..., predicted_rating={validated_predicted_rating}, is_binary={is_binary}")
+        self.db.add(db_prompt)
+        self.db.commit()
+        self.db.refresh(db_prompt)
 
-      if validated_predicted_rating is not None:
-        # Normalize the rating value
-        try:
-          validated_predicted_rating = float(validated_predicted_rating)
-        except (ValueError, TypeError):
-          logger.warning(f"Could not convert predicted_rating {evaluation.predicted_rating} to float for trace {evaluation.trace_id[:8]}... - keeping as-is")
+        return JudgePrompt(
+            id=db_prompt.id,
+            workshop_id=db_prompt.workshop_id,
+            prompt_text=db_prompt.prompt_text,
+            version=db_prompt.version,
+            few_shot_examples=db_prompt.few_shot_examples,
+            model_name=db_prompt.model_name,
+            model_parameters=db_prompt.model_parameters,
+            created_by=db_prompt.created_by,
+            created_at=db_prompt.created_at,
+            performance_metrics=db_prompt.performance_metrics,
+        )
 
-        # Apply appropriate normalization based on detected judge type
-        if is_binary:
-          # Binary: normalize to 0 or 1
-          if validated_predicted_rating == 0 or validated_predicted_rating == 0.0:
-            validated_predicted_rating = 0.0
-          elif validated_predicted_rating == 1 or validated_predicted_rating == 1.0:
-            validated_predicted_rating = 1.0
-          elif 1 <= validated_predicted_rating <= 5:
-            # Convert Likert-style rating to binary using threshold of 3
-            original_value = validated_predicted_rating
-            validated_predicted_rating = 1.0 if validated_predicted_rating >= 3 else 0.0
-            logger.info(f"Converting Likert rating {original_value} to binary {validated_predicted_rating} for trace {evaluation.trace_id[:8]}...")
-          else:
-            # Unknown value - convert to binary based on threshold
-            original_value = validated_predicted_rating
-            validated_predicted_rating = 1.0 if validated_predicted_rating > 0.5 else 0.0
-            logger.info(f"Converting unknown rating {original_value} to binary {validated_predicted_rating} for trace {evaluation.trace_id[:8]}...")
-        else:
-          # Likert: clamp to 1-5 range, NEVER reject
-          if validated_predicted_rating < 1 or validated_predicted_rating > 5:
-            original_value = validated_predicted_rating
-            validated_predicted_rating = max(1.0, min(5.0, validated_predicted_rating))
-            logger.info(f"Likert rating {original_value} clamped to {validated_predicted_rating} for trace {evaluation.trace_id[:8]}...")
-      
-      db_evaluation = JudgeEvaluationDB(
-        id=evaluation.id,
-        workshop_id=evaluation.workshop_id,
-        prompt_id=evaluation.prompt_id,
-        trace_id=evaluation.trace_id,
-        predicted_rating=validated_predicted_rating,
-        human_rating=evaluation.human_rating,
-        confidence=evaluation.confidence,
-        reasoning=evaluation.reasoning,
-        predicted_feedback=evaluation.predicted_feedback,  # judge_name for per-question filtering
-      )
-      self.db.add(db_evaluation)
+    def get_judge_prompts(self, workshop_id: str) -> list[JudgePrompt]:
+        """Get all judge prompts for a workshop."""
+        db_prompts = (
+            self.db.query(JudgePromptDB)
+            .filter(JudgePromptDB.workshop_id == workshop_id)
+            .order_by(JudgePromptDB.version.desc())
+            .all()
+        )
 
-    self.db.commit()
+        return [
+            JudgePrompt(
+                id=db_prompt.id,
+                workshop_id=db_prompt.workshop_id,
+                prompt_text=db_prompt.prompt_text,
+                version=db_prompt.version,
+                few_shot_examples=db_prompt.few_shot_examples,
+                model_name=db_prompt.model_name,
+                model_parameters=db_prompt.model_parameters,
+                created_by=db_prompt.created_by,
+                created_at=db_prompt.created_at,
+                performance_metrics=db_prompt.performance_metrics,
+            )
+            for db_prompt in db_prompts
+        ]
 
-  def get_judge_evaluations(self, workshop_id: str, prompt_id: str) -> List[JudgeEvaluation]:
-    """Get evaluation results for a judge prompt."""
-    db_evaluations = (
-      self.db.query(JudgeEvaluationDB).filter(and_(JudgeEvaluationDB.workshop_id == workshop_id, JudgeEvaluationDB.prompt_id == prompt_id)).all()
-    )
+    def get_judge_prompt(self, workshop_id: str, prompt_id: str) -> JudgePrompt | None:
+        """Get a specific judge prompt."""
+        db_prompt = (
+            self.db.query(JudgePromptDB)
+            .filter(and_(JudgePromptDB.workshop_id == workshop_id, JudgePromptDB.id == prompt_id))
+            .first()
+        )
 
-    return [
-      JudgeEvaluation(
-        id=db_eval.id,
-        workshop_id=db_eval.workshop_id,
-        prompt_id=db_eval.prompt_id,
-        trace_id=db_eval.trace_id,
-        predicted_rating=db_eval.predicted_rating,
-        human_rating=db_eval.human_rating,
-        confidence=db_eval.confidence,
-        reasoning=db_eval.reasoning,
-        predicted_feedback=db_eval.predicted_feedback,
-      )
-      for db_eval in db_evaluations
-    ]
+        if not db_prompt:
+            return None
 
-  def clear_judge_evaluations(self, workshop_id: str, prompt_id: str) -> None:
-    """Clear all evaluation results for a specific judge prompt."""
-    self.db.query(JudgeEvaluationDB).filter(and_(JudgeEvaluationDB.workshop_id == workshop_id, JudgeEvaluationDB.prompt_id == prompt_id)).delete()
-    self.db.commit()
+        return JudgePrompt(
+            id=db_prompt.id,
+            workshop_id=db_prompt.workshop_id,
+            prompt_text=db_prompt.prompt_text,
+            version=db_prompt.version,
+            few_shot_examples=db_prompt.few_shot_examples,
+            model_name=db_prompt.model_name,
+            model_parameters=db_prompt.model_parameters,
+            created_by=db_prompt.created_by,
+            created_at=db_prompt.created_at,
+            performance_metrics=db_prompt.performance_metrics,
+        )
 
-  def get_latest_evaluations(self, workshop_id: str) -> List[JudgeEvaluation]:
-    """Get the most recent evaluation results for a workshop (from any prompt).
+    def update_judge_prompt_metrics(self, prompt_id: str, metrics: dict) -> None:
+        """Update performance metrics for a judge prompt."""
+        db_prompt = self.db.query(JudgePromptDB).filter(JudgePromptDB.id == prompt_id).first()
 
-    This returns evaluations from the most recently created prompt that has evaluations.
-    Useful for getting auto-evaluation results without knowing the prompt ID.
+        if db_prompt:
+            db_prompt.performance_metrics = metrics
+            self.db.commit()
 
-    Note: We find the latest prompt that actually HAS evaluations, not just the latest
-    prompt. This is important because alignment creates new prompt versions (with aligned
-    instructions) that don't yet have evaluations until re-evaluation is run.
-    """
-    # Get prompts ordered by creation date (newest first)
-    prompts = (
-      self.db.query(JudgePromptDB)
-      .filter(JudgePromptDB.workshop_id == workshop_id)
-      .order_by(JudgePromptDB.created_at.desc())
-      .all()
-    )
+    def store_judge_evaluations(self, evaluations: list[JudgeEvaluation]) -> None:
+        """Store judge evaluation results."""
+        # Clear existing evaluations for this prompt
+        if evaluations:
+            self.db.query(JudgeEvaluationDB).filter(JudgeEvaluationDB.prompt_id == evaluations[0].prompt_id).delete()
 
-    if not prompts:
-      return []
+        # Get rubric to validate ratings if available
+        rubric = None
+        if evaluations:
+            rubric = self.get_rubric(evaluations[0].workshop_id)
 
-    # Find the latest prompt that actually has evaluations
-    db_evaluations = []
-    for prompt in prompts:
-      db_evaluations = (
-        self.db.query(JudgeEvaluationDB)
-        .filter(and_(
-          JudgeEvaluationDB.workshop_id == workshop_id,
-          JudgeEvaluationDB.prompt_id == prompt.id
-        ))
-        .all()
-      )
-      if db_evaluations:
-        break
-    
-    return [
-      JudgeEvaluation(
-        id=db_eval.id,
-        workshop_id=db_eval.workshop_id,
-        prompt_id=db_eval.prompt_id,
-        trace_id=db_eval.trace_id,
-        predicted_rating=db_eval.predicted_rating,
-        human_rating=db_eval.human_rating,
-        confidence=db_eval.confidence,
-        reasoning=db_eval.reasoning,
-        predicted_feedback=db_eval.predicted_feedback,
-      )
-      for db_eval in db_evaluations
-    ]
+        # Detect judge type: parse questions first (more accurate), then fall back to rubric-level judge_type
+        judge_type_str = "likert"  # Default
+        if rubric:
+            # First, try to parse rubric questions to get per-question judge types
+            if rubric.question:
+                try:
+                    questions = self._parse_rubric_questions(rubric.question)
+                    if questions:
+                        # Check if any question is binary
+                        binary_questions = [q for q in questions if q.get("judge_type") == "binary"]
+                        likert_questions = [q for q in questions if q.get("judge_type") == "likert"]
 
-  # User trace order operations
-  def get_user_trace_order(self, workshop_id: str, user_id: str) -> Optional[UserTraceOrder]:
-    """Get user's trace order for a workshop."""
-    db_order = self.db.query(UserTraceOrderDB).filter(and_(UserTraceOrderDB.workshop_id == workshop_id, UserTraceOrderDB.user_id == user_id)).first()
+                        if binary_questions and not likert_questions:
+                            # All questions are binary
+                            judge_type_str = "binary"
+                            logger.info(
+                                f"Detected binary judge type from rubric questions ({len(binary_questions)} binary questions) for evaluation validation"
+                            )
+                        elif likert_questions and not binary_questions:
+                            # All questions are likert
+                            judge_type_str = "likert"
+                        elif binary_questions:
+                            # Mixed - but if we have binary questions, prefer binary
+                            judge_type_str = "binary"
+                            logger.info(
+                                f"Detected binary judge type from rubric questions (mixed types, {len(binary_questions)} binary questions) for evaluation validation"
+                            )
+                except Exception as parse_error:
+                    logger.warning(f"Could not parse rubric questions for judge type detection: {parse_error}")
 
-    if not db_order:
-      return None
+            # Fallback to rubric-level judge_type if no questions parsed or all questions are likert
+            if judge_type_str == "likert" and hasattr(rubric, "judge_type") and rubric.judge_type:
+                judge_type_enum = rubric.judge_type
+                if isinstance(judge_type_enum, JudgeType):
+                    judge_type_str = judge_type_enum.value
+                else:
+                    judge_type_str = str(judge_type_enum)
 
-    return UserTraceOrder(
-      id=db_order.id,
-      user_id=db_order.user_id,
-      workshop_id=db_order.workshop_id,
-      discovery_traces=db_order.discovery_traces or [],
-      annotation_traces=db_order.annotation_traces or [],
-      created_at=db_order.created_at,
-      updated_at=db_order.updated_at,
-    )
+        is_binary = judge_type_str == "binary"
+        logger.info(f"Judge type for evaluation validation: {judge_type_str}, is_binary={is_binary}")
 
-  def create_user_trace_order(self, workshop_id: str, user_id: str) -> UserTraceOrder:
-    """Create a new user trace order."""
-    order_id = str(uuid.uuid4())
-    db_order = UserTraceOrderDB(
-      id=order_id,
-      user_id=user_id,
-      workshop_id=workshop_id,
-      discovery_traces=[],
-      annotation_traces=[],
-    )
-    self.db.add(db_order)
-    self.db.commit()
-    self.db.refresh(db_order)
+        # Add new evaluations - ALWAYS save ratings, never reject them
+        for evaluation in evaluations:
+            validated_predicted_rating = evaluation.predicted_rating
 
-    return UserTraceOrder(
-      id=db_order.id,
-      user_id=db_order.user_id,
-      workshop_id=db_order.workshop_id,
-      discovery_traces=db_order.discovery_traces or [],
-      annotation_traces=db_order.annotation_traces or [],
-      created_at=db_order.created_at,
-      updated_at=db_order.updated_at,
-    )
+            # Log what we're saving for debugging
+            if evaluation == evaluations[0]:
+                logger.info(
+                    f"Storing evaluation: trace={evaluation.trace_id[:8]}..., predicted_rating={validated_predicted_rating}, is_binary={is_binary}"
+                )
 
-  def update_user_trace_order(self, user_order: UserTraceOrder) -> None:
-    """Update an existing user trace order."""
-    db_order = self.db.query(UserTraceOrderDB).filter(UserTraceOrderDB.id == user_order.id).first()
+            if validated_predicted_rating is not None:
+                # Normalize the rating value
+                try:
+                    validated_predicted_rating = float(validated_predicted_rating)
+                except (ValueError, TypeError):
+                    logger.warning(
+                        f"Could not convert predicted_rating {evaluation.predicted_rating} to float for trace {evaluation.trace_id[:8]}... - keeping as-is"
+                    )
 
-    if db_order:
-      db_order.discovery_traces = user_order.discovery_traces
-      db_order.annotation_traces = user_order.annotation_traces
-      db_order.updated_at = datetime.now()
-      self.db.commit()
+                # Apply appropriate normalization based on detected judge type
+                if is_binary:
+                    # Binary: normalize to 0 or 1
+                    if validated_predicted_rating == 0 or validated_predicted_rating == 0.0:
+                        validated_predicted_rating = 0.0
+                    elif validated_predicted_rating == 1 or validated_predicted_rating == 1.0:
+                        validated_predicted_rating = 1.0
+                    elif 1 <= validated_predicted_rating <= 5:
+                        # Convert Likert-style rating to binary using threshold of 3
+                        original_value = validated_predicted_rating
+                        validated_predicted_rating = 1.0 if validated_predicted_rating >= 3 else 0.0
+                        logger.info(
+                            f"Converting Likert rating {original_value} to binary {validated_predicted_rating} for trace {evaluation.trace_id[:8]}..."
+                        )
+                    else:
+                        # Unknown value - convert to binary based on threshold
+                        original_value = validated_predicted_rating
+                        validated_predicted_rating = 1.0 if validated_predicted_rating > 0.5 else 0.0
+                        logger.info(
+                            f"Converting unknown rating {original_value} to binary {validated_predicted_rating} for trace {evaluation.trace_id[:8]}..."
+                        )
+                else:
+                    # Likert: clamp to 1-5 range, NEVER reject
+                    if validated_predicted_rating < 1 or validated_predicted_rating > 5:
+                        original_value = validated_predicted_rating
+                        validated_predicted_rating = max(1.0, min(5.0, validated_predicted_rating))
+                        logger.info(
+                            f"Likert rating {original_value} clamped to {validated_predicted_rating} for trace {evaluation.trace_id[:8]}..."
+                        )
 
-  def get_trace(self, trace_id: str) -> Optional[Trace]:
-    """Get a specific trace by ID."""
-    db_trace = self.db.query(TraceDB).filter(TraceDB.id == trace_id).first()
+            db_evaluation = JudgeEvaluationDB(
+                id=evaluation.id,
+                workshop_id=evaluation.workshop_id,
+                prompt_id=evaluation.prompt_id,
+                trace_id=evaluation.trace_id,
+                predicted_rating=validated_predicted_rating,
+                human_rating=evaluation.human_rating,
+                confidence=evaluation.confidence,
+                reasoning=evaluation.reasoning,
+                predicted_feedback=evaluation.predicted_feedback,  # judge_name for per-question filtering
+            )
+            self.db.add(db_evaluation)
 
-    if not db_trace:
-      return None
+        self.db.commit()
 
-    return self._trace_from_db(db_trace)
+    def get_judge_evaluations(self, workshop_id: str, prompt_id: str) -> list[JudgeEvaluation]:
+        """Get evaluation results for a judge prompt."""
+        db_evaluations = (
+            self.db.query(JudgeEvaluationDB)
+            .filter(and_(JudgeEvaluationDB.workshop_id == workshop_id, JudgeEvaluationDB.prompt_id == prompt_id))
+            .all()
+        )
 
-  def _trace_from_db(self, db_trace: TraceDB) -> Trace:
-    """Convert a database trace to a response model."""
-    return Trace(
-      id=db_trace.id,
-      workshop_id=db_trace.workshop_id,
-      input=db_trace.input,
-      output=db_trace.output,
-      context=db_trace.context,
-      trace_metadata=db_trace.trace_metadata,  # Renamed from metadata
-      mlflow_trace_id=db_trace.mlflow_trace_id,
-      mlflow_url=db_trace.mlflow_url,
-      mlflow_host=db_trace.mlflow_host,
-      mlflow_experiment_id=db_trace.mlflow_experiment_id,
-      include_in_alignment=db_trace.include_in_alignment if db_trace.include_in_alignment is not None else True,
-      sme_feedback=db_trace.sme_feedback,
-      created_at=db_trace.created_at,
-    )
+        return [
+            JudgeEvaluation(
+                id=db_eval.id,
+                workshop_id=db_eval.workshop_id,
+                prompt_id=db_eval.prompt_id,
+                trace_id=db_eval.trace_id,
+                predicted_rating=db_eval.predicted_rating,
+                human_rating=db_eval.human_rating,
+                confidence=db_eval.confidence,
+                reasoning=db_eval.reasoning,
+                predicted_feedback=db_eval.predicted_feedback,
+            )
+            for db_eval in db_evaluations
+        ]
 
-  def update_trace_alignment_inclusion(self, trace_id: str, include_in_alignment: bool) -> Optional[Trace]:
-    """Update whether a trace should be included in judge alignment."""
-    db_trace = self.db.query(TraceDB).filter(TraceDB.id == trace_id).first()
-    if not db_trace:
-      return None
+    def clear_judge_evaluations(self, workshop_id: str, prompt_id: str) -> None:
+        """Clear all evaluation results for a specific judge prompt."""
+        self.db.query(JudgeEvaluationDB).filter(
+            and_(JudgeEvaluationDB.workshop_id == workshop_id, JudgeEvaluationDB.prompt_id == prompt_id)
+        ).delete()
+        self.db.commit()
 
-    db_trace.include_in_alignment = include_in_alignment
-    self.db.commit()
-    self.db.refresh(db_trace)
+    def get_latest_evaluations(self, workshop_id: str) -> list[JudgeEvaluation]:
+        """Get the most recent evaluation results for a workshop (from any prompt).
 
-    return self._trace_from_db(db_trace)
+        This returns evaluations from the most recently created prompt that has evaluations.
+        Useful for getting auto-evaluation results without knowing the prompt ID.
 
-  def update_trace_sme_feedback(self, trace_id: str, sme_feedback: str) -> Optional[Trace]:
-    """Update the concatenated SME feedback for a trace."""
-    db_trace = self.db.query(TraceDB).filter(TraceDB.id == trace_id).first()
-    if not db_trace:
-      return None
+        Note: We find the latest prompt that actually HAS evaluations, not just the latest
+        prompt. This is important because alignment creates new prompt versions (with aligned
+        instructions) that don't yet have evaluations until re-evaluation is run.
+        """
+        # Get prompts ordered by creation date (newest first)
+        prompts = (
+            self.db.query(JudgePromptDB)
+            .filter(JudgePromptDB.workshop_id == workshop_id)
+            .order_by(JudgePromptDB.created_at.desc())
+            .all()
+        )
 
-    db_trace.sme_feedback = sme_feedback
-    self.db.commit()
-    self.db.refresh(db_trace)
+        if not prompts:
+            return []
 
-    return self._trace_from_db(db_trace)
+        # Find the latest prompt that actually has evaluations
+        db_evaluations = []
+        for prompt in prompts:
+            db_evaluations = (
+                self.db.query(JudgeEvaluationDB)
+                .filter(and_(JudgeEvaluationDB.workshop_id == workshop_id, JudgeEvaluationDB.prompt_id == prompt.id))
+                .all()
+            )
+            if db_evaluations:
+                break
 
-  def get_traces_for_alignment(self, workshop_id: str) -> List[Trace]:
-    """Get all traces that are marked for inclusion in alignment."""
-    db_traces = (
-      self.db.query(TraceDB)
-      .filter(
-        TraceDB.workshop_id == workshop_id,
-        TraceDB.include_in_alignment == True  # noqa: E712
-      )
-      .order_by(TraceDB.created_at)
-      .all()
-    )
-    return [self._trace_from_db(db_trace) for db_trace in db_traces]
+        return [
+            JudgeEvaluation(
+                id=db_eval.id,
+                workshop_id=db_eval.workshop_id,
+                prompt_id=db_eval.prompt_id,
+                trace_id=db_eval.trace_id,
+                predicted_rating=db_eval.predicted_rating,
+                human_rating=db_eval.human_rating,
+                confidence=db_eval.confidence,
+                reasoning=db_eval.reasoning,
+                predicted_feedback=db_eval.predicted_feedback,
+            )
+            for db_eval in db_evaluations
+        ]
 
-  def aggregate_sme_feedback_for_trace(self, workshop_id: str, trace_id: str) -> Optional[str]:
-    """Aggregate all SME comments for a trace into a single feedback string.
-    
-    Returns the concatenated feedback from all annotations on this trace.
-    """
-    annotations = self.get_annotations(workshop_id)
-    trace_annotations = [a for a in annotations if a.trace_id == trace_id and a.comment]
-    
-    if not trace_annotations:
-      return None
-    
-    # Concatenate all non-empty comments
-    feedback_parts = []
-    for ann in trace_annotations:
-      if ann.comment and ann.comment.strip():
-        feedback_parts.append(f"[{ann.user_id}]: {ann.comment.strip()}")
-    
-    return "\n\n".join(feedback_parts) if feedback_parts else None
+    # User trace order operations
+    def get_user_trace_order(self, workshop_id: str, user_id: str) -> UserTraceOrder | None:
+        """Get user's trace order for a workshop."""
+        db_order = (
+            self.db.query(UserTraceOrderDB)
+            .filter(and_(UserTraceOrderDB.workshop_id == workshop_id, UserTraceOrderDB.user_id == user_id))
+            .first()
+        )
 
-  def delete_all_traces(self, workshop_id: str) -> int:
-    """Delete all traces for a workshop and reset to intake phase.
-    
-    Returns the number of traces deleted.
-    """
-    # Import all related models
-    from server.database import (
-      AnnotationDB, UserTraceOrderDB, RubricDB, MLflowIntakeConfigDB,
-      DiscoveryFindingDB, UserDiscoveryCompletionDB, JudgePromptDB, JudgeEvaluationDB
-    )
-    
-    # Get trace IDs first
-    trace_ids = [t.id for t in self.db.query(TraceDB).filter(TraceDB.workshop_id == workshop_id).all()]
-    
-    if trace_ids:
-      # Delete annotations for these traces
-      self.db.query(AnnotationDB).filter(AnnotationDB.trace_id.in_(trace_ids)).delete(synchronize_session=False)
-      # Delete judge evaluations for these traces
-      self.db.query(JudgeEvaluationDB).filter(JudgeEvaluationDB.trace_id.in_(trace_ids)).delete(synchronize_session=False)
-    
-    # Delete user trace orders for this workshop
-    self.db.query(UserTraceOrderDB).filter(UserTraceOrderDB.workshop_id == workshop_id).delete(synchronize_session=False)
-    
-    # Delete discovery findings for this workshop
-    self.db.query(DiscoveryFindingDB).filter(DiscoveryFindingDB.workshop_id == workshop_id).delete(synchronize_session=False)
-    
-    # Delete user discovery completions for this workshop
-    self.db.query(UserDiscoveryCompletionDB).filter(UserDiscoveryCompletionDB.workshop_id == workshop_id).delete(synchronize_session=False)
-    
-    # Delete judge prompts for this workshop (after evaluations are deleted)
-    self.db.query(JudgePromptDB).filter(JudgePromptDB.workshop_id == workshop_id).delete(synchronize_session=False)
-    
-    # Delete all traces
-    deleted_count = self.db.query(TraceDB).filter(TraceDB.workshop_id == workshop_id).delete(synchronize_session=False)
-    
-    # Delete rubric for this workshop
-    self.db.query(RubricDB).filter(RubricDB.workshop_id == workshop_id).delete(synchronize_session=False)
-    
-    # Reset MLflow intake status (trace_count and is_ingested)
-    mlflow_config = self.db.query(MLflowIntakeConfigDB).filter(MLflowIntakeConfigDB.workshop_id == workshop_id).first()
-    if mlflow_config:
-      mlflow_config.trace_count = 0
-      mlflow_config.is_ingested = False
-      mlflow_config.last_ingestion_time = None
-    
-    # Reset workshop to intake phase
-    workshop = self.db.query(WorkshopDB).filter(WorkshopDB.id == workshop_id).first()
-    if workshop:
-      workshop.current_phase = WorkshopPhase.INTAKE
-      workshop.completed_phases = []
-      workshop.discovery_started = False
-      workshop.annotation_started = False
-      workshop.active_discovery_trace_ids = None
-      workshop.active_annotation_trace_ids = None
-    
-    self.db.commit()
-    return deleted_count
+        if not db_order:
+            return None
 
-  def reset_workshop_to_discovery(self, workshop_id: str) -> Optional[Workshop]:
-    """Reset a workshop back to the discovery start page (before discovery was started).
-    
-    This allows changing the discovery configuration (e.g., number of traces).
-    The phase stays as DISCOVERY but discovery_started is set to False,
-    which causes the UI to show the Discovery Start Page.
-    
-    IMPORTANT: This also clears all discovery-related data so participants start fresh:
-    - Discovery findings (participant responses)
-    - User trace orders (personalized trace lists)
-    - User discovery completions (who completed discovery)
-    
-    Returns the updated workshop or None if not found.
-    """
-    workshop = self.db.query(WorkshopDB).filter(WorkshopDB.id == workshop_id).first()
-    if not workshop:
-      return None
-    
-    # Clear all discovery-related data so participants start fresh
-    # 1. Clear discovery findings (participant responses)
-    self.db.query(DiscoveryFindingDB).filter(
-      DiscoveryFindingDB.workshop_id == workshop_id
-    ).delete(synchronize_session=False)
-    
-    # 2. Clear user trace orders (personalized trace lists)
-    self.db.query(UserTraceOrderDB).filter(
-      UserTraceOrderDB.workshop_id == workshop_id
-    ).delete(synchronize_session=False)
-    
-    # 3. Clear user discovery completions (who completed discovery)
-    self.db.query(UserDiscoveryCompletionDB).filter(
-      UserDiscoveryCompletionDB.workshop_id == workshop_id
-    ).delete(synchronize_session=False)
-    
-    # Keep phase as DISCOVERY but mark discovery as NOT started
-    # This causes the UI to show the Discovery Start Page
-    workshop.current_phase = WorkshopPhase.DISCOVERY
-    workshop.discovery_started = False
-    
-    # Keep completed phases up to intake (discovery not yet complete)
-    completed = workshop.completed_phases or []
-    workshop.completed_phases = [p for p in completed if p in ['intake']]
-    
-    # Clear active discovery trace list so new selection can be made
-    workshop.active_discovery_trace_ids = None
-    
-    self.db.commit()
-    self.db.refresh(workshop)
-    
-    return Workshop(
-      id=workshop.id,
-      name=workshop.name,
-      description=workshop.description,
-      facilitator_id=workshop.facilitator_id,
-      status=workshop.status,
-      current_phase=workshop.current_phase,
-      completed_phases=workshop.completed_phases or [],
-      discovery_started=workshop.discovery_started or False,
-      annotation_started=workshop.annotation_started or False,
-      active_discovery_trace_ids=workshop.active_discovery_trace_ids or [],
-      active_annotation_trace_ids=workshop.active_annotation_trace_ids or [],
-      created_at=workshop.created_at,
-    )
+        return UserTraceOrder(
+            id=db_order.id,
+            user_id=db_order.user_id,
+            workshop_id=db_order.workshop_id,
+            discovery_traces=db_order.discovery_traces or [],
+            annotation_traces=db_order.annotation_traces or [],
+            created_at=db_order.created_at,
+            updated_at=db_order.updated_at,
+        )
 
-  def reset_workshop_to_annotation(self, workshop_id: str) -> Optional[Workshop]:
-    """Reset a workshop back to the annotation start page (before annotation was started).
-    
-    This allows changing the annotation configuration (e.g., trace selection, randomization).
-    The phase stays as ANNOTATION but annotation_started is set to False,
-    which causes the UI to show the Annotation Start Page.
-    
-    IMPORTANT: This clears all annotation-related data so SMEs start fresh:
-    - All annotations submitted by SMEs
-    
-    Traces are kept, but SMEs will start fresh from the beginning.
-    
-    Returns the updated workshop or None if not found.
-    """
-    workshop = self.db.query(WorkshopDB).filter(WorkshopDB.id == workshop_id).first()
-    if not workshop:
-      return None
-    
-    # Clear all annotation-related data so SMEs start fresh
-    # Clear annotations submitted by SMEs
-    self.db.query(AnnotationDB).filter(
-      AnnotationDB.workshop_id == workshop_id
-    ).delete(synchronize_session=False)
-    
-    # Keep phase as ANNOTATION but mark annotation as NOT started
-    # This causes the UI to show the Annotation Start Page
-    workshop.current_phase = WorkshopPhase.ANNOTATION
-    workshop.annotation_started = False
-    
-    # Keep completed phases up to discovery (annotation not yet complete)
-    completed = workshop.completed_phases or []
-    workshop.completed_phases = [p for p in completed if p in ['intake', 'discovery']]
-    
-    # Clear active annotation trace list so new selection can be made
-    workshop.active_annotation_trace_ids = None
+    def create_user_trace_order(self, workshop_id: str, user_id: str) -> UserTraceOrder:
+        """Create a new user trace order."""
+        order_id = str(uuid.uuid4())
+        db_order = UserTraceOrderDB(
+            id=order_id,
+            user_id=user_id,
+            workshop_id=workshop_id,
+            discovery_traces=[],
+            annotation_traces=[],
+        )
+        self.db.add(db_order)
+        self.db.commit()
+        self.db.refresh(db_order)
 
-    self.db.commit()
-    self.db.refresh(workshop)
+        return UserTraceOrder(
+            id=db_order.id,
+            user_id=db_order.user_id,
+            workshop_id=db_order.workshop_id,
+            discovery_traces=db_order.discovery_traces or [],
+            annotation_traces=db_order.annotation_traces or [],
+            created_at=db_order.created_at,
+            updated_at=db_order.updated_at,
+        )
 
-    return Workshop(
-      id=workshop.id,
-      name=workshop.name,
-      description=workshop.description,
-      facilitator_id=workshop.facilitator_id,
-      status=workshop.status,
-      current_phase=workshop.current_phase,
-      completed_phases=workshop.completed_phases or [],
-      discovery_started=workshop.discovery_started or False,
-      annotation_started=workshop.annotation_started or False,
-      active_discovery_trace_ids=workshop.active_discovery_trace_ids or [],
-      active_annotation_trace_ids=workshop.active_annotation_trace_ids or [],
-      created_at=workshop.created_at,
-    )
+    def update_user_trace_order(self, user_order: UserTraceOrder) -> None:
+        """Update an existing user trace order."""
+        db_order = self.db.query(UserTraceOrderDB).filter(UserTraceOrderDB.id == user_order.id).first()
 
-  # Custom LLM Provider operations
-  def get_custom_llm_provider_config(self, workshop_id: str):
-    """Get the custom LLM provider configuration for a workshop.
+        if db_order:
+            db_order.discovery_traces = user_order.discovery_traces
+            db_order.annotation_traces = user_order.annotation_traces
+            db_order.updated_at = datetime.now()
+            self.db.commit()
 
-    Returns the DB model directly (CustomLLMProviderConfigDB) for use in router,
-    or None if no configuration exists.
-    """
-    from server.database import CustomLLMProviderConfigDB
+    def get_trace(self, trace_id: str) -> Trace | None:
+        """Get a specific trace by ID."""
+        db_trace = self.db.query(TraceDB).filter(TraceDB.id == trace_id).first()
 
-    return (
-      self.db.query(CustomLLMProviderConfigDB)
-      .filter(CustomLLMProviderConfigDB.workshop_id == workshop_id)
-      .first()
-    )
+        if not db_trace:
+            return None
 
-  def create_custom_llm_provider_config(self, workshop_id: str, config_data):
-    """Create or update custom LLM provider configuration for a workshop.
+        return self._trace_from_db(db_trace)
 
-    Args:
-      workshop_id: The workshop ID
-      config_data: CustomLLMProviderConfigCreate with provider details
+    def _trace_from_db(self, db_trace: TraceDB) -> Trace:
+        """Convert a database trace to a response model."""
+        return Trace(
+            id=db_trace.id,
+            workshop_id=db_trace.workshop_id,
+            input=db_trace.input,
+            output=db_trace.output,
+            context=db_trace.context,
+            trace_metadata=db_trace.trace_metadata,  # Renamed from metadata
+            mlflow_trace_id=db_trace.mlflow_trace_id,
+            mlflow_url=db_trace.mlflow_url,
+            mlflow_host=db_trace.mlflow_host,
+            mlflow_experiment_id=db_trace.mlflow_experiment_id,
+            include_in_alignment=db_trace.include_in_alignment if db_trace.include_in_alignment is not None else True,
+            sme_feedback=db_trace.sme_feedback,
+            created_at=db_trace.created_at,
+        )
 
-    Returns:
-      The created or updated CustomLLMProviderConfigDB record
-    """
-    from server.database import CustomLLMProviderConfigDB
+    def update_trace_alignment_inclusion(self, trace_id: str, include_in_alignment: bool) -> Trace | None:
+        """Update whether a trace should be included in judge alignment."""
+        db_trace = self.db.query(TraceDB).filter(TraceDB.id == trace_id).first()
+        if not db_trace:
+            return None
 
-    # Check if config already exists
-    existing_config = (
-      self.db.query(CustomLLMProviderConfigDB)
-      .filter(CustomLLMProviderConfigDB.workshop_id == workshop_id)
-      .first()
-    )
+        db_trace.include_in_alignment = include_in_alignment
+        self.db.commit()
+        self.db.refresh(db_trace)
 
-    if existing_config:
-      # Update existing config
-      existing_config.provider_name = config_data.provider_name
-      existing_config.base_url = config_data.base_url
-      existing_config.model_name = config_data.model_name
-      existing_config.is_enabled = True
-      self.db.commit()
-      self.db.refresh(existing_config)
-      return existing_config
-    else:
-      # Create new config
-      new_config = CustomLLMProviderConfigDB(
-        id=str(uuid.uuid4()),
-        workshop_id=workshop_id,
-        provider_name=config_data.provider_name,
-        base_url=config_data.base_url,
-        model_name=config_data.model_name,
-        is_enabled=True,
-      )
-      self.db.add(new_config)
-      self.db.commit()
-      self.db.refresh(new_config)
-      return new_config
+        return self._trace_from_db(db_trace)
 
-  def delete_custom_llm_provider_config(self, workshop_id: str) -> bool:
-    """Delete custom LLM provider configuration for a workshop.
+    def update_trace_sme_feedback(self, trace_id: str, sme_feedback: str) -> Trace | None:
+        """Update the concatenated SME feedback for a trace."""
+        db_trace = self.db.query(TraceDB).filter(TraceDB.id == trace_id).first()
+        if not db_trace:
+            return None
 
-    Args:
-      workshop_id: The workshop ID
+        db_trace.sme_feedback = sme_feedback
+        self.db.commit()
+        self.db.refresh(db_trace)
 
-    Returns:
-      True if a config was deleted, False if none existed
-    """
-    from server.database import CustomLLMProviderConfigDB
+        return self._trace_from_db(db_trace)
 
-    deleted_count = (
-      self.db.query(CustomLLMProviderConfigDB)
-      .filter(CustomLLMProviderConfigDB.workshop_id == workshop_id)
-      .delete(synchronize_session=False)
-    )
-    self.db.commit()
-    return deleted_count > 0
+    def get_traces_for_alignment(self, workshop_id: str) -> list[Trace]:
+        """Get all traces that are marked for inclusion in alignment."""
+        db_traces = (
+            self.db.query(TraceDB)
+            .filter(
+                TraceDB.workshop_id == workshop_id,
+                TraceDB.include_in_alignment == True,  # noqa: E712
+            )
+            .order_by(TraceDB.created_at)
+            .all()
+        )
+        return [self._trace_from_db(db_trace) for db_trace in db_traces]
 
-  def update_custom_llm_provider_enabled(self, workshop_id: str, is_enabled: bool):
-    """Update the enabled status of the custom LLM provider.
+    def aggregate_sme_feedback_for_trace(self, workshop_id: str, trace_id: str) -> str | None:
+        """Aggregate all SME comments for a trace into a single feedback string.
 
-    Args:
-      workshop_id: The workshop ID
-      is_enabled: Whether the custom provider should be enabled
+        Returns the concatenated feedback from all annotations on this trace.
+        """
+        annotations = self.get_annotations(workshop_id)
+        trace_annotations = [a for a in annotations if a.trace_id == trace_id and a.comment]
 
-    Returns:
-      The updated config or None if not found
-    """
-    from server.database import CustomLLMProviderConfigDB
+        if not trace_annotations:
+            return None
 
-    config = (
-      self.db.query(CustomLLMProviderConfigDB)
-      .filter(CustomLLMProviderConfigDB.workshop_id == workshop_id)
-      .first()
-    )
+        # Concatenate all non-empty comments
+        feedback_parts = []
+        for ann in trace_annotations:
+            if ann.comment and ann.comment.strip():
+                feedback_parts.append(f"[{ann.user_id}]: {ann.comment.strip()}")
 
-    if config:
-      config.is_enabled = is_enabled
-      self.db.commit()
-      self.db.refresh(config)
+        return "\n\n".join(feedback_parts) if feedback_parts else None
 
-    return config
+    def delete_all_traces(self, workshop_id: str) -> int:
+        """Delete all traces for a workshop and reset to intake phase.
+
+        Returns the number of traces deleted.
+        """
+        # Import all related models
+        from server.database import (
+            AnnotationDB,
+            DiscoveryFindingDB,
+            JudgeEvaluationDB,
+            JudgePromptDB,
+            MLflowIntakeConfigDB,
+            RubricDB,
+            UserDiscoveryCompletionDB,
+            UserTraceOrderDB,
+        )
+
+        # Get trace IDs first
+        trace_ids = [t.id for t in self.db.query(TraceDB).filter(TraceDB.workshop_id == workshop_id).all()]
+
+        if trace_ids:
+            # Delete annotations for these traces
+            self.db.query(AnnotationDB).filter(AnnotationDB.trace_id.in_(trace_ids)).delete(synchronize_session=False)
+            # Delete judge evaluations for these traces
+            self.db.query(JudgeEvaluationDB).filter(JudgeEvaluationDB.trace_id.in_(trace_ids)).delete(
+                synchronize_session=False
+            )
+
+        # Delete user trace orders for this workshop
+        self.db.query(UserTraceOrderDB).filter(UserTraceOrderDB.workshop_id == workshop_id).delete(
+            synchronize_session=False
+        )
+
+        # Delete discovery findings for this workshop
+        self.db.query(DiscoveryFindingDB).filter(DiscoveryFindingDB.workshop_id == workshop_id).delete(
+            synchronize_session=False
+        )
+
+        # Delete user discovery completions for this workshop
+        self.db.query(UserDiscoveryCompletionDB).filter(UserDiscoveryCompletionDB.workshop_id == workshop_id).delete(
+            synchronize_session=False
+        )
+
+        # Delete judge prompts for this workshop (after evaluations are deleted)
+        self.db.query(JudgePromptDB).filter(JudgePromptDB.workshop_id == workshop_id).delete(synchronize_session=False)
+
+        # Delete all traces
+        deleted_count = (
+            self.db.query(TraceDB).filter(TraceDB.workshop_id == workshop_id).delete(synchronize_session=False)
+        )
+
+        # Delete rubric for this workshop
+        self.db.query(RubricDB).filter(RubricDB.workshop_id == workshop_id).delete(synchronize_session=False)
+
+        # Reset MLflow intake status (trace_count and is_ingested)
+        mlflow_config = (
+            self.db.query(MLflowIntakeConfigDB).filter(MLflowIntakeConfigDB.workshop_id == workshop_id).first()
+        )
+        if mlflow_config:
+            mlflow_config.trace_count = 0
+            mlflow_config.is_ingested = False
+            mlflow_config.last_ingestion_time = None
+
+        # Reset workshop to intake phase
+        workshop = self.db.query(WorkshopDB).filter(WorkshopDB.id == workshop_id).first()
+        if workshop:
+            workshop.current_phase = WorkshopPhase.INTAKE
+            workshop.completed_phases = []
+            workshop.discovery_started = False
+            workshop.annotation_started = False
+            workshop.active_discovery_trace_ids = None
+            workshop.active_annotation_trace_ids = None
+
+        self.db.commit()
+        return deleted_count
+
+    def reset_workshop_to_discovery(self, workshop_id: str) -> Workshop | None:
+        """Reset a workshop back to the discovery start page (before discovery was started).
+
+        This allows changing the discovery configuration (e.g., number of traces).
+        The phase stays as DISCOVERY but discovery_started is set to False,
+        which causes the UI to show the Discovery Start Page.
+
+        IMPORTANT: This also clears all discovery-related data so participants start fresh:
+        - Discovery findings (participant responses)
+        - User trace orders (personalized trace lists)
+        - User discovery completions (who completed discovery)
+
+        Returns the updated workshop or None if not found.
+        """
+        workshop = self.db.query(WorkshopDB).filter(WorkshopDB.id == workshop_id).first()
+        if not workshop:
+            return None
+
+        # Clear all discovery-related data so participants start fresh
+        # 1. Clear discovery findings (participant responses)
+        self.db.query(DiscoveryFindingDB).filter(DiscoveryFindingDB.workshop_id == workshop_id).delete(
+            synchronize_session=False
+        )
+
+        # 2. Clear user trace orders (personalized trace lists)
+        self.db.query(UserTraceOrderDB).filter(UserTraceOrderDB.workshop_id == workshop_id).delete(
+            synchronize_session=False
+        )
+
+        # 3. Clear user discovery completions (who completed discovery)
+        self.db.query(UserDiscoveryCompletionDB).filter(UserDiscoveryCompletionDB.workshop_id == workshop_id).delete(
+            synchronize_session=False
+        )
+
+        # Keep phase as DISCOVERY but mark discovery as NOT started
+        # This causes the UI to show the Discovery Start Page
+        workshop.current_phase = WorkshopPhase.DISCOVERY
+        workshop.discovery_started = False
+
+        # Keep completed phases up to intake (discovery not yet complete)
+        completed = workshop.completed_phases or []
+        workshop.completed_phases = [p for p in completed if p in ["intake"]]
+
+        # Clear active discovery trace list so new selection can be made
+        workshop.active_discovery_trace_ids = None
+
+        self.db.commit()
+        self.db.refresh(workshop)
+
+        return Workshop(
+            id=workshop.id,
+            name=workshop.name,
+            description=workshop.description,
+            facilitator_id=workshop.facilitator_id,
+            status=workshop.status,
+            current_phase=workshop.current_phase,
+            completed_phases=workshop.completed_phases or [],
+            discovery_started=workshop.discovery_started or False,
+            annotation_started=workshop.annotation_started or False,
+            active_discovery_trace_ids=workshop.active_discovery_trace_ids or [],
+            active_annotation_trace_ids=workshop.active_annotation_trace_ids or [],
+            created_at=workshop.created_at,
+        )
+
+    def reset_workshop_to_annotation(self, workshop_id: str) -> Workshop | None:
+        """Reset a workshop back to the annotation start page (before annotation was started).
+
+        This allows changing the annotation configuration (e.g., trace selection, randomization).
+        The phase stays as ANNOTATION but annotation_started is set to False,
+        which causes the UI to show the Annotation Start Page.
+
+        IMPORTANT: This clears all annotation-related data so SMEs start fresh:
+        - All annotations submitted by SMEs
+
+        Traces are kept, but SMEs will start fresh from the beginning.
+
+        Returns the updated workshop or None if not found.
+        """
+        workshop = self.db.query(WorkshopDB).filter(WorkshopDB.id == workshop_id).first()
+        if not workshop:
+            return None
+
+        # Clear all annotation-related data so SMEs start fresh
+        # Clear annotations submitted by SMEs
+        self.db.query(AnnotationDB).filter(AnnotationDB.workshop_id == workshop_id).delete(synchronize_session=False)
+
+        # Keep phase as ANNOTATION but mark annotation as NOT started
+        # This causes the UI to show the Annotation Start Page
+        workshop.current_phase = WorkshopPhase.ANNOTATION
+        workshop.annotation_started = False
+
+        # Keep completed phases up to discovery (annotation not yet complete)
+        completed = workshop.completed_phases or []
+        workshop.completed_phases = [p for p in completed if p in ["intake", "discovery"]]
+
+        # Clear active annotation trace list so new selection can be made
+        workshop.active_annotation_trace_ids = None
+
+        self.db.commit()
+        self.db.refresh(workshop)
+
+        return Workshop(
+            id=workshop.id,
+            name=workshop.name,
+            description=workshop.description,
+            facilitator_id=workshop.facilitator_id,
+            status=workshop.status,
+            current_phase=workshop.current_phase,
+            completed_phases=workshop.completed_phases or [],
+            discovery_started=workshop.discovery_started or False,
+            annotation_started=workshop.annotation_started or False,
+            active_discovery_trace_ids=workshop.active_discovery_trace_ids or [],
+            active_annotation_trace_ids=workshop.active_annotation_trace_ids or [],
+            created_at=workshop.created_at,
+        )
+
+    # Custom LLM Provider operations
+    def get_custom_llm_provider_config(self, workshop_id: str):
+        """Get the custom LLM provider configuration for a workshop.
+
+        Returns the DB model directly (CustomLLMProviderConfigDB) for use in router,
+        or None if no configuration exists.
+        """
+        from server.database import CustomLLMProviderConfigDB
+
+        return (
+            self.db.query(CustomLLMProviderConfigDB)
+            .filter(CustomLLMProviderConfigDB.workshop_id == workshop_id)
+            .first()
+        )
+
+    def create_custom_llm_provider_config(self, workshop_id: str, config_data):
+        """Create or update custom LLM provider configuration for a workshop.
+
+        Args:
+          workshop_id: The workshop ID
+          config_data: CustomLLMProviderConfigCreate with provider details
+
+        Returns:
+          The created or updated CustomLLMProviderConfigDB record
+        """
+        from server.database import CustomLLMProviderConfigDB
+
+        # Check if config already exists
+        existing_config = (
+            self.db.query(CustomLLMProviderConfigDB)
+            .filter(CustomLLMProviderConfigDB.workshop_id == workshop_id)
+            .first()
+        )
+
+        if existing_config:
+            # Update existing config
+            existing_config.provider_name = config_data.provider_name
+            existing_config.base_url = config_data.base_url
+            existing_config.model_name = config_data.model_name
+            existing_config.is_enabled = True
+            self.db.commit()
+            self.db.refresh(existing_config)
+            return existing_config
+        # Create new config
+        new_config = CustomLLMProviderConfigDB(
+            id=str(uuid.uuid4()),
+            workshop_id=workshop_id,
+            provider_name=config_data.provider_name,
+            base_url=config_data.base_url,
+            model_name=config_data.model_name,
+            is_enabled=True,
+        )
+        self.db.add(new_config)
+        self.db.commit()
+        self.db.refresh(new_config)
+        return new_config
+
+    def delete_custom_llm_provider_config(self, workshop_id: str) -> bool:
+        """Delete custom LLM provider configuration for a workshop.
+
+        Args:
+          workshop_id: The workshop ID
+
+        Returns:
+          True if a config was deleted, False if none existed
+        """
+        from server.database import CustomLLMProviderConfigDB
+
+        deleted_count = (
+            self.db.query(CustomLLMProviderConfigDB)
+            .filter(CustomLLMProviderConfigDB.workshop_id == workshop_id)
+            .delete(synchronize_session=False)
+        )
+        self.db.commit()
+        return deleted_count > 0
+
+    def update_custom_llm_provider_enabled(self, workshop_id: str, is_enabled: bool):
+        """Update the enabled status of the custom LLM provider.
+
+        Args:
+          workshop_id: The workshop ID
+          is_enabled: Whether the custom provider should be enabled
+
+        Returns:
+          The updated config or None if not found
+        """
+        from server.database import CustomLLMProviderConfigDB
+
+        config = (
+            self.db.query(CustomLLMProviderConfigDB)
+            .filter(CustomLLMProviderConfigDB.workshop_id == workshop_id)
+            .first()
+        )
+
+        if config:
+            config.is_enabled = is_enabled
+            self.db.commit()
+            self.db.refresh(config)
+
+        return config

--- a/server/services/databricks_service.py
+++ b/server/services/databricks_service.py
@@ -6,7 +6,7 @@ This service handles calls to Databricks model serving endpoints using the OpenA
 import hashlib
 import logging
 import os
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 import requests
 from fastapi import HTTPException
@@ -20,411 +20,413 @@ _client_cache = {}
 
 
 def _get_token_hash(token: str) -> str:
-  """Get a hash of the token for cache key (don't store actual token in cache key)."""
-  return hashlib.sha256(token.encode()).hexdigest()[:16]
+    """Get a hash of the token for cache key (don't store actual token in cache key)."""
+    return hashlib.sha256(token.encode()).hexdigest()[:16]
 
 
 class DatabricksService:
-  """Service for interacting with Databricks model serving endpoints."""
+    """Service for interacting with Databricks model serving endpoints."""
 
-  def __init__(
-    self,
-    workspace_url: Optional[str] = None,
-    token: Optional[str] = None,
-    workshop_id: Optional[str] = None,
-    db_service=None,
-    init_sdk: bool = True,
-  ):
-    """Initialize the Databricks service.
+    def __init__(
+        self,
+        workspace_url: str | None = None,
+        token: str | None = None,
+        workshop_id: str | None = None,
+        db_service=None,
+        init_sdk: bool = True,
+    ):
+        """Initialize the Databricks service.
 
-    Args:
-        workspace_url: Databricks workspace URL (e.g., https://adb-1234567890123456.7.azuredatabricks.net)
-        token: Databricks API token
-        workshop_id: Workshop ID to get MLflow config from database
-        db_service: Database service instance to fetch MLflow config
-        init_sdk: Whether to initialize the Databricks SDK (set False for direct HTTP calls only)
-    """
-    # If workshop_id and db_service are provided, try to get token from memory storage
-    if workshop_id and db_service:
-      try:
-        from server.services.token_storage_service import token_storage
+        Args:
+            workspace_url: Databricks workspace URL (e.g., https://adb-1234567890123456.7.azuredatabricks.net)
+            token: Databricks API token
+            workshop_id: Workshop ID to get MLflow config from database
+            db_service: Database service instance to fetch MLflow config
+            init_sdk: Whether to initialize the Databricks SDK (set False for direct HTTP calls only)
+        """
+        # If workshop_id and db_service are provided, try to get token from memory storage
+        if workshop_id and db_service:
+            try:
+                from server.services.token_storage_service import token_storage
 
-        databricks_token = token_storage.get_token(workshop_id)
-        if not databricks_token and db_service:
-          databricks_token = db_service.get_databricks_token(workshop_id)
-          if databricks_token:
-            token_storage.store_token(workshop_id, databricks_token)
-        if databricks_token:
-          mlflow_config = db_service.get_mlflow_config(workshop_id)
-          if mlflow_config:
-            self.workspace_url = workspace_url or mlflow_config.databricks_host
-            self.token = token or databricks_token
-            print(f'Using token from memory storage for workshop {workshop_id}')
-          else:
-            # Fallback to provided parameters or environment variables
-            self.workspace_url = workspace_url or os.getenv('DATABRICKS_HOST')
-            self.token = token or databricks_token
+                databricks_token = token_storage.get_token(workshop_id)
+                if not databricks_token and db_service:
+                    databricks_token = db_service.get_databricks_token(workshop_id)
+                    if databricks_token:
+                        token_storage.store_token(workshop_id, databricks_token)
+                if databricks_token:
+                    mlflow_config = db_service.get_mlflow_config(workshop_id)
+                    if mlflow_config:
+                        self.workspace_url = workspace_url or mlflow_config.databricks_host
+                        self.token = token or databricks_token
+                        print(f"Using token from memory storage for workshop {workshop_id}")
+                    else:
+                        # Fallback to provided parameters or environment variables
+                        self.workspace_url = workspace_url or os.getenv("DATABRICKS_HOST")
+                        self.token = token or databricks_token
+                else:
+                    # Fallback to provided parameters or environment variables
+                    self.workspace_url = workspace_url or os.getenv("DATABRICKS_HOST")
+                    self.token = token or os.getenv("DATABRICKS_TOKEN")
+            except Exception as e:
+                print(f"Failed to get token from memory storage for workshop {workshop_id}: {e}")
+                # Fallback to provided parameters or environment variables
+                self.workspace_url = workspace_url or os.getenv("DATABRICKS_HOST")
+                self.token = token or os.getenv("DATABRICKS_TOKEN")
         else:
-          # Fallback to provided parameters or environment variables
-          self.workspace_url = workspace_url or os.getenv('DATABRICKS_HOST')
-          self.token = token or os.getenv('DATABRICKS_TOKEN')
-      except Exception as e:
-        print(f'Failed to get token from memory storage for workshop {workshop_id}: {e}')
-        # Fallback to provided parameters or environment variables
-        self.workspace_url = workspace_url or os.getenv('DATABRICKS_HOST')
-        self.token = token or os.getenv('DATABRICKS_TOKEN')
-    else:
-      # Use provided parameters or environment variables
-      self.workspace_url = workspace_url or os.getenv('DATABRICKS_HOST')
-      self.token = token or os.getenv('DATABRICKS_TOKEN')
+            # Use provided parameters or environment variables
+            self.workspace_url = workspace_url or os.getenv("DATABRICKS_HOST")
+            self.token = token or os.getenv("DATABRICKS_TOKEN")
 
-    if not self.workspace_url or not self.token:
-      raise ValueError('Databricks workspace URL and token are required')
+        if not self.workspace_url or not self.token:
+            raise ValueError("Databricks workspace URL and token are required")
 
-    # Initialize the OpenAI client for calling serving endpoints
-    # Use cached client if available to avoid reinitializing for every request
-    try:
-      cache_key = (self.workspace_url, _get_token_hash(self.token))
-      
-      if cache_key in _client_cache:
-        self.client = _client_cache[cache_key]
-        logger.info(f'✅ Reusing cached OpenAI client for Databricks workspace: {self.workspace_url}')
-      else:
-        print(f'Initializing OpenAI client for Databricks workspace: {self.workspace_url}')
-        
-        # Create OpenAI client configured for Databricks serving endpoints
-        self.client = OpenAI(api_key=self.token, base_url=f'{self.workspace_url}/serving-endpoints')
-        
-        # Cache the client for future requests
-        _client_cache[cache_key] = self.client
-        
-        logger.info(f'Successfully initialized and cached OpenAI client for Databricks workspace: {self.workspace_url}')
-    except Exception as e:
-      logger.error(f'Failed to initialize OpenAI client: {e}')
-      raise HTTPException(status_code=500, detail=f'Failed to initialize OpenAI client: {str(e)}')
+        # Initialize the OpenAI client for calling serving endpoints
+        # Use cached client if available to avoid reinitializing for every request
+        try:
+            cache_key = (self.workspace_url, _get_token_hash(self.token))
 
-  def call_serving_endpoint(
-    self,
-    endpoint_name: str,
-    prompt: str,
-    temperature: float = 0.5,
-    max_tokens: Optional[int] = None,
-    model_parameters: Optional[Dict[str, Any]] = None,
-  ) -> Dict[str, Any]:
-    """Call a Databricks serving endpoint using chat completion format.
+            if cache_key in _client_cache:
+                self.client = _client_cache[cache_key]
+                logger.info(f"✅ Reusing cached OpenAI client for Databricks workspace: {self.workspace_url}")
+            else:
+                print(f"Initializing OpenAI client for Databricks workspace: {self.workspace_url}")
 
-    Args:
-        endpoint_name: Name of the serving endpoint
-        prompt: The prompt to send to the model
-        temperature: Temperature for generation (0.0 to 1.0)
-        max_tokens: Maximum number of tokens to generate
-        model_parameters: Additional model parameters
+                # Create OpenAI client configured for Databricks serving endpoints
+                self.client = OpenAI(api_key=self.token, base_url=f"{self.workspace_url}/serving-endpoints")
 
-    Returns:
-        Dictionary containing the response from the model
-    """
-    try:
-      # Prepare messages in OpenAI format
-      messages = [
-        {'role': 'system', 'content': 'You are a helpful assistant.'},
-        {'role': 'user', 'content': prompt},
-      ]
+                # Cache the client for future requests
+                _client_cache[cache_key] = self.client
 
-      # Prepare the request parameters
-      request_params = {'messages': messages, 'model': endpoint_name, 'temperature': temperature}
+                logger.info(
+                    f"Successfully initialized and cached OpenAI client for Databricks workspace: {self.workspace_url}"
+                )
+        except Exception as e:
+            logger.error(f"Failed to initialize OpenAI client: {e}")
+            raise HTTPException(status_code=500, detail=f"Failed to initialize OpenAI client: {e!s}") from e
 
-      # Add optional parameters
-      if max_tokens:
-        request_params['max_tokens'] = max_tokens
+    def call_serving_endpoint(
+        self,
+        endpoint_name: str,
+        prompt: str,
+        temperature: float = 0.5,
+        max_tokens: int | None = None,
+        model_parameters: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Call a Databricks serving endpoint using chat completion format.
 
-      if model_parameters:
-        request_params.update(model_parameters)
+        Args:
+            endpoint_name: Name of the serving endpoint
+            prompt: The prompt to send to the model
+            temperature: Temperature for generation (0.0 to 1.0)
+            max_tokens: Maximum number of tokens to generate
+            model_parameters: Additional model parameters
 
-      logger.info(f'Calling Databricks serving endpoint: {endpoint_name}')
-      logger.debug(f'Request parameters: {request_params}')
+        Returns:
+            Dictionary containing the response from the model
+        """
+        try:
+            # Prepare messages in OpenAI format
+            messages = [
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": prompt},
+            ]
 
-      # Make the API call using OpenAI client
-      response = self.client.chat.completions.create(**request_params)
+            # Prepare the request parameters
+            request_params = {"messages": messages, "model": endpoint_name, "temperature": temperature}
 
-      # Convert response to dictionary format
-      result = {
-        'choices': [
-          {
-            'message': {
-              'content': response.choices[0].message.content,
-              'role': response.choices[0].message.role,
-            },
-            'index': response.choices[0].index,
-            'finish_reason': response.choices[0].finish_reason,
-          }
-        ],
-        'model': response.model,
-        'usage': {
-          'prompt_tokens': response.usage.prompt_tokens,
-          'completion_tokens': response.usage.completion_tokens,
-          'total_tokens': response.usage.total_tokens,
-        },
-      }
+            # Add optional parameters
+            if max_tokens:
+                request_params["max_tokens"] = max_tokens
 
-      logger.info(f'Successfully called serving endpoint: {endpoint_name}')
-      logger.debug(f'Response: {result}')
+            if model_parameters:
+                request_params.update(model_parameters)
 
-      return result
+            logger.info(f"Calling Databricks serving endpoint: {endpoint_name}")
+            logger.debug(f"Request parameters: {request_params}")
 
-    except Exception as e:
-      logger.error(f'Error calling serving endpoint {endpoint_name}: {e}')
-      logger.error(f'Error type: {type(e)}')
-      logger.error('Full traceback:', exc_info=True)
-      raise HTTPException(status_code=500, detail=f'Error calling serving endpoint: {str(e)}')
+            # Make the API call using OpenAI client
+            response = self.client.chat.completions.create(**request_params)
 
-  def list_serving_endpoints(self) -> List[Dict[str, Any]]:
-    """List all available serving endpoints.
-    Note: This method returns a placeholder since OpenAI client doesn't provide endpoint listing.
-    You may need to implement this using direct HTTP calls to Databricks API.
+            # Convert response to dictionary format
+            result = {
+                "choices": [
+                    {
+                        "message": {
+                            "content": response.choices[0].message.content,
+                            "role": response.choices[0].message.role,
+                        },
+                        "index": response.choices[0].index,
+                        "finish_reason": response.choices[0].finish_reason,
+                    }
+                ],
+                "model": response.model,
+                "usage": {
+                    "prompt_tokens": response.usage.prompt_tokens,
+                    "completion_tokens": response.usage.completion_tokens,
+                    "total_tokens": response.usage.total_tokens,
+                },
+            }
 
-    Returns:
-        List of serving endpoint information
-    """
-    try:
-      logger.info('Listing Databricks serving endpoints')
+            logger.info(f"Successfully called serving endpoint: {endpoint_name}")
+            logger.debug(f"Response: {result}")
 
-      # Since OpenAI client doesn't provide endpoint listing, return a placeholder
-      # In a real implementation, you might want to make direct HTTP calls to Databricks API
-      endpoint_list = [
-        {
-          'name': 'databricks-claude-sonnet-4-5',
-          'id': 'placeholder-id',
-          'state': 'active',
-          'config': {'model_name': 'claude-4-5-sonnet'},
-        }
-      ]
+            return result
 
-      logger.info(f'Found {len(endpoint_list)} serving endpoints (placeholder)')
-      return endpoint_list
+        except Exception as e:
+            logger.error(f"Error calling serving endpoint {endpoint_name}: {e}")
+            logger.error(f"Error type: {type(e)}")
+            logger.error("Full traceback:", exc_info=True)
+            raise HTTPException(status_code=500, detail=f"Error calling serving endpoint: {e!s}") from e
 
-    except Exception as e:
-      logger.error(f'Error listing endpoints: {e}')
-      raise HTTPException(status_code=500, detail=f'Error listing endpoints: {str(e)}')
+    def list_serving_endpoints(self) -> list[dict[str, Any]]:
+        """List all available serving endpoints.
+        Note: This method returns a placeholder since OpenAI client doesn't provide endpoint listing.
+        You may need to implement this using direct HTTP calls to Databricks API.
 
-  def get_endpoint_info(self, endpoint_name: str) -> Dict[str, Any]:
-    """Get information about a specific serving endpoint.
-    Note: This method returns placeholder info since OpenAI client doesn't provide endpoint details.
-    You may need to implement this using direct HTTP calls to Databricks API.
+        Returns:
+            List of serving endpoint information
+        """
+        try:
+            logger.info("Listing Databricks serving endpoints")
 
-    Args:
-        endpoint_name: Name of the serving endpoint
+            # Since OpenAI client doesn't provide endpoint listing, return a placeholder
+            # In a real implementation, you might want to make direct HTTP calls to Databricks API
+            endpoint_list = [
+                {
+                    "name": "databricks-claude-sonnet-4-5",
+                    "id": "placeholder-id",
+                    "state": "active",
+                    "config": {"model_name": "claude-4-5-sonnet"},
+                }
+            ]
 
-    Returns:
-        Dictionary containing endpoint information
-    """
-    try:
-      logger.info(f'Getting information for serving endpoint: {endpoint_name}')
+            logger.info(f"Found {len(endpoint_list)} serving endpoints (placeholder)")
+            return endpoint_list
 
-      # Since OpenAI client doesn't provide endpoint details, return placeholder info
-      endpoint_info = {
-        'name': endpoint_name,
-        'id': 'placeholder-id',
-        'state': 'active',
-        'config': {'model_name': endpoint_name},
-        'creator': 'placeholder',
-        'created_at': '2024-01-01T00:00:00Z',
-        'updated_at': '2024-01-01T00:00:00Z',
-      }
+        except Exception as e:
+            logger.error(f"Error listing endpoints: {e}")
+            raise HTTPException(status_code=500, detail=f"Error listing endpoints: {e!s}") from e
 
-      logger.info(f'Successfully retrieved endpoint info for: {endpoint_name} (placeholder)')
-      return endpoint_info
+    def get_endpoint_info(self, endpoint_name: str) -> dict[str, Any]:
+        """Get information about a specific serving endpoint.
+        Note: This method returns placeholder info since OpenAI client doesn't provide endpoint details.
+        You may need to implement this using direct HTTP calls to Databricks API.
 
-    except Exception as e:
-      logger.error(f'Error getting endpoint info for {endpoint_name}: {e}')
-      raise HTTPException(status_code=500, detail=f'Error getting endpoint info: {str(e)}')
+        Args:
+            endpoint_name: Name of the serving endpoint
 
-  def test_connection(self) -> Dict[str, Any]:
-    """Test the connection to Databricks workspace.
+        Returns:
+            Dictionary containing endpoint information
+        """
+        try:
+            logger.info(f"Getting information for serving endpoint: {endpoint_name}")
 
-    Returns:
-        Dictionary containing connection status
-    """
-    try:
-      logger.info('Testing Databricks connection')
+            # Since OpenAI client doesn't provide endpoint details, return placeholder info
+            endpoint_info = {
+                "name": endpoint_name,
+                "id": "placeholder-id",
+                "state": "active",
+                "config": {"model_name": endpoint_name},
+                "creator": "placeholder",
+                "created_at": "2024-01-01T00:00:00Z",
+                "updated_at": "2024-01-01T00:00:00Z",
+            }
 
-      return {
-        'status': 'connected',
-        'workspace_url': self.workspace_url,
-        'endpoints_count': 1,  # Placeholder
-        'message': 'Successfully connected to Databricks workspace',
-      }
+            logger.info(f"Successfully retrieved endpoint info for: {endpoint_name} (placeholder)")
+            return endpoint_info
 
-    except Exception as e:
-      logger.error(f'Connection test failed: {e}')
-      return {
-        'status': 'failed',
-        'workspace_url': self.workspace_url,
-        'error': str(e),
-        'message': 'Failed to connect to Databricks workspace',
-      }
+        except Exception as e:
+            logger.error(f"Error getting endpoint info for {endpoint_name}: {e}")
+            raise HTTPException(status_code=500, detail=f"Error getting endpoint info: {e!s}") from e
 
-  def call_chat_completion(
-    self,
-    endpoint_name: str,
-    messages: List[Dict[str, str]],
-    temperature: float = 0.5,
-    max_tokens: Optional[int] = None,
-    model_parameters: Optional[Dict[str, Any]] = None,
-  ) -> Dict[str, Any]:
-    """Call a Databricks serving endpoint using chat completion format with OpenAI client.
+    def test_connection(self) -> dict[str, Any]:
+        """Test the connection to Databricks workspace.
 
-    Args:
-        endpoint_name: Name of the serving endpoint
-        messages: List of message dictionaries with 'role' and 'content'
-        temperature: Temperature for generation (0.0 to 1.0)
-        max_tokens: Maximum number of tokens to generate
-        model_parameters: Additional model parameters
+        Returns:
+            Dictionary containing connection status
+        """
+        try:
+            logger.info("Testing Databricks connection")
 
-    Returns:
-        Dictionary containing the response from the model
-    """
-    try:
-      # Prepare the request parameters
-      request_params = {'messages': messages, 'model': endpoint_name, 'temperature': temperature}
+            return {
+                "status": "connected",
+                "workspace_url": self.workspace_url,
+                "endpoints_count": 1,  # Placeholder
+                "message": "Successfully connected to Databricks workspace",
+            }
 
-      # Add optional parameters
-      if max_tokens:
-        request_params['max_tokens'] = max_tokens
+        except Exception as e:
+            logger.error(f"Connection test failed: {e}")
+            return {
+                "status": "failed",
+                "workspace_url": self.workspace_url,
+                "error": str(e),
+                "message": "Failed to connect to Databricks workspace",
+            }
 
-      if model_parameters:
-        request_params.update(model_parameters)
+    def call_chat_completion(
+        self,
+        endpoint_name: str,
+        messages: list[dict[str, str]],
+        temperature: float = 0.5,
+        max_tokens: int | None = None,
+        model_parameters: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Call a Databricks serving endpoint using chat completion format with OpenAI client.
 
-      logger.info(f'Calling Databricks serving endpoint with chat completion: {endpoint_name}')
-      logger.debug(f'Request parameters: {request_params}')
+        Args:
+            endpoint_name: Name of the serving endpoint
+            messages: List of message dictionaries with 'role' and 'content'
+            temperature: Temperature for generation (0.0 to 1.0)
+            max_tokens: Maximum number of tokens to generate
+            model_parameters: Additional model parameters
 
-      # Make the API call using OpenAI client
-      response = self.client.chat.completions.create(**request_params)
+        Returns:
+            Dictionary containing the response from the model
+        """
+        try:
+            # Prepare the request parameters
+            request_params = {"messages": messages, "model": endpoint_name, "temperature": temperature}
 
-      # Convert response to dictionary format
-      result = {
-        'choices': [
-          {
-            'message': {
-              'content': response.choices[0].message.content,
-              'role': response.choices[0].message.role,
-            },
-            'index': response.choices[0].index,
-            'finish_reason': response.choices[0].finish_reason,
-          }
-        ],
-        'model': response.model,
-        'usage': {
-          'prompt_tokens': response.usage.prompt_tokens,
-          'completion_tokens': response.usage.completion_tokens,
-          'total_tokens': response.usage.total_tokens,
-        },
-      }
+            # Add optional parameters
+            if max_tokens:
+                request_params["max_tokens"] = max_tokens
 
-      logger.info(f'Successfully called serving endpoint: {endpoint_name}')
-      logger.debug(f'Response: {result}')
+            if model_parameters:
+                request_params.update(model_parameters)
 
-      return result
+            logger.info(f"Calling Databricks serving endpoint with chat completion: {endpoint_name}")
+            logger.debug(f"Request parameters: {request_params}")
 
-    except Exception as e:
-      logger.error(f'Error calling serving endpoint {endpoint_name}: {e}')
-      logger.error(f'Error type: {type(e)}')
-      logger.error('Full traceback:', exc_info=True)
-      raise HTTPException(status_code=500, detail=f'Error calling serving endpoint: {str(e)}')
+            # Make the API call using OpenAI client
+            response = self.client.chat.completions.create(**request_params)
 
-  def call_serving_endpoint_direct(
-    self,
-    endpoint_name: str,
-    prompt: str,
-    temperature: float = 0.5,
-    max_tokens: Optional[int] = None,
-  ) -> Dict[str, Any]:
-    """Call a Databricks serving endpoint directly via HTTP API.
-    This bypasses the Databricks SDK to avoid authentication issues.
+            # Convert response to dictionary format
+            result = {
+                "choices": [
+                    {
+                        "message": {
+                            "content": response.choices[0].message.content,
+                            "role": response.choices[0].message.role,
+                        },
+                        "index": response.choices[0].index,
+                        "finish_reason": response.choices[0].finish_reason,
+                    }
+                ],
+                "model": response.model,
+                "usage": {
+                    "prompt_tokens": response.usage.prompt_tokens,
+                    "completion_tokens": response.usage.completion_tokens,
+                    "total_tokens": response.usage.total_tokens,
+                },
+            }
 
-    Args:
-        endpoint_name: Name of the serving endpoint
-        prompt: The prompt to send to the model
-        temperature: Temperature for generation (0.0 to 1.0)
-        max_tokens: Maximum number of tokens to generate
+            logger.info(f"Successfully called serving endpoint: {endpoint_name}")
+            logger.debug(f"Response: {result}")
 
-    Returns:
-        Dictionary containing the response from the model
-    """
-    try:
-      # Prepare the API URL
-      api_url = f'{self.workspace_url.rstrip("/")}/serving-endpoints/{endpoint_name}/invocations'
+            return result
 
-      # Prepare headers with PAT token authentication
-      headers = {'Authorization': f'Bearer {self.token}', 'Content-Type': 'application/json'}
+        except Exception as e:
+            logger.error(f"Error calling serving endpoint {endpoint_name}: {e}")
+            logger.error(f"Error type: {type(e)}")
+            logger.error("Full traceback:", exc_info=True)
+            raise HTTPException(status_code=500, detail=f"Error calling serving endpoint: {e!s}") from e
 
-      # Prepare the request payload in chat completion format
-      payload = {
-        'messages': [
-          {'role': 'system', 'content': 'You are a helpful assistant.'},
-          {'role': 'user', 'content': prompt},
-        ],
-        'temperature': temperature,
-      }
+    def call_serving_endpoint_direct(
+        self,
+        endpoint_name: str,
+        prompt: str,
+        temperature: float = 0.5,
+        max_tokens: int | None = None,
+    ) -> dict[str, Any]:
+        """Call a Databricks serving endpoint directly via HTTP API.
+        This bypasses the Databricks SDK to avoid authentication issues.
 
-      # Add max_tokens if specified
-      if max_tokens:
-        payload['max_tokens'] = max_tokens
+        Args:
+            endpoint_name: Name of the serving endpoint
+            prompt: The prompt to send to the model
+            temperature: Temperature for generation (0.0 to 1.0)
+            max_tokens: Maximum number of tokens to generate
 
-      logger.info(f'Calling Databricks serving endpoint directly: {endpoint_name}')
-      logger.debug(f'Request URL: {api_url}')
-      logger.debug(f'Request payload: {payload}')
-      # Log token prefix for debugging (never log full token)
-      token_prefix = self.token[:10] if self.token else 'None'
-      print(f'Using token starting with: {token_prefix}...')
+        Returns:
+            Dictionary containing the response from the model
+        """
+        try:
+            # Prepare the API URL
+            api_url = f"{self.workspace_url.rstrip('/')}/serving-endpoints/{endpoint_name}/invocations"
 
-      # Make the HTTP request
-      response = requests.post(api_url, headers=headers, json=payload, timeout=60)
+            # Prepare headers with PAT token authentication
+            headers = {"Authorization": f"Bearer {self.token}", "Content-Type": "application/json"}
 
-      # Add detailed error logging for 403 errors
-      if response.status_code == 403:
-        print('403 Forbidden error details:')
-        print(f'  - Endpoint: {endpoint_name}')
-        print(f'  - URL: {api_url}')
-        print(f'  - Token prefix: {token_prefix}...')
-        print(f'  - Response text: {response.text}')
+            # Prepare the request payload in chat completion format
+            payload = {
+                "messages": [
+                    {"role": "system", "content": "You are a helpful assistant."},
+                    {"role": "user", "content": prompt},
+                ],
+                "temperature": temperature,
+            }
 
-      # Check if request was successful
-      response.raise_for_status()
+            # Add max_tokens if specified
+            if max_tokens:
+                payload["max_tokens"] = max_tokens
 
-      # Parse the response
-      result = response.json()
+            logger.info(f"Calling Databricks serving endpoint directly: {endpoint_name}")
+            logger.debug(f"Request URL: {api_url}")
+            logger.debug(f"Request payload: {payload}")
+            # Log token prefix for debugging (never log full token)
+            token_prefix = self.token[:10] if self.token else "None"
+            print(f"Using token starting with: {token_prefix}...")
 
-      logger.info(f'Successfully called serving endpoint: {endpoint_name}')
-      logger.debug(f'Response: {result}')
+            # Make the HTTP request
+            response = requests.post(api_url, headers=headers, json=payload, timeout=60)
 
-      return result
+            # Add detailed error logging for 403 errors
+            if response.status_code == 403:
+                print("403 Forbidden error details:")
+                print(f"  - Endpoint: {endpoint_name}")
+                print(f"  - URL: {api_url}")
+                print(f"  - Token prefix: {token_prefix}...")
+                print(f"  - Response text: {response.text}")
 
-    except requests.exceptions.RequestException as e:
-      logger.error(f'HTTP request error calling endpoint {endpoint_name}: {e}')
-      raise HTTPException(status_code=500, detail=f'HTTP request error: {str(e)}')
-    except Exception as e:
-      logger.error(f'Unexpected error calling serving endpoint {endpoint_name}: {e}')
-      logger.error(f'Error type: {type(e)}')
-      logger.error('Full traceback:', exc_info=True)
-      raise HTTPException(status_code=500, detail=f'Unexpected error: {str(e)}')
+            # Check if request was successful
+            response.raise_for_status()
+
+            # Parse the response
+            result = response.json()
+
+            logger.info(f"Successfully called serving endpoint: {endpoint_name}")
+            logger.debug(f"Response: {result}")
+
+            return result
+
+        except requests.exceptions.RequestException as e:
+            logger.error(f"HTTP request error calling endpoint {endpoint_name}: {e}")
+            raise HTTPException(status_code=500, detail=f"HTTP request error: {e!s}") from e
+        except Exception as e:
+            logger.error(f"Unexpected error calling serving endpoint {endpoint_name}: {e}")
+            logger.error(f"Error type: {type(e)}")
+            logger.error("Full traceback:", exc_info=True)
+            raise HTTPException(status_code=500, detail=f"Unexpected error: {e!s}") from e
 
 
 # Factory function to create Databricks service instance
 def create_databricks_service(
-  workspace_url: Optional[str] = None,
-  token: Optional[str] = None,
-  workshop_id: Optional[str] = None,
-  db_service=None,
+    workspace_url: str | None = None,
+    token: str | None = None,
+    workshop_id: str | None = None,
+    db_service=None,
 ) -> DatabricksService:
-  """Create a Databricks service instance.
+    """Create a Databricks service instance.
 
-  Args:
-      workspace_url: Databricks workspace URL
-      token: Databricks API token
-      workshop_id: Workshop ID to get MLflow config from database
-      db_service: Database service instance to fetch MLflow config
+    Args:
+        workspace_url: Databricks workspace URL
+        token: Databricks API token
+        workshop_id: Workshop ID to get MLflow config from database
+        db_service: Database service instance to fetch MLflow config
 
-  Returns:
-      DatabricksService instance
-  """
-  return DatabricksService(workspace_url=workspace_url, token=token, workshop_id=workshop_id, db_service=db_service)
+    Returns:
+        DatabricksService instance
+    """
+    return DatabricksService(workspace_url=workspace_url, token=token, workshop_id=workshop_id, db_service=db_service)

--- a/server/services/dbsql_export_service.py
+++ b/server/services/dbsql_export_service.py
@@ -5,7 +5,7 @@ This service exports all workshop data from SQLite to Databricks DBSQL tables.
 
 import logging
 import sqlite3
-from typing import Any, Dict
+from typing import Any
 
 import databricks.sql as sql
 import pandas as pd
@@ -14,221 +14,221 @@ logger = logging.getLogger(__name__)
 
 
 class DBSQLExportService:
-  """Service for exporting SQLite data to Databricks DBSQL tables."""
+    """Service for exporting SQLite data to Databricks DBSQL tables."""
 
-  def __init__(
-    self,
-    databricks_host: str,
-    databricks_token: str,
-    http_path: str,
-    catalog: str,
-    schema_name: str,
-  ):
-    """Initialize DBSQL export service.
+    def __init__(
+        self,
+        databricks_host: str,
+        databricks_token: str,
+        http_path: str,
+        catalog: str,
+        schema_name: str,
+    ):
+        """Initialize DBSQL export service.
 
-    Args:
-        databricks_host: Databricks workspace URL
-        databricks_token: Databricks access token
-        http_path: DBSQL warehouse HTTP path
-        catalog: Unity Catalog catalog name
-        schema_name: Unity Catalog schema name
-    """
-    self.databricks_host = databricks_host
-    self.databricks_token = databricks_token
-    self.http_path = http_path
-    self.catalog = catalog
-    self.schema_name = schema_name
+        Args:
+            databricks_host: Databricks workspace URL
+            databricks_token: Databricks access token
+            http_path: DBSQL warehouse HTTP path
+            catalog: Unity Catalog catalog name
+            schema_name: Unity Catalog schema name
+        """
+        self.databricks_host = databricks_host
+        self.databricks_token = databricks_token
+        self.http_path = http_path
+        self.catalog = catalog
+        self.schema_name = schema_name
 
-    # Configure authentication
-    import os
+        # Configure authentication
+        import os
 
-    os.environ['DATABRICKS_HOST'] = databricks_host
-    os.environ['DATABRICKS_TOKEN'] = databricks_token
+        os.environ["DATABRICKS_HOST"] = databricks_host
+        os.environ["DATABRICKS_TOKEN"] = databricks_token
 
-    logger.info(f'DBSQL Export Service initialized for {catalog}.{schema_name}')
+        logger.info(f"DBSQL Export Service initialized for {catalog}.{schema_name}")
 
-  def get_connection(self):
-    """Get DBSQL connection."""
-    return sql.connect(
-      server_hostname=self.databricks_host,
-      http_path=self.http_path,
-      access_token=self.databricks_token,
-    )
+    def get_connection(self):
+        """Get DBSQL connection."""
+        return sql.connect(
+            server_hostname=self.databricks_host,
+            http_path=self.http_path,
+            access_token=self.databricks_token,
+        )
 
-  def read_table(self, table_name: str, conn) -> pd.DataFrame:
-    """Read data from DBSQL table."""
-    with conn.cursor() as cursor:
-      cursor.execute(f'SELECT * FROM {table_name}')
-      return cursor.fetchall_arrow().to_pandas()
+    def read_table(self, table_name: str, conn) -> pd.DataFrame:
+        """Read data from DBSQL table."""
+        with conn.cursor() as cursor:
+            cursor.execute(f"SELECT * FROM {table_name}")
+            return cursor.fetchall_arrow().to_pandas()
 
-  def insert_overwrite_table(self, table_name: str, df: pd.DataFrame, conn):
-    """Insert or overwrite data in DBSQL table."""
-    if df.empty:
-      logger.warning(f'No data to insert for table {table_name}')
-      return
+    def insert_overwrite_table(self, table_name: str, df: pd.DataFrame, conn):
+        """Insert or overwrite data in DBSQL table."""
+        if df.empty:
+            logger.warning(f"No data to insert for table {table_name}")
+            return
 
-    with conn.cursor() as cursor:
-      # Convert DataFrame to list of tuples
-      rows = [tuple(row) for row in df.values]
+        with conn.cursor() as cursor:
+            # Convert DataFrame to list of tuples
+            rows = [tuple(row) for row in df.values]
 
-      # Create placeholders for the INSERT statement
-      placeholders = ','.join(['?' for _ in df.columns])
-      columns = ','.join(df.columns)
+            # Create placeholders for the INSERT statement
+            placeholders = ",".join(["?" for _ in df.columns])
+            columns = ",".join(df.columns)
 
-      # Clear existing data
-      cursor.execute(f'DELETE FROM {table_name}')
+            # Clear existing data
+            cursor.execute(f"DELETE FROM {table_name}")
 
-      # Insert new data
-      cursor.executemany(f'INSERT INTO {table_name} ({columns}) VALUES ({placeholders})', rows)
+            # Insert new data
+            cursor.executemany(f"INSERT INTO {table_name} ({columns}) VALUES ({placeholders})", rows)
 
-      logger.info(f'Inserted {len(rows)} rows into {table_name}')
+            logger.info(f"Inserted {len(rows)} rows into {table_name}")
 
-  def create_table_if_not_exists(self, table_name: str, df: pd.DataFrame, conn):
-    """Create DBSQL table, dropping existing table if it exists to ensure schema is up to date."""
-    if df.empty:
-      logger.info(f'Skipping table {table_name} - no data to export')
-      return True  # Return True to indicate success (no action needed)
+    def create_table_if_not_exists(self, table_name: str, df: pd.DataFrame, conn):
+        """Create DBSQL table, dropping existing table if it exists to ensure schema is up to date."""
+        if df.empty:
+            logger.info(f"Skipping table {table_name} - no data to export")
+            return True  # Return True to indicate success (no action needed)
 
-    # Generate CREATE TABLE statement
-    columns = []
-    for col_name, dtype in df.dtypes.items():
-      # Map pandas dtypes to SQL types
-      if dtype == 'object':
-        sql_type = 'STRING'
-      elif dtype == 'int64':
-        sql_type = 'BIGINT'
-      elif dtype == 'float64':
-        sql_type = 'DOUBLE'
-      elif dtype == 'bool':
-        sql_type = 'BOOLEAN'
-      elif dtype == 'datetime64[ns]':
-        sql_type = 'TIMESTAMP'
-      else:
-        sql_type = 'STRING'
+        # Generate CREATE TABLE statement
+        columns = []
+        for col_name, dtype in df.dtypes.items():
+            # Map pandas dtypes to SQL types
+            if dtype == "object":
+                sql_type = "STRING"
+            elif dtype == "int64":
+                sql_type = "BIGINT"
+            elif dtype == "float64":
+                sql_type = "DOUBLE"
+            elif dtype == "bool":
+                sql_type = "BOOLEAN"
+            elif dtype == "datetime64[ns]":
+                sql_type = "TIMESTAMP"
+            else:
+                sql_type = "STRING"
 
-      columns.append(f'{col_name} {sql_type}')
+            columns.append(f"{col_name} {sql_type}")
 
-    try:
-      with conn.cursor() as cursor:
-        # Drop table if it exists to ensure schema is current
-        drop_sql = f'DROP TABLE IF EXISTS {table_name}'
-        cursor.execute(drop_sql)
-        logger.info(f'Dropped existing table {table_name} (if it existed)')
+        try:
+            with conn.cursor() as cursor:
+                # Drop table if it exists to ensure schema is current
+                drop_sql = f"DROP TABLE IF EXISTS {table_name}"
+                cursor.execute(drop_sql)
+                logger.info(f"Dropped existing table {table_name} (if it existed)")
 
-        # Create table with current schema
-        create_sql = f"""
+                # Create table with current schema
+                create_sql = f"""
                 CREATE TABLE {table_name} (
-                    {', '.join(columns)}
+                    {", ".join(columns)}
                 )
                 """
-        cursor.execute(create_sql)
-        logger.info(f'Created table {table_name} with {len(columns)} columns')
-        return True
-    except Exception as e:
-      logger.error(f'Failed to create table {table_name}: {str(e)}')
-      return False
-
-  def get_sqlite_data(self, db_path: str) -> Dict[str, pd.DataFrame]:
-    """Extract all data from SQLite database."""
-    try:
-      conn = sqlite3.connect(db_path)
-
-      # Get all table names
-      cursor = conn.cursor()
-      cursor.execute("SELECT name FROM sqlite_master WHERE type='table';")
-      tables = [row[0] for row in cursor.fetchall()]
-
-      data = {}
-      for table in tables:
-        try:
-          df = pd.read_sql_query(f'SELECT * FROM {table}', conn)
-          data[table] = df
-          logger.info(f'Extracted {len(df)} rows from {table}')
+                cursor.execute(create_sql)
+                logger.info(f"Created table {table_name} with {len(columns)} columns")
+                return True
         except Exception as e:
-          logger.error(f'Failed to extract data from {table}: {str(e)}')
+            logger.error(f"Failed to create table {table_name}: {e!s}")
+            return False
 
-      conn.close()
-      return data
-
-    except Exception as e:
-      logger.error(f'Failed to connect to SQLite database: {str(e)}')
-      return {}
-
-  def export_workshop_data(self, db_path: str) -> Dict[str, Any]:
-    """Export all workshop data from SQLite to DBSQL tables.
-
-    Args:
-        db_path: Path to SQLite database file
-
-    Returns:
-        Dictionary with export results
-    """
-    try:
-      logger.info('Starting DBSQL export of workshop data')
-
-      # Extract data from SQLite
-      sqlite_data = self.get_sqlite_data(db_path)
-
-      if not sqlite_data:
-        return {'success': False, 'error': 'No data found in SQLite database'}
-
-      # Connect to DBSQL
-      conn = self.get_connection()
-
-      export_results = {'success': True, 'tables_exported': [], 'total_rows': 0, 'errors': []}
-
-      # Export each table
-      for table_name, df in sqlite_data.items():
+    def get_sqlite_data(self, db_path: str) -> dict[str, pd.DataFrame]:
+        """Extract all data from SQLite database."""
         try:
-          # Create full table name
-          full_table_name = f'{self.catalog}.{self.schema_name}.{table_name}'
+            conn = sqlite3.connect(db_path)
 
-          # Create table if it doesn't exist
-          if not self.create_table_if_not_exists(full_table_name, df, conn):
-            export_results['errors'].append(f'Failed to create table {table_name}')
-            continue
+            # Get all table names
+            cursor = conn.cursor()
+            cursor.execute("SELECT name FROM sqlite_master WHERE type='table';")
+            tables = [row[0] for row in cursor.fetchall()]
 
-          # Skip data insertion for empty tables
-          if df.empty:
-            logger.info(f'Skipping data insertion for empty table {table_name}')
-            export_results['tables_exported'].append(
-              {
-                'table_name': table_name,
-                'full_table_name': full_table_name,
-                'rows_exported': 0,
-                'status': 'skipped_empty',
-              }
+            data = {}
+            for table in tables:
+                try:
+                    df = pd.read_sql_query(f"SELECT * FROM {table}", conn)
+                    data[table] = df
+                    logger.info(f"Extracted {len(df)} rows from {table}")
+                except Exception as e:
+                    logger.error(f"Failed to extract data from {table}: {e!s}")
+
+            conn.close()
+            return data
+
+        except Exception as e:
+            logger.error(f"Failed to connect to SQLite database: {e!s}")
+            return {}
+
+    def export_workshop_data(self, db_path: str) -> dict[str, Any]:
+        """Export all workshop data from SQLite to DBSQL tables.
+
+        Args:
+            db_path: Path to SQLite database file
+
+        Returns:
+            Dictionary with export results
+        """
+        try:
+            logger.info("Starting DBSQL export of workshop data")
+
+            # Extract data from SQLite
+            sqlite_data = self.get_sqlite_data(db_path)
+
+            if not sqlite_data:
+                return {"success": False, "error": "No data found in SQLite database"}
+
+            # Connect to DBSQL
+            conn = self.get_connection()
+
+            export_results = {"success": True, "tables_exported": [], "total_rows": 0, "errors": []}
+
+            # Export each table
+            for table_name, df in sqlite_data.items():
+                try:
+                    # Create full table name
+                    full_table_name = f"{self.catalog}.{self.schema_name}.{table_name}"
+
+                    # Create table if it doesn't exist
+                    if not self.create_table_if_not_exists(full_table_name, df, conn):
+                        export_results["errors"].append(f"Failed to create table {table_name}")
+                        continue
+
+                    # Skip data insertion for empty tables
+                    if df.empty:
+                        logger.info(f"Skipping data insertion for empty table {table_name}")
+                        export_results["tables_exported"].append(
+                            {
+                                "table_name": table_name,
+                                "full_table_name": full_table_name,
+                                "rows_exported": 0,
+                                "status": "skipped_empty",
+                            }
+                        )
+                        continue
+
+                    # Insert data
+                    self.insert_overwrite_table(full_table_name, df, conn)
+
+                    export_results["tables_exported"].append(
+                        {
+                            "table_name": table_name,
+                            "full_table_name": full_table_name,
+                            "rows_exported": len(df),
+                            "status": "exported",
+                        }
+                    )
+                    export_results["total_rows"] += len(df)
+
+                    logger.info(f"Successfully exported {len(df)} rows to {full_table_name}")
+
+                except Exception as e:
+                    error_msg = f"Failed to export table {table_name}: {e!s}"
+                    logger.error(error_msg)
+                    export_results["errors"].append(error_msg)
+
+            conn.close()
+
+            logger.info(
+                f"DBSQL export completed. Exported {export_results['total_rows']} total rows across {len(export_results['tables_exported'])} tables"
             )
-            continue
 
-          # Insert data
-          self.insert_overwrite_table(full_table_name, df, conn)
-
-          export_results['tables_exported'].append(
-            {
-              'table_name': table_name,
-              'full_table_name': full_table_name,
-              'rows_exported': len(df),
-              'status': 'exported',
-            }
-          )
-          export_results['total_rows'] += len(df)
-
-          logger.info(f'Successfully exported {len(df)} rows to {full_table_name}')
+            return export_results
 
         except Exception as e:
-          error_msg = f'Failed to export table {table_name}: {str(e)}'
-          logger.error(error_msg)
-          export_results['errors'].append(error_msg)
-
-      conn.close()
-
-      logger.info(
-        f'DBSQL export completed. Exported {export_results["total_rows"]} total rows across {len(export_results["tables_exported"])} tables'
-      )
-
-      return export_results
-
-    except Exception as e:
-      logger.error(f'Failed to export workshop data to DBSQL: {str(e)}')
-      return {'success': False, 'error': str(e)}
+            logger.error(f"Failed to export workshop data to DBSQL: {e!s}")
+            return {"success": False, "error": str(e)}

--- a/server/services/irr_service.py
+++ b/server/services/irr_service.py
@@ -6,294 +6,294 @@ for IRR calculations in the workshop application.
 """
 
 import logging
-from typing import Any, Dict, List
+from typing import Any
 
 from server.models import Annotation, IRRResult
 from server.services.cohens_kappa import (
-  calculate_cohens_kappa,
-  interpret_cohens_kappa,
-  is_cohens_kappa_acceptable,
+    calculate_cohens_kappa,
+    interpret_cohens_kappa,
+    is_cohens_kappa_acceptable,
 )
 from server.services.irr_utils import (
-  analyze_annotation_structure,
-  detect_problematic_patterns,
-  format_irr_result,
-  validate_annotations_for_irr,
+    analyze_annotation_structure,
+    detect_problematic_patterns,
+    format_irr_result,
+    validate_annotations_for_irr,
 )
 from server.services.krippendorff_alpha import (
-  calculate_krippendorff_alpha,
-  calculate_krippendorff_alpha_per_metric,
-  get_krippendorff_improvement_suggestions,
-  interpret_krippendorff_alpha,
-  is_krippendorff_alpha_acceptable,
+    calculate_krippendorff_alpha,
+    calculate_krippendorff_alpha_per_metric,
+    get_krippendorff_improvement_suggestions,
+    interpret_krippendorff_alpha,
+    is_krippendorff_alpha_acceptable,
 )
 
 logger = logging.getLogger(__name__)
 
 
-def calculate_irr_for_workshop(workshop_id: str, annotations: List[Annotation], db=None) -> IRRResult:
-  """Calculate Inter-Rater Reliability for a workshop with automatic metric selection.
+def calculate_irr_for_workshop(workshop_id: str, annotations: list[Annotation], db=None) -> IRRResult:
+    """Calculate Inter-Rater Reliability for a workshop with automatic metric selection.
 
-  Args:
-      workshop_id: ID of the workshop to calculate IRR for
-      annotations: List of annotations for the workshop
-      db: Database session for user lookups
+    Args:
+        workshop_id: ID of the workshop to calculate IRR for
+        annotations: List of annotations for the workshop
+        db: Database session for user lookups
 
-  Returns:
-      IRRResult: Comprehensive IRR calculation result
+    Returns:
+        IRRResult: Comprehensive IRR calculation result
 
-  This function automatically selects the appropriate IRR metric based on:
-      - Number of raters (2 = Cohen's Kappa, >2 = Krippendorff's Alpha)
-      - Data completeness (missing data = Krippendorff's Alpha)
-      - Data type (ordinal 1-5 scale favors Krippendorff's Alpha)
+    This function automatically selects the appropriate IRR metric based on:
+        - Number of raters (2 = Cohen's Kappa, >2 = Krippendorff's Alpha)
+        - Data completeness (missing data = Krippendorff's Alpha)
+        - Data type (ordinal 1-5 scale favors Krippendorff's Alpha)
 
-  The result includes the IRR score, interpretation, improvement suggestions,
-  and metadata about the calculation process.
-  """
-  # Validate annotations
-  is_valid, error_message = validate_annotations_for_irr(annotations)
-  if not is_valid:
-    logger.warning(f'Invalid annotations for workshop {workshop_id}: {error_message}')
-    return IRRResult(
-      workshop_id=workshop_id,
-      score=0.0,
-      ready_to_proceed=False,
-      details={'error': error_message, 'metric_used': 'none', 'num_annotations': len(annotations)},
+    The result includes the IRR score, interpretation, improvement suggestions,
+    and metadata about the calculation process.
+    """
+    # Validate annotations
+    is_valid, error_message = validate_annotations_for_irr(annotations)
+    if not is_valid:
+        logger.warning(f"Invalid annotations for workshop {workshop_id}: {error_message}")
+        return IRRResult(
+            workshop_id=workshop_id,
+            score=0.0,
+            ready_to_proceed=False,
+            details={"error": error_message, "metric_used": "none", "num_annotations": len(annotations)},
+        )
+
+    # Analyze annotation structure
+    analysis = analyze_annotation_structure(annotations)
+
+    # Calculate IRR using appropriate metric
+    try:
+        if analysis["recommended_metric"] == "cohens_kappa":
+            result = _calculate_cohens_kappa_result(annotations, analysis)
+        else:
+            result = _calculate_krippendorff_alpha_result(annotations, analysis)
+
+        # Add diagnostic information
+        result["problematic_patterns"] = detect_problematic_patterns(annotations, db)
+
+        logger.info(f"IRR calculated for workshop {workshop_id}: {result['metric_used']} = {result['score']}")
+
+        return IRRResult(
+            workshop_id=workshop_id,
+            score=result["score"],
+            ready_to_proceed=result["ready_to_proceed"],
+            details=result,
+        )
+
+    except Exception as e:
+        logger.error(f"Error calculating IRR for workshop {workshop_id}: {e}")
+        return IRRResult(
+            workshop_id=workshop_id,
+            score=0.0,
+            ready_to_proceed=False,
+            details={
+                "error": f"Calculation failed: {e!s}",
+                "metric_used": "none",
+                "num_annotations": len(annotations),
+            },
+        )
+
+
+def _calculate_cohens_kappa_result(annotations: list[Annotation], analysis: dict[str, Any]) -> dict[str, Any]:
+    """Calculate Cohen's Kappa and format result with per-metric scores.
+
+    Args:
+        annotations: List of annotations from exactly 2 raters
+        analysis: Annotation structure analysis
+
+    Returns:
+        Dict containing formatted Cohen's Kappa result with per-metric scores
+    """
+    # Calculate per-metric IRR using Krippendorff's Alpha
+    # (Cohen's Kappa doesn't support multi-metric calculation, so we use Krippendorff's Alpha)
+    per_metric_scores = calculate_krippendorff_alpha_per_metric(annotations)
+
+    # Calculate overall Cohen's Kappa for the main score
+    kappa = calculate_cohens_kappa(annotations)
+    interpretation = interpret_cohens_kappa(kappa)
+    ready_to_proceed = is_cohens_kappa_acceptable(kappa)
+
+    # Generate suggestions if needed
+    suggestions = []
+    if not ready_to_proceed:
+        suggestions = [
+            "Consider revising the rubric to reduce ambiguity",
+            "Provide additional training on the rating scale",
+            "Discuss specific examples where disagreement occurred",
+            "Ensure both raters understand the evaluation criteria identically",
+        ]
+
+    result = format_irr_result(
+        metric_name="Cohen's Kappa",
+        score=kappa,
+        interpretation=interpretation,
+        suggestions=suggestions,
+        analysis=analysis,
     )
 
-  # Analyze annotation structure
-  analysis = analyze_annotation_structure(annotations)
+    # Add per-metric scores to the result (using Krippendorff's Alpha for each metric)
+    result["per_metric_scores"] = {}
+    for question_id, score in per_metric_scores.items():
+        result["per_metric_scores"][question_id] = {
+            "score": score,
+            "interpretation": interpret_krippendorff_alpha(score),
+            "acceptable": is_krippendorff_alpha_acceptable(score),
+        }
 
-  # Calculate IRR using appropriate metric
-  try:
-    if analysis['recommended_metric'] == 'cohens_kappa':
-      result = _calculate_cohens_kappa_result(annotations, analysis)
+    return result
+
+
+def _is_binary_metric(annotations: list[Annotation], question_id: str) -> bool:
+    """Check if a metric uses binary (0/1) ratings.
+
+    Args:
+        annotations: List of annotations
+        question_id: The question ID to check
+
+    Returns:
+        bool: True if all ratings for this metric are 0 or 1
+    """
+    ratings = []
+    for ann in annotations:
+        if ann.ratings and question_id in ann.ratings:
+            ratings.append(ann.ratings[question_id])
+
+    if not ratings:
+        return False
+
+    return all(r in (0, 1) for r in ratings)
+
+
+def _calculate_krippendorff_alpha_result(annotations: list[Annotation], analysis: dict[str, Any]) -> dict[str, Any]:
+    """Calculate Krippendorff's Alpha and format result.
+
+    Args:
+        annotations: List of annotations from any number of raters
+        analysis: Annotation structure analysis
+
+    Returns:
+        Dict containing formatted Krippendorff's Alpha result with per-metric scores
+    """
+    # Calculate per-metric IRR
+    per_metric_scores = calculate_krippendorff_alpha_per_metric(annotations)
+
+    # Calculate overall score (average of all metrics, or legacy single rating)
+    if len(per_metric_scores) == 1 and "overall" in per_metric_scores:
+        # Legacy single rating
+        alpha = per_metric_scores["overall"]
     else:
-      result = _calculate_krippendorff_alpha_result(annotations, analysis)
+        # Average across all metrics
+        alpha = sum(per_metric_scores.values()) / len(per_metric_scores) if per_metric_scores else 0.0
 
-    # Add diagnostic information
-    result['problematic_patterns'] = detect_problematic_patterns(annotations, db)
+    interpretation = interpret_krippendorff_alpha(alpha)
+    suggestions = get_krippendorff_improvement_suggestions(alpha)
 
-    logger.info(f'IRR calculated for workshop {workshop_id}: {result["metric_used"]} = {result["score"]}')
-
-    return IRRResult(
-      workshop_id=workshop_id,
-      score=result['score'],
-      ready_to_proceed=result['ready_to_proceed'],
-      details=result,
+    result = format_irr_result(
+        metric_name="Krippendorff's Alpha",
+        score=alpha,
+        interpretation=interpretation,
+        suggestions=suggestions,
+        analysis=analysis,
     )
 
-  except Exception as e:
-    logger.error(f'Error calculating IRR for workshop {workshop_id}: {e}')
-    return IRRResult(
-      workshop_id=workshop_id,
-      score=0.0,
-      ready_to_proceed=False,
-      details={
-        'error': f'Calculation failed: {str(e)}',
-        'metric_used': 'none',
-        'num_annotations': len(annotations),
-      },
-    )
+    # Add per-metric scores to the result with individual suggestions
+    result["per_metric_scores"] = {}
+    for question_id, score in per_metric_scores.items():
+        # Detect if this metric uses binary scale
+        is_binary = _is_binary_metric(annotations, question_id)
+        metric_suggestions = get_krippendorff_improvement_suggestions(score, is_binary=is_binary)
+        result["per_metric_scores"][question_id] = {
+            "score": score,
+            "interpretation": interpret_krippendorff_alpha(score),
+            "acceptable": is_krippendorff_alpha_acceptable(score),
+            "suggestions": metric_suggestions,
+            "is_binary": is_binary,  # Include for frontend display
+        }
+
+    return result
 
 
-def _calculate_cohens_kappa_result(annotations: List[Annotation], analysis: Dict[str, Any]) -> Dict[str, Any]:
-  """Calculate Cohen's Kappa and format result with per-metric scores.
+def get_irr_status_for_workshop(workshop_id: str, annotations: list[Annotation]) -> dict[str, Any]:
+    """Get current IRR status for a workshop without recalculating.
 
-  Args:
-      annotations: List of annotations from exactly 2 raters
-      analysis: Annotation structure analysis
+    Args:
+        workshop_id: ID of the workshop
+        annotations: List of annotations for the workshop
 
-  Returns:
-      Dict containing formatted Cohen's Kappa result with per-metric scores
-  """
-  # Calculate per-metric IRR using Krippendorff's Alpha
-  # (Cohen's Kappa doesn't support multi-metric calculation, so we use Krippendorff's Alpha)
-  per_metric_scores = calculate_krippendorff_alpha_per_metric(annotations)
-  
-  # Calculate overall Cohen's Kappa for the main score
-  kappa = calculate_cohens_kappa(annotations)
-  interpretation = interpret_cohens_kappa(kappa)
-  ready_to_proceed = is_cohens_kappa_acceptable(kappa)
+    Returns:
+        Dict containing current IRR status
+    """
+    analysis = analyze_annotation_structure(annotations)
 
-  # Generate suggestions if needed
-  suggestions = []
-  if not ready_to_proceed:
-    suggestions = [
-      'Consider revising the rubric to reduce ambiguity',
-      'Provide additional training on the rating scale',
-      'Discuss specific examples where disagreement occurred',
-      'Ensure both raters understand the evaluation criteria identically',
-    ]
-
-  result = format_irr_result(
-    metric_name="Cohen's Kappa",
-    score=kappa,
-    interpretation=interpretation,
-    suggestions=suggestions,
-    analysis=analysis,
-  )
-  
-  # Add per-metric scores to the result (using Krippendorff's Alpha for each metric)
-  result['per_metric_scores'] = {}
-  for question_id, score in per_metric_scores.items():
-    result['per_metric_scores'][question_id] = {
-      'score': score,
-      'interpretation': interpret_krippendorff_alpha(score),
-      'acceptable': is_krippendorff_alpha_acceptable(score),
-    }
-  
-  return result
-
-
-def _is_binary_metric(annotations: List[Annotation], question_id: str) -> bool:
-  """Check if a metric uses binary (0/1) ratings.
-  
-  Args:
-      annotations: List of annotations
-      question_id: The question ID to check
-      
-  Returns:
-      bool: True if all ratings for this metric are 0 or 1
-  """
-  ratings = []
-  for ann in annotations:
-    if ann.ratings and question_id in ann.ratings:
-      ratings.append(ann.ratings[question_id])
-  
-  if not ratings:
-    return False
-  
-  return all(r in (0, 1) for r in ratings)
-
-
-def _calculate_krippendorff_alpha_result(annotations: List[Annotation], analysis: Dict[str, Any]) -> Dict[str, Any]:
-  """Calculate Krippendorff's Alpha and format result.
-
-  Args:
-      annotations: List of annotations from any number of raters
-      analysis: Annotation structure analysis
-
-  Returns:
-      Dict containing formatted Krippendorff's Alpha result with per-metric scores
-  """
-  # Calculate per-metric IRR
-  per_metric_scores = calculate_krippendorff_alpha_per_metric(annotations)
-  
-  # Calculate overall score (average of all metrics, or legacy single rating)
-  if len(per_metric_scores) == 1 and "overall" in per_metric_scores:
-    # Legacy single rating
-    alpha = per_metric_scores["overall"]
-  else:
-    # Average across all metrics
-    alpha = sum(per_metric_scores.values()) / len(per_metric_scores) if per_metric_scores else 0.0
-  
-  interpretation = interpret_krippendorff_alpha(alpha)
-  suggestions = get_krippendorff_improvement_suggestions(alpha)
-
-  result = format_irr_result(
-    metric_name="Krippendorff's Alpha",
-    score=alpha,
-    interpretation=interpretation,
-    suggestions=suggestions,
-    analysis=analysis,
-  )
-  
-  # Add per-metric scores to the result with individual suggestions
-  result['per_metric_scores'] = {}
-  for question_id, score in per_metric_scores.items():
-    # Detect if this metric uses binary scale
-    is_binary = _is_binary_metric(annotations, question_id)
-    metric_suggestions = get_krippendorff_improvement_suggestions(score, is_binary=is_binary)
-    result['per_metric_scores'][question_id] = {
-      'score': score,
-      'interpretation': interpret_krippendorff_alpha(score),
-      'acceptable': is_krippendorff_alpha_acceptable(score),
-      'suggestions': metric_suggestions,
-      'is_binary': is_binary,  # Include for frontend display
-    }
-  
-  return result
-
-
-def get_irr_status_for_workshop(workshop_id: str, annotations: List[Annotation]) -> Dict[str, Any]:
-  """Get current IRR status for a workshop without recalculating.
-
-  Args:
-      workshop_id: ID of the workshop
-      annotations: List of annotations for the workshop
-
-  Returns:
-      Dict containing current IRR status
-  """
-  analysis = analyze_annotation_structure(annotations)
-
-  return {
-    'workshop_id': workshop_id,
-    'has_sufficient_data': len(annotations) >= 2 and analysis['num_raters'] >= 2,
-    'num_annotations': len(annotations),
-    'num_raters': analysis['num_raters'],
-    'num_traces': analysis['num_traces'],
-    'completeness': analysis['completeness'],
-    'recommended_metric': analysis['recommended_metric'],
-    'ready_for_calculation': validate_annotations_for_irr(annotations)[0],
-  }
-
-
-def compare_irr_metrics(annotations: List[Annotation]) -> Dict[str, Any]:
-  """Compare Cohen's Kappa and Krippendorff's Alpha for the same data (if applicable).
-
-  Args:
-      annotations: List of annotations
-
-  Returns:
-      Dict containing comparison of both metrics
-
-  This function is useful for understanding how different metrics
-  perform on the same dataset and for educational purposes.
-  """
-  analysis = analyze_annotation_structure(annotations)
-
-  results = {
-    'analysis': analysis,
-    'cohens_kappa': None,
-    'krippendorff_alpha': None,
-    'comparison': None,
-  }
-
-  # Calculate Krippendorff's Alpha (always possible with sufficient data)
-  if len(annotations) >= 2 and analysis['num_raters'] >= 2:
-    try:
-      alpha = calculate_krippendorff_alpha(annotations)
-      results['krippendorff_alpha'] = {
-        'score': alpha,
-        'interpretation': interpret_krippendorff_alpha(alpha),
-        'acceptable': is_krippendorff_alpha_acceptable(alpha),
-      }
-    except Exception as e:
-      results['krippendorff_alpha'] = {'error': str(e)}
-
-  # Calculate Cohen's Kappa (only if exactly 2 raters and no missing data)
-  if analysis['num_raters'] == 2 and not analysis['missing_data']:
-    try:
-      kappa = calculate_cohens_kappa(annotations)
-      results['cohens_kappa'] = {
-        'score': kappa,
-        'interpretation': interpret_cohens_kappa(kappa),
-        'acceptable': is_cohens_kappa_acceptable(kappa),
-      }
-    except Exception as e:
-      results['cohens_kappa'] = {'error': str(e)}
-
-  # Add comparison if both metrics were calculated
-  if results['cohens_kappa'] and results['krippendorff_alpha']:
-    kappa_score = results['cohens_kappa']['score']
-    alpha_score = results['krippendorff_alpha']['score']
-
-    results['comparison'] = {
-      'difference': abs(kappa_score - alpha_score),
-      'agreement': 'close' if abs(kappa_score - alpha_score) < 0.1 else 'different',
-      'note': "Cohen's Kappa and Krippendorff's Alpha use different mathematical approaches",
+    return {
+        "workshop_id": workshop_id,
+        "has_sufficient_data": len(annotations) >= 2 and analysis["num_raters"] >= 2,
+        "num_annotations": len(annotations),
+        "num_raters": analysis["num_raters"],
+        "num_traces": analysis["num_traces"],
+        "completeness": analysis["completeness"],
+        "recommended_metric": analysis["recommended_metric"],
+        "ready_for_calculation": validate_annotations_for_irr(annotations)[0],
     }
 
-  return results
+
+def compare_irr_metrics(annotations: list[Annotation]) -> dict[str, Any]:
+    """Compare Cohen's Kappa and Krippendorff's Alpha for the same data (if applicable).
+
+    Args:
+        annotations: List of annotations
+
+    Returns:
+        Dict containing comparison of both metrics
+
+    This function is useful for understanding how different metrics
+    perform on the same dataset and for educational purposes.
+    """
+    analysis = analyze_annotation_structure(annotations)
+
+    results = {
+        "analysis": analysis,
+        "cohens_kappa": None,
+        "krippendorff_alpha": None,
+        "comparison": None,
+    }
+
+    # Calculate Krippendorff's Alpha (always possible with sufficient data)
+    if len(annotations) >= 2 and analysis["num_raters"] >= 2:
+        try:
+            alpha = calculate_krippendorff_alpha(annotations)
+            results["krippendorff_alpha"] = {
+                "score": alpha,
+                "interpretation": interpret_krippendorff_alpha(alpha),
+                "acceptable": is_krippendorff_alpha_acceptable(alpha),
+            }
+        except Exception as e:
+            results["krippendorff_alpha"] = {"error": str(e)}
+
+    # Calculate Cohen's Kappa (only if exactly 2 raters and no missing data)
+    if analysis["num_raters"] == 2 and not analysis["missing_data"]:
+        try:
+            kappa = calculate_cohens_kappa(annotations)
+            results["cohens_kappa"] = {
+                "score": kappa,
+                "interpretation": interpret_cohens_kappa(kappa),
+                "acceptable": is_cohens_kappa_acceptable(kappa),
+            }
+        except Exception as e:
+            results["cohens_kappa"] = {"error": str(e)}
+
+    # Add comparison if both metrics were calculated
+    if results["cohens_kappa"] and results["krippendorff_alpha"]:
+        kappa_score = results["cohens_kappa"]["score"]
+        alpha_score = results["krippendorff_alpha"]["score"]
+
+        results["comparison"] = {
+            "difference": abs(kappa_score - alpha_score),
+            "agreement": "close" if abs(kappa_score - alpha_score) < 0.1 else "different",
+            "note": "Cohen's Kappa and Krippendorff's Alpha use different mathematical approaches",
+        }
+
+    return results

--- a/server/services/irr_utils.py
+++ b/server/services/irr_utils.py
@@ -6,289 +6,286 @@ logic and result formatting.
 """
 
 from collections import defaultdict
-from typing import Dict, List, Tuple
 
 from server.database import UserDB
 from server.models import Annotation
 
 
-def analyze_annotation_structure(annotations: List[Annotation]) -> Dict[str, any]:
-  """Analyze the structure of annotations to determine appropriate IRR metric.
+def analyze_annotation_structure(annotations: list[Annotation]) -> dict[str, any]:
+    """Analyze the structure of annotations to determine appropriate IRR metric.
 
-  Args:
-      annotations: List of annotations to analyze
+    Args:
+        annotations: List of annotations to analyze
 
-  Returns:
-      Dict containing analysis results:
-      - num_raters: Number of unique raters
-      - num_traces: Number of unique traces
-      - total_annotations: Total number of annotations
-      - completeness: Proportion of possible annotations present
-      - rater_participation: Dict of rater_id -> number of annotations
-      - trace_coverage: Dict of trace_id -> number of annotations
-      - missing_data: Whether there are missing annotations
-      - recommended_metric: "cohens_kappa" or "krippendorff_alpha"
+    Returns:
+        Dict containing analysis results:
+        - num_raters: Number of unique raters
+        - num_traces: Number of unique traces
+        - total_annotations: Total number of annotations
+        - completeness: Proportion of possible annotations present
+        - rater_participation: Dict of rater_id -> number of annotations
+        - trace_coverage: Dict of trace_id -> number of annotations
+        - missing_data: Whether there are missing annotations
+        - recommended_metric: "cohens_kappa" or "krippendorff_alpha"
 
-  This analysis helps determine which IRR metric is most appropriate
-  for the given annotation structure.
-  """
-  if not annotations:
+    This analysis helps determine which IRR metric is most appropriate
+    for the given annotation structure.
+    """
+    if not annotations:
+        return {
+            "num_raters": 0,
+            "num_traces": 0,
+            "total_annotations": 0,
+            "completeness": 0.0,
+            "rater_participation": {},
+            "trace_coverage": {},
+            "missing_data": False,
+            "recommended_metric": None,
+        }
+
+    # Count unique raters and traces
+    raters = {ann.user_id for ann in annotations}
+    traces = {ann.trace_id for ann in annotations}
+
+    # Analyze rater participation
+    rater_participation = defaultdict(int)
+    for ann in annotations:
+        rater_participation[ann.user_id] += 1
+
+    # Analyze trace coverage
+    trace_coverage = defaultdict(int)
+    for ann in annotations:
+        trace_coverage[ann.trace_id] += 1
+
+    # Calculate completeness (proportion of possible annotations present)
+    possible_annotations = len(raters) * len(traces)
+    actual_annotations = len(annotations)
+    completeness = actual_annotations / possible_annotations if possible_annotations > 0 else 0.0
+
+    # Determine if there's missing data
+    missing_data = completeness < 1.0
+
+    # Recommend appropriate metric
+    recommended_metric = _recommend_irr_metric(len(raters), missing_data, actual_annotations)
+
     return {
-      'num_raters': 0,
-      'num_traces': 0,
-      'total_annotations': 0,
-      'completeness': 0.0,
-      'rater_participation': {},
-      'trace_coverage': {},
-      'missing_data': False,
-      'recommended_metric': None,
+        "num_raters": len(raters),
+        "num_traces": len(traces),
+        "total_annotations": actual_annotations,
+        "completeness": completeness,
+        "rater_participation": dict(rater_participation),
+        "trace_coverage": dict(trace_coverage),
+        "missing_data": missing_data,
+        "recommended_metric": recommended_metric,
     }
-
-  # Count unique raters and traces
-  raters = set(ann.user_id for ann in annotations)
-  traces = set(ann.trace_id for ann in annotations)
-
-  # Analyze rater participation
-  rater_participation = defaultdict(int)
-  for ann in annotations:
-    rater_participation[ann.user_id] += 1
-
-  # Analyze trace coverage
-  trace_coverage = defaultdict(int)
-  for ann in annotations:
-    trace_coverage[ann.trace_id] += 1
-
-  # Calculate completeness (proportion of possible annotations present)
-  possible_annotations = len(raters) * len(traces)
-  actual_annotations = len(annotations)
-  completeness = actual_annotations / possible_annotations if possible_annotations > 0 else 0.0
-
-  # Determine if there's missing data
-  missing_data = completeness < 1.0
-
-  # Recommend appropriate metric
-  recommended_metric = _recommend_irr_metric(len(raters), missing_data, actual_annotations)
-
-  return {
-    'num_raters': len(raters),
-    'num_traces': len(traces),
-    'total_annotations': actual_annotations,
-    'completeness': completeness,
-    'rater_participation': dict(rater_participation),
-    'trace_coverage': dict(trace_coverage),
-    'missing_data': missing_data,
-    'recommended_metric': recommended_metric,
-  }
 
 
 def _recommend_irr_metric(num_raters: int, missing_data: bool, total_annotations: int) -> str:
-  """Recommend appropriate IRR metric based on data characteristics.
+    """Recommend appropriate IRR metric based on data characteristics.
 
-  Args:
-      num_raters: Number of unique raters
-      missing_data: Whether there are missing annotations
-      total_annotations: Total number of annotations
+    Args:
+        num_raters: Number of unique raters
+        missing_data: Whether there are missing annotations
+        total_annotations: Total number of annotations
 
-  Returns:
-      str: "cohens_kappa" or "krippendorff_alpha"
+    Returns:
+        str: "cohens_kappa" or "krippendorff_alpha"
 
-  Decision logic:
-      - Cohen's Kappa: Exactly 2 raters, no missing data, sufficient annotations
-      - Krippendorff's Alpha: Multiple raters, missing data, or ordinal data
-  """
-  if total_annotations < 2:
-    return 'krippendorff_alpha'  # Default for insufficient data
+    Decision logic:
+        - Cohen's Kappa: Exactly 2 raters, no missing data, sufficient annotations
+        - Krippendorff's Alpha: Multiple raters, missing data, or ordinal data
+    """
+    if total_annotations < 2:
+        return "krippendorff_alpha"  # Default for insufficient data
 
-  if num_raters == 2 and not missing_data:
-    return 'cohens_kappa'
-  else:
-    return 'krippendorff_alpha'
+    if num_raters == 2 and not missing_data:
+        return "cohens_kappa"
+    return "krippendorff_alpha"
 
 
-def validate_annotations_for_irr(annotations: List[Annotation]) -> Tuple[bool, str]:
-  """Validate that annotations are suitable for IRR calculation.
+def validate_annotations_for_irr(annotations: list[Annotation]) -> tuple[bool, str]:
+    """Validate that annotations are suitable for IRR calculation.
 
-  Args:
-      annotations: List of annotations to validate
+    Args:
+        annotations: List of annotations to validate
 
-  Returns:
-      Tuple[bool, str]: (is_valid, error_message)
+    Returns:
+        Tuple[bool, str]: (is_valid, error_message)
 
-  Validation checks:
-      - Minimum number of annotations
-      - Valid rating range (1-5)
-      - At least 2 raters
-      - At least 2 traces with multiple ratings
-  """
-  if len(annotations) < 2:
-    return False, 'Need at least 2 annotations to calculate IRR'
+    Validation checks:
+        - Minimum number of annotations
+        - Valid rating range (1-5)
+        - At least 2 raters
+        - At least 2 traces with multiple ratings
+    """
+    if len(annotations) < 2:
+        return False, "Need at least 2 annotations to calculate IRR"
 
-  # Check rating range - support both binary (0/1) and Likert (1-5)
-  for ann in annotations:
-    if not (0 <= ann.rating <= 5):
-      return False, f'Invalid rating {ann.rating}: must be between 0 and 5'
+    # Check rating range - support both binary (0/1) and Likert (1-5)
+    for ann in annotations:
+        if not (0 <= ann.rating <= 5):
+            return False, f"Invalid rating {ann.rating}: must be between 0 and 5"
 
-  # Check number of raters
-  raters = set(ann.user_id for ann in annotations)
-  if len(raters) < 2:
-    return False, f'Need at least 2 raters to calculate IRR, got {len(raters)}'
+    # Check number of raters
+    raters = {ann.user_id for ann in annotations}
+    if len(raters) < 2:
+        return False, f"Need at least 2 raters to calculate IRR, got {len(raters)}"
 
-  # Check for traces with multiple ratings
-  trace_ratings = defaultdict(set)
-  for ann in annotations:
-    trace_ratings[ann.trace_id].add(ann.user_id)
+    # Check for traces with multiple ratings
+    trace_ratings = defaultdict(set)
+    for ann in annotations:
+        trace_ratings[ann.trace_id].add(ann.user_id)
 
-  multi_rated_traces = sum(1 for raters in trace_ratings.values() if len(raters) > 1)
-  if multi_rated_traces < 2:
-    return False, f'Need at least 2 traces rated by multiple raters, got {multi_rated_traces}'
+    multi_rated_traces = sum(1 for raters in trace_ratings.values() if len(raters) > 1)
+    if multi_rated_traces < 2:
+        return False, f"Need at least 2 traces rated by multiple raters, got {multi_rated_traces}"
 
-  return True, ''
+    return True, ""
 
 
 def format_irr_result(
-  metric_name: str,
-  score: float,
-  interpretation: str,
-  suggestions: List[str],
-  analysis: Dict[str, any],
-) -> Dict[str, any]:
-  """Format IRR calculation result for API response.
+    metric_name: str,
+    score: float,
+    interpretation: str,
+    suggestions: list[str],
+    analysis: dict[str, any],
+) -> dict[str, any]:
+    """Format IRR calculation result for API response.
 
-  Args:
-      metric_name: Name of the metric used ("Cohen's Kappa" or "Krippendorff's Alpha")
-      score: IRR score value
-      interpretation: Human-readable interpretation
-      suggestions: List of improvement suggestions
-      analysis: Annotation structure analysis
+    Args:
+        metric_name: Name of the metric used ("Cohen's Kappa" or "Krippendorff's Alpha")
+        score: IRR score value
+        interpretation: Human-readable interpretation
+        suggestions: List of improvement suggestions
+        analysis: Annotation structure analysis
 
-  Returns:
-      Dict containing formatted IRR result
-  """
-  return {
-    'metric_used': metric_name,
-    'score': round(score, 3),
-    'interpretation': interpretation,
-    'ready_to_proceed': score >= 0.3,
-    'threshold': 0.3,
-    'suggestions': suggestions,
-    'num_raters': analysis['num_raters'],
-    'num_traces': analysis['num_traces'],
-    'num_annotations': analysis['total_annotations'],
-    'completeness': round(analysis['completeness'], 3),
-    'missing_data': analysis['missing_data'],
-  }
+    Returns:
+        Dict containing formatted IRR result
+    """
+    return {
+        "metric_used": metric_name,
+        "score": round(score, 3),
+        "interpretation": interpretation,
+        "ready_to_proceed": score >= 0.3,
+        "threshold": 0.3,
+        "suggestions": suggestions,
+        "num_raters": analysis["num_raters"],
+        "num_traces": analysis["num_traces"],
+        "num_annotations": analysis["total_annotations"],
+        "completeness": round(analysis["completeness"], 3),
+        "missing_data": analysis["missing_data"],
+    }
 
 
 def get_irr_confidence_level(score: float) -> str:
-  """Determine confidence level for IRR score.
+    """Determine confidence level for IRR score.
 
-  Args:
-      score: IRR score (0-1)
+    Args:
+        score: IRR score (0-1)
 
-  Returns:
-      str: Confidence level description
-  """
-  if score >= 0.8:
-    return 'High confidence - results are reliable'
-  elif score >= 0.6:
-    return 'Moderate confidence - results are acceptable'
-  elif score >= 0.3:
-    return 'Low confidence - results are tentative'
-  else:
-    return 'Very low confidence - results are unreliable'
+    Returns:
+        str: Confidence level description
+    """
+    if score >= 0.8:
+        return "High confidence - results are reliable"
+    if score >= 0.6:
+        return "Moderate confidence - results are acceptable"
+    if score >= 0.3:
+        return "Low confidence - results are tentative"
+    return "Very low confidence - results are unreliable"
 
 
-def detect_problematic_patterns(annotations: List[Annotation], db=None, question_id: str = None) -> List[str]:
-  """Detect problematic patterns in annotation data.
+def detect_problematic_patterns(annotations: list[Annotation], db=None, question_id: str = None) -> list[str]:
+    """Detect problematic patterns in annotation data.
 
-  Args:
-      annotations: List of annotations to analyze
-      db: Database session for user name lookups
-      question_id: Optional question ID to analyze a specific metric
+    Args:
+        annotations: List of annotations to analyze
+        db: Database session for user name lookups
+        question_id: Optional question ID to analyze a specific metric
 
-  Returns:
-      List[str]: List of detected issues
+    Returns:
+        List[str]: List of detected issues
 
-  Detects patterns that might indicate problems:
-      - Raters who always give the same rating
-      - Traces with extreme disagreement
-      - Systematic bias between raters
-  """
-  issues = []
+    Detects patterns that might indicate problems:
+        - Raters who always give the same rating
+        - Traces with extreme disagreement
+        - Systematic bias between raters
+    """
+    issues = []
 
-  # Helper function to get user name
-  def get_user_name(user_id: str) -> str:
-    if db:
-      try:
-        user = db.query(UserDB).filter(UserDB.id == user_id).first()
-        if user and user.name:
-          return user.name
-      except Exception:
-        pass  # Fall back to user_id if lookup fails
-    return user_id
+    # Helper function to get user name
+    def get_user_name(user_id: str) -> str:
+        if db:
+            try:
+                user = db.query(UserDB).filter(UserDB.id == user_id).first()
+                if user and user.name:
+                    return user.name
+            except Exception:
+                pass  # Fall back to user_id if lookup fails
+        return user_id
 
-  # Helper function to get rating from annotation
-  # Prefers per-question ratings dict, falls back to legacy rating
-  def get_rating(ann: Annotation) -> int:
-    if ann.ratings and len(ann.ratings) > 0:
-      if question_id and question_id in ann.ratings:
-        return ann.ratings[question_id]
-      # Return first rating if no specific question_id
-      return list(ann.ratings.values())[0]
-    return ann.rating
+    # Helper function to get rating from annotation
+    # Prefers per-question ratings dict, falls back to legacy rating
+    def get_rating(ann: Annotation) -> int:
+        if ann.ratings and len(ann.ratings) > 0:
+            if question_id and question_id in ann.ratings:
+                return ann.ratings[question_id]
+            # Return first rating if no specific question_id
+            return next(iter(ann.ratings.values()))
+        return ann.rating
 
-  # Collect all ratings to detect if binary
-  all_ratings = [get_rating(ann) for ann in annotations if get_rating(ann) is not None]
-  is_binary = all(r in (0, 1) for r in all_ratings) if all_ratings else False
+    # Collect all ratings to detect if binary
+    all_ratings = [get_rating(ann) for ann in annotations if get_rating(ann) is not None]
+    is_binary = all(r in (0, 1) for r in all_ratings) if all_ratings else False
 
-  # Check for raters with no variation
-  rater_ratings = defaultdict(set)
-  for ann in annotations:
-    rating = get_rating(ann)
-    if rating is not None:
-      rater_ratings[ann.user_id].add(rating)
-
-  for rater_id, ratings in rater_ratings.items():
-    if len(ratings) == 1:
-      rating = list(ratings)[0]
-      rater_name = get_user_name(rater_id)
-      if is_binary:
-        rating_label = 'Pass' if rating == 1 else 'Fail'
-        issues.append(f'Rater {rater_name} always gives {rating_label} (no variation)')
-      else:
-        issues.append(f'Rater {rater_name} always gives rating {rating} (no variation)')
-
-  # Check for traces with extreme disagreement
-  trace_ratings = defaultdict(list)
-  for ann in annotations:
-    rating = get_rating(ann)
-    if rating is not None:
-      trace_ratings[ann.trace_id].append(rating)
-
-  for trace_id, ratings in trace_ratings.items():
-    if len(ratings) > 1:
-      rating_range = max(ratings) - min(ratings)
-      # For binary: any disagreement is notable; for Likert: only extreme (4+ points)
-      threshold = 1 if is_binary else 4
-      if rating_range >= threshold:
-        if is_binary:
-          issues.append(f'Trace {trace_id[:16]}... has disagreement (Pass vs Fail)')
-        else:
-          issues.append(f'Trace {trace_id[:16]}... has extreme disagreement (range: {rating_range})')
-
-  # Check for systematic bias (only for Likert scale)
-  if not is_binary and len(set(ann.user_id for ann in annotations)) >= 2:
-    avg_by_rater = defaultdict(list)
+    # Check for raters with no variation
+    rater_ratings = defaultdict(set)
     for ann in annotations:
-      rating = get_rating(ann)
-      if rating is not None:
-        avg_by_rater[ann.user_id].append(rating)
+        rating = get_rating(ann)
+        if rating is not None:
+            rater_ratings[ann.user_id].add(rating)
 
-    rater_averages = {rater: sum(ratings) / len(ratings) for rater, ratings in avg_by_rater.items() if ratings}
+    for rater_id, ratings in rater_ratings.items():
+        if len(ratings) == 1:
+            rating = next(iter(ratings))
+            rater_name = get_user_name(rater_id)
+            if is_binary:
+                rating_label = "Pass" if rating == 1 else "Fail"
+                issues.append(f"Rater {rater_name} always gives {rating_label} (no variation)")
+            else:
+                issues.append(f"Rater {rater_name} always gives rating {rating} (no variation)")
 
-    if len(rater_averages) >= 2:
-      avg_range = max(rater_averages.values()) - min(rater_averages.values())
-      if avg_range >= 2:  # Large difference in average ratings
-        issues.append('Raters have very different average ratings - consider discussing rating standards')
+    # Check for traces with extreme disagreement
+    trace_ratings = defaultdict(list)
+    for ann in annotations:
+        rating = get_rating(ann)
+        if rating is not None:
+            trace_ratings[ann.trace_id].append(rating)
 
-  return issues
+    for trace_id, ratings in trace_ratings.items():
+        if len(ratings) > 1:
+            rating_range = max(ratings) - min(ratings)
+            # For binary: any disagreement is notable; for Likert: only extreme (4+ points)
+            threshold = 1 if is_binary else 4
+            if rating_range >= threshold:
+                if is_binary:
+                    issues.append(f"Trace {trace_id[:16]}... has disagreement (Pass vs Fail)")
+                else:
+                    issues.append(f"Trace {trace_id[:16]}... has extreme disagreement (range: {rating_range})")
+
+    # Check for systematic bias (only for Likert scale)
+    if not is_binary and len({ann.user_id for ann in annotations}) >= 2:
+        avg_by_rater = defaultdict(list)
+        for ann in annotations:
+            rating = get_rating(ann)
+            if rating is not None:
+                avg_by_rater[ann.user_id].append(rating)
+
+        rater_averages = {rater: sum(ratings) / len(ratings) for rater, ratings in avg_by_rater.items() if ratings}
+
+        if len(rater_averages) >= 2:
+            avg_range = max(rater_averages.values()) - min(rater_averages.values())
+            if avg_range >= 2:  # Large difference in average ratings
+                issues.append("Raters have very different average ratings - consider discussing rating standards")
+
+    return issues

--- a/server/services/judge_service.py
+++ b/server/services/judge_service.py
@@ -4,576 +4,598 @@ import json
 import os
 import random
 import uuid
-from typing import Any, Dict, List
+from typing import Any
 
 import numpy as np
 from fastapi import HTTPException
 from sklearn.metrics import accuracy_score, cohen_kappa_score, confusion_matrix
 
 from server.models import (
-  JudgeEvaluation,
-  JudgeEvaluationDirectRequest,
-  JudgeEvaluationRequest,
-  JudgeEvaluationResult,
-  JudgeExportConfig,
-  JudgePerformanceMetrics,
-  JudgePrompt,
+    JudgeEvaluation,
+    JudgeEvaluationDirectRequest,
+    JudgeEvaluationRequest,
+    JudgeEvaluationResult,
+    JudgeExportConfig,
+    JudgePerformanceMetrics,
+    JudgePrompt,
 )
 from server.services.database_service import DatabaseService
 
 try:
-  import mlflow
-  from mlflow.metrics.genai import make_genai_metric_from_prompt
+    import mlflow
+    from mlflow.metrics.genai import make_genai_metric_from_prompt
 
-  MLFLOW_AVAILABLE = True
+    MLFLOW_AVAILABLE = True
 except ImportError:
-  MLFLOW_AVAILABLE = False
+    MLFLOW_AVAILABLE = False
 
 
 class JudgeService:
-  """Service for judge prompt evaluation and management."""
+    """Service for judge prompt evaluation and management."""
 
-  def __init__(self, db_service: DatabaseService):
-    self.db_service = db_service
+    def __init__(self, db_service: DatabaseService):
+        self.db_service = db_service
 
-  def evaluate_prompt(self, workshop_id: str, evaluation_request: JudgeEvaluationRequest) -> JudgePerformanceMetrics:
-    """Evaluate a judge prompt against human annotations."""
-    # Get the prompt
-    prompt = self.db_service.get_judge_prompt(workshop_id, evaluation_request.prompt_id)
-    if not prompt:
-      raise ValueError(f'Judge prompt {evaluation_request.prompt_id} not found')
+    def evaluate_prompt(self, workshop_id: str, evaluation_request: JudgeEvaluationRequest) -> JudgePerformanceMetrics:
+        """Evaluate a judge prompt against human annotations."""
+        # Get the prompt
+        prompt = self.db_service.get_judge_prompt(workshop_id, evaluation_request.prompt_id)
+        if not prompt:
+            raise ValueError(f"Judge prompt {evaluation_request.prompt_id} not found")
 
-    # Clear old cached evaluations for this prompt to prevent stale data
-    self.db_service.clear_judge_evaluations(workshop_id, evaluation_request.prompt_id)
+        # Clear old cached evaluations for this prompt to prevent stale data
+        self.db_service.clear_judge_evaluations(workshop_id, evaluation_request.prompt_id)
 
-    # Get annotations for evaluation
-    annotations = self.db_service.get_annotations(workshop_id)
-    if not annotations:
-      raise ValueError('No annotations found for evaluation')
+        # Get annotations for evaluation
+        annotations = self.db_service.get_annotations(workshop_id)
+        if not annotations:
+            raise ValueError("No annotations found for evaluation")
 
-    # Filter to specific traces if requested
-    if evaluation_request.trace_ids:
-      annotations = [a for a in annotations if a.trace_id in evaluation_request.trace_ids]
+        # Filter to specific traces if requested
+        if evaluation_request.trace_ids:
+            annotations = [a for a in annotations if a.trace_id in evaluation_request.trace_ids]
 
-    # Check if we should use real MLflow or simulation
-    # IMPORTANT: Use override_model from UI if provided (e.g., user selected 'demo')
-    effective_model = evaluation_request.override_model if evaluation_request.override_model else prompt.model_name
-    use_mlflow = effective_model != 'demo' and MLFLOW_AVAILABLE
+        # Check if we should use real MLflow or simulation
+        # IMPORTANT: Use override_model from UI if provided (e.g., user selected 'demo')
+        effective_model = evaluation_request.override_model if evaluation_request.override_model else prompt.model_name
+        use_mlflow = effective_model != "demo" and MLFLOW_AVAILABLE
 
-    # Add debug logging to track what's happening
-    print(
-      f"""Judge evaluation: saved_model='{prompt.model_name}',
+        # Add debug logging to track what's happening
+        print(
+            f"""Judge evaluation: saved_model='{prompt.model_name}',
       override_model='{evaluation_request.override_model}', effective_model='{effective_model}',
       use_mlflow={use_mlflow}, MLFLOW_AVAILABLE={MLFLOW_AVAILABLE}"""
-    )
-
-    # Get MLflow configuration if needed
-    mlflow_config = None
-    if use_mlflow:
-      mlflow_config = self.db_service.get_mlflow_config(workshop_id)
-      if not mlflow_config:
-        # No fallback - raise error
-        raise HTTPException(
-          status_code=400,
-          detail='MLflow configuration required for AI judge evaluation. Configure in Intake phase.',
         )
 
-      # Get token from memory storage
-      from server.services.token_storage_service import token_storage
-
-      databricks_token = token_storage.get_token(workshop_id)
-      if not databricks_token:
-        databricks_token = self.db_service.get_databricks_token(workshop_id)
-        if databricks_token:
-          token_storage.store_token(workshop_id, databricks_token)
-      if not databricks_token:
-        raise HTTPException(
-          status_code=400,
-          detail='Databricks token not found. Please configure MLflow intake with your token.',
-        )
-
-      # Validate MLflow credentials before proceeding
-      if not mlflow_config.databricks_host:
-        raise HTTPException(status_code=400, detail='Invalid MLflow configuration: missing Databricks host')
-
-      # Update the config with the token from memory
-      mlflow_config.databricks_token = databricks_token
-
-      # Validate the effective model has a valid non-demo model
-      if not effective_model or effective_model == 'demo':
-        raise HTTPException(
-          status_code=400,
-          detail='Cannot use MLflow evaluation with demo model. Select a real model (databricks-*, openai-*)',
-        )
-
-    # Calculate mode-based ground truth at the evaluate_prompt level for meaningful aggregation
-    from collections import Counter
-
-    # Group annotations by trace_id and calculate mode (most common rating) as ground truth
-    trace_ground_truth = {}
-    trace_objects = {}
-
-    for annotation in annotations:
-      trace_id = annotation.trace_id
-      if trace_id not in trace_ground_truth:
-        trace_ground_truth[trace_id] = []
-        # Get trace object
-        trace = self.db_service.get_trace(trace_id)
-        if trace:
-          trace_objects[trace_id] = trace
-
-      trace_ground_truth[trace_id].append(annotation.rating)
-
-    # Calculate mode for each trace and create unique evaluations
-    unique_evaluations = []
-    for trace_id, ratings in trace_ground_truth.items():
-      if trace_id in trace_objects:
-        # Calculate mode (most common rating)
-        rating_counts = Counter(ratings)
-        mode_rating = rating_counts.most_common(1)[0][0]  # Most frequent rating
-
-        trace = trace_objects[trace_id]
-
-        # Evaluate using either MLflow or simulation
+        # Get MLflow configuration if needed
+        mlflow_config = None
         if use_mlflow:
-          try:
-            predicted_rating, reasoning = self._evaluate_with_mlflow(workshop_id, prompt, trace.input, trace.output, mlflow_config)
-          except Exception as e:
-            # Don't fallback - propagate the error
-            raise HTTPException(status_code=503, detail=f'MLflow evaluation failed: {str(e)}')
-        else:
-          predicted_rating = self._simulate_judge_rating(prompt.prompt_text, trace.input, trace.output, mode_rating)
-          reasoning = 'Test judge evaluation (development mode)'
+            mlflow_config = self.db_service.get_mlflow_config(workshop_id)
+            if not mlflow_config:
+                # No fallback - raise error
+                raise HTTPException(
+                    status_code=400,
+                    detail="MLflow configuration required for AI judge evaluation. Configure in Intake phase.",
+                )
 
-        evaluation = JudgeEvaluation(
-          id=str(uuid.uuid4()),
-          workshop_id=workshop_id,
-          prompt_id=evaluation_request.prompt_id,
-          trace_id=trace_id,
-          predicted_rating=predicted_rating,
-          human_rating=mode_rating,  # Use mode-based ground truth
-          confidence=None,  # Don't fake confidence values
-          reasoning=reasoning,
+            # Get token from memory storage
+            from server.services.token_storage_service import token_storage
+
+            databricks_token = token_storage.get_token(workshop_id)
+            if not databricks_token:
+                databricks_token = self.db_service.get_databricks_token(workshop_id)
+                if databricks_token:
+                    token_storage.store_token(workshop_id, databricks_token)
+            if not databricks_token:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Databricks token not found. Please configure MLflow intake with your token.",
+                )
+
+            # Validate MLflow credentials before proceeding
+            if not mlflow_config.databricks_host:
+                raise HTTPException(status_code=400, detail="Invalid MLflow configuration: missing Databricks host")
+
+            # Update the config with the token from memory
+            mlflow_config.databricks_token = databricks_token
+
+            # Validate the effective model has a valid non-demo model
+            if not effective_model or effective_model == "demo":
+                raise HTTPException(
+                    status_code=400,
+                    detail="Cannot use MLflow evaluation with demo model. Select a real model (databricks-*, openai-*)",
+                )
+
+        # Calculate mode-based ground truth at the evaluate_prompt level for meaningful aggregation
+        from collections import Counter
+
+        # Group annotations by trace_id and calculate mode (most common rating) as ground truth
+        trace_ground_truth = {}
+        trace_objects = {}
+
+        for annotation in annotations:
+            trace_id = annotation.trace_id
+            if trace_id not in trace_ground_truth:
+                trace_ground_truth[trace_id] = []
+                # Get trace object
+                trace = self.db_service.get_trace(trace_id)
+                if trace:
+                    trace_objects[trace_id] = trace
+
+            trace_ground_truth[trace_id].append(annotation.rating)
+
+        # Calculate mode for each trace and create unique evaluations
+        unique_evaluations = []
+        for trace_id, ratings in trace_ground_truth.items():
+            if trace_id in trace_objects:
+                # Calculate mode (most common rating)
+                rating_counts = Counter(ratings)
+                mode_rating = rating_counts.most_common(1)[0][0]  # Most frequent rating
+
+                trace = trace_objects[trace_id]
+
+                # Evaluate using either MLflow or simulation
+                if use_mlflow:
+                    try:
+                        predicted_rating, reasoning = self._evaluate_with_mlflow(
+                            workshop_id, prompt, trace.input, trace.output, mlflow_config
+                        )
+                    except Exception as e:
+                        # Don't fallback - propagate the error
+                        raise HTTPException(status_code=503, detail=f"MLflow evaluation failed: {e!s}") from e
+                else:
+                    predicted_rating = self._simulate_judge_rating(
+                        prompt.prompt_text, trace.input, trace.output, mode_rating
+                    )
+                    reasoning = "Test judge evaluation (development mode)"
+
+                evaluation = JudgeEvaluation(
+                    id=str(uuid.uuid4()),
+                    workshop_id=workshop_id,
+                    prompt_id=evaluation_request.prompt_id,
+                    trace_id=trace_id,
+                    predicted_rating=predicted_rating,
+                    human_rating=mode_rating,  # Use mode-based ground truth
+                    confidence=None,  # Don't fake confidence values
+                    reasoning=reasoning,
+                )
+                unique_evaluations.append(evaluation)
+
+        # Store evaluations in database
+        self.db_service.store_judge_evaluations(unique_evaluations)
+
+        # Calculate performance metrics
+        metrics = self._calculate_performance_metrics(unique_evaluations)
+
+        # Update prompt with performance metrics
+        self.db_service.update_judge_prompt_metrics(evaluation_request.prompt_id, metrics.__dict__)
+
+        return metrics
+
+    def evaluate_prompt_direct(
+        self, workshop_id: str, evaluation_request: JudgeEvaluationDirectRequest
+    ) -> JudgeEvaluationResult:
+        """Evaluate a judge prompt without saving it to history."""
+        # Create a temporary prompt object for evaluation
+        from datetime import datetime
+
+        temp_prompt = JudgePrompt(
+            id="temp",  # Temporary ID
+            workshop_id=workshop_id,
+            prompt_text=evaluation_request.prompt_text,
+            version=0,  # Temporary version
+            few_shot_examples=[],
+            model_name=evaluation_request.model_name,
+            model_parameters=evaluation_request.model_parameters,
+            created_by="temp",
+            created_at=datetime.now(),
+            performance_metrics=None,
         )
-        unique_evaluations.append(evaluation)
 
-    # Store evaluations in database
-    self.db_service.store_judge_evaluations(unique_evaluations)
+        # Get annotations for evaluation
+        annotations = self.db_service.get_annotations(workshop_id)
+        if not annotations:
+            raise ValueError("No annotations found for evaluation")
 
-    # Calculate performance metrics
-    metrics = self._calculate_performance_metrics(unique_evaluations)
+        # Filter to specific traces if requested
+        if evaluation_request.trace_ids:
+            annotations = [a for a in annotations if a.trace_id in evaluation_request.trace_ids]
 
-    # Update prompt with performance metrics
-    self.db_service.update_judge_prompt_metrics(evaluation_request.prompt_id, metrics.__dict__)
+        # Use the model from the request
+        use_mlflow = evaluation_request.model_name != "demo" and MLFLOW_AVAILABLE
 
-    return metrics
-
-  def evaluate_prompt_direct(self, workshop_id: str, evaluation_request: JudgeEvaluationDirectRequest) -> JudgeEvaluationResult:
-    """Evaluate a judge prompt without saving it to history."""
-    # Create a temporary prompt object for evaluation
-    from datetime import datetime
-
-    temp_prompt = JudgePrompt(
-      id='temp',  # Temporary ID
-      workshop_id=workshop_id,
-      prompt_text=evaluation_request.prompt_text,
-      version=0,  # Temporary version
-      few_shot_examples=[],
-      model_name=evaluation_request.model_name,
-      model_parameters=evaluation_request.model_parameters,
-      created_by='temp',
-      created_at=datetime.now(),
-      performance_metrics=None,
-    )
-
-    # Get annotations for evaluation
-    annotations = self.db_service.get_annotations(workshop_id)
-    if not annotations:
-      raise ValueError('No annotations found for evaluation')
-
-    # Filter to specific traces if requested
-    if evaluation_request.trace_ids:
-      annotations = [a for a in annotations if a.trace_id in evaluation_request.trace_ids]
-
-    # Use the model from the request
-    use_mlflow = evaluation_request.model_name != 'demo' and MLFLOW_AVAILABLE
-
-    # Get MLflow configuration if needed
-    mlflow_config = None
-    if use_mlflow:
-      mlflow_config = self.db_service.get_mlflow_config(workshop_id)
-      if not mlflow_config:
-        raise HTTPException(
-          status_code=400,
-          detail='MLflow configuration required for AI judge evaluation. Configure in Intake phase.',
-        )
-
-      # Validate MLflow credentials before proceeding
-      if not mlflow_config.databricks_host or not mlflow_config.databricks_token:
-        raise HTTPException(status_code=400, detail='Invalid MLflow configuration: missing Databricks host or token')
-
-    # Calculate mode-based ground truth
-    from collections import Counter
-
-    # Group annotations by trace_id and calculate mode (most common rating) as ground truth
-    trace_ground_truth = {}
-    trace_objects = {}
-
-    for annotation in annotations:
-      trace_id = annotation.trace_id
-      if trace_id not in trace_ground_truth:
-        trace_ground_truth[trace_id] = []
-        # Get trace object
-        trace = self.db_service.get_trace(trace_id)
-        if trace:
-          trace_objects[trace_id] = trace
-
-      trace_ground_truth[trace_id].append(annotation.rating)
-
-    # Calculate mode for each trace and create unique evaluations
-    unique_evaluations = []
-    for trace_id, ratings in trace_ground_truth.items():
-      if trace_id in trace_objects:
-        # Calculate mode (most common rating)
-        rating_counts = Counter(ratings)
-        mode_rating = rating_counts.most_common(1)[0][0]
-
-        trace = trace_objects[trace_id]
-
-        # Evaluate using either MLflow or simulation
+        # Get MLflow configuration if needed
+        mlflow_config = None
         if use_mlflow:
-          try:
-            predicted_rating, reasoning = self._evaluate_with_mlflow(workshop_id, temp_prompt, trace.input, trace.output, mlflow_config)
-          except Exception as e:
-            raise HTTPException(status_code=503, detail=f'MLflow evaluation failed: {str(e)}')
-        else:
-          predicted_rating = self._simulate_judge_rating(temp_prompt.prompt_text, trace.input, trace.output, mode_rating)
-          reasoning = 'Test judge evaluation (development mode)'
+            mlflow_config = self.db_service.get_mlflow_config(workshop_id)
+            if not mlflow_config:
+                raise HTTPException(
+                    status_code=400,
+                    detail="MLflow configuration required for AI judge evaluation. Configure in Intake phase.",
+                )
 
-        evaluation = JudgeEvaluation(
-          id=str(uuid.uuid4()),
-          workshop_id=workshop_id,
-          prompt_id='temp',  # Temporary prompt ID
-          trace_id=trace_id,
-          predicted_rating=predicted_rating,
-          human_rating=mode_rating,
-          confidence=None,
-          reasoning=reasoning,
-        )
-        unique_evaluations.append(evaluation)
+            # Validate MLflow credentials before proceeding
+            if not mlflow_config.databricks_host or not mlflow_config.databricks_token:
+                raise HTTPException(
+                    status_code=400, detail="Invalid MLflow configuration: missing Databricks host or token"
+                )
 
-    # Calculate performance metrics (don't store evaluations)
-    metrics = self._calculate_performance_metrics(unique_evaluations)
-    metrics.prompt_id = 'temp'  # Set temporary prompt ID for metrics
+        # Calculate mode-based ground truth
+        from collections import Counter
 
-    # Return both metrics and evaluations for UI display
-    return JudgeEvaluationResult(metrics=metrics, evaluations=unique_evaluations)
+        # Group annotations by trace_id and calculate mode (most common rating) as ground truth
+        trace_ground_truth = {}
+        trace_objects = {}
 
-  def _evaluate_with_mlflow(self, workshop_id: str, prompt: JudgePrompt, input_text: str, output_text: str, mlflow_config) -> tuple[int, str]:
-    """Evaluate using real MLflow LLM judge."""
-    # Set up MLflow with Databricks credentials
-    os.environ['DATABRICKS_HOST'] = mlflow_config.databricks_host.rstrip('/')
-    os.environ['DATABRICKS_TOKEN'] = mlflow_config.databricks_token
+        for annotation in annotations:
+            trace_id = annotation.trace_id
+            if trace_id not in trace_ground_truth:
+                trace_ground_truth[trace_id] = []
+                # Get trace object
+                trace = self.db_service.get_trace(trace_id)
+                if trace:
+                    trace_objects[trace_id] = trace
 
-    # Validate credentials format
-    if not mlflow_config.databricks_host.startswith('https://'):
-      raise ValueError('Databricks host must start with https://')
-    if not mlflow_config.databricks_token.startswith('dapi'):
-      print(f"Warning: Databricks token should typically start with 'dapi'. Current token starts with: {mlflow_config.databricks_token[:10]}...")
+            trace_ground_truth[trace_id].append(annotation.rating)
 
-    # Initialize MLflow with proper experiment context
-    try:
-      # Use same method as intake service - "databricks" URI with environment variables
-      # This leverages databricks-sdk for authentication which works reliably
-      mlflow.set_tracking_uri('databricks')
+        # Calculate mode for each trace and create unique evaluations
+        unique_evaluations = []
+        for trace_id, ratings in trace_ground_truth.items():
+            if trace_id in trace_objects:
+                # Calculate mode (most common rating)
+                rating_counts = Counter(ratings)
+                mode_rating = rating_counts.most_common(1)[0][0]
 
-      # Use existing experiment from MLflow config instead of creating new ones
-      # NOTE: Default experiment ID '0' often requires special permissions in Databricks
-      if hasattr(mlflow_config, 'experiment_id') and mlflow_config.experiment_id:
-        # Use the experiment_id from intake config directly
-        experiment_id = mlflow_config.experiment_id
-      elif hasattr(mlflow_config, 'experiment_name') and mlflow_config.experiment_name:
-        experiment_name = mlflow_config.experiment_name
-        try:
-          experiment = mlflow.get_experiment_by_name(experiment_name)
-          if experiment:
-            experiment_id = experiment.experiment_id
-          else:
-            # Try to create experiment if it doesn't exist
-            experiment_id = mlflow.create_experiment(experiment_name)
-        except Exception as exp_err:
-          # Don't fall back to experiment '0' - it often has permission issues
-          error_msg = str(exp_err)
-          if 'PERMISSION_DENIED' in error_msg:
-            raise ValueError(
-              'Permission denied accessing MLflow experiments. Please configure an experiment in Intake phase with proper permissions.'
+                trace = trace_objects[trace_id]
+
+                # Evaluate using either MLflow or simulation
+                if use_mlflow:
+                    try:
+                        predicted_rating, reasoning = self._evaluate_with_mlflow(
+                            workshop_id, temp_prompt, trace.input, trace.output, mlflow_config
+                        )
+                    except Exception as e:
+                        raise HTTPException(status_code=503, detail=f"MLflow evaluation failed: {e!s}") from e
+                else:
+                    predicted_rating = self._simulate_judge_rating(
+                        temp_prompt.prompt_text, trace.input, trace.output, mode_rating
+                    )
+                    reasoning = "Test judge evaluation (development mode)"
+
+                evaluation = JudgeEvaluation(
+                    id=str(uuid.uuid4()),
+                    workshop_id=workshop_id,
+                    prompt_id="temp",  # Temporary prompt ID
+                    trace_id=trace_id,
+                    predicted_rating=predicted_rating,
+                    human_rating=mode_rating,
+                    confidence=None,
+                    reasoning=reasoning,
+                )
+                unique_evaluations.append(evaluation)
+
+        # Calculate performance metrics (don't store evaluations)
+        metrics = self._calculate_performance_metrics(unique_evaluations)
+        metrics.prompt_id = "temp"  # Set temporary prompt ID for metrics
+
+        # Return both metrics and evaluations for UI display
+        return JudgeEvaluationResult(metrics=metrics, evaluations=unique_evaluations)
+
+    def _evaluate_with_mlflow(
+        self, workshop_id: str, prompt: JudgePrompt, input_text: str, output_text: str, mlflow_config
+    ) -> tuple[int, str]:
+        """Evaluate using real MLflow LLM judge."""
+        # Set up MLflow with Databricks credentials
+        os.environ["DATABRICKS_HOST"] = mlflow_config.databricks_host.rstrip("/")
+        os.environ["DATABRICKS_TOKEN"] = mlflow_config.databricks_token
+
+        # Validate credentials format
+        if not mlflow_config.databricks_host.startswith("https://"):
+            raise ValueError("Databricks host must start with https://")
+        if not mlflow_config.databricks_token.startswith("dapi"):
+            print(
+                f"Warning: Databricks token should typically start with 'dapi'. Current token starts with: {mlflow_config.databricks_token[:10]}..."
             )
-          else:
-            raise ValueError(f"Could not access experiment '{experiment_name}': {error_msg}")
-      else:
-        # Don't default to experiment '0' - require explicit config
-        raise ValueError('No MLflow experiment configured. Please configure an experiment ID in the Intake phase.')
 
-      mlflow.set_experiment(experiment_id=experiment_id)
+        # Initialize MLflow with proper experiment context
+        try:
+            # Use same method as intake service - "databricks" URI with environment variables
+            # This leverages databricks-sdk for authentication which works reliably
+            mlflow.set_tracking_uri("databricks")
 
-      # Test the connection by trying to get experiment info
-      try:
-        current_exp = mlflow.get_experiment(experiment_id)
-        print(f'Successfully connected to MLflow experiment: {current_exp.name if current_exp else "Default"}')
-      except Exception as test_err:
-        print(f'Warning: Could not verify MLflow experiment connection: {test_err}')
+            # Use existing experiment from MLflow config instead of creating new ones
+            # NOTE: Default experiment ID '0' often requires special permissions in Databricks
+            if hasattr(mlflow_config, "experiment_id") and mlflow_config.experiment_id:
+                # Use the experiment_id from intake config directly
+                experiment_id = mlflow_config.experiment_id
+            elif hasattr(mlflow_config, "experiment_name") and mlflow_config.experiment_name:
+                experiment_name = mlflow_config.experiment_name
+                try:
+                    experiment = mlflow.get_experiment_by_name(experiment_name)
+                    if experiment:
+                        experiment_id = experiment.experiment_id
+                    else:
+                        # Try to create experiment if it doesn't exist
+                        experiment_id = mlflow.create_experiment(experiment_name)
+                except Exception as exp_err:
+                    # Don't fall back to experiment '0' - it often has permission issues
+                    error_msg = str(exp_err)
+                    if "PERMISSION_DENIED" in error_msg:
+                        raise ValueError(
+                            "Permission denied accessing MLflow experiments. Please configure an experiment in Intake phase with proper permissions."
+                        ) from exp_err
+                    raise ValueError(f"Could not access experiment '{experiment_name}': {error_msg}") from exp_err
+            else:
+                # Don't default to experiment '0' - require explicit config
+                raise ValueError(
+                    "No MLflow experiment configured. Please configure an experiment ID in the Intake phase."
+                )
 
-    except Exception as e:
-      # Provide helpful error messages for common issues
-      error_msg = str(e)
-      if '401' in error_msg or 'credential' in error_msg.lower():
-        raise ValueError(f'MLflow authentication failed. Please check your Databricks token. Error: {error_msg}')
-      elif '404' in error_msg or 'not found' in error_msg.lower():
-        raise ValueError(f'MLflow tracking server not found. Please verify your Databricks host URL. Error: {error_msg}')
-      elif 'databricks-sdk' in error_msg:
-        raise ValueError(f'Databricks SDK authentication issue. Using direct URL method but got: {error_msg}')
-      else:
-        raise ValueError(f'Failed to initialize MLflow experiment: {error_msg}')
+            mlflow.set_experiment(experiment_id=experiment_id)
 
-    # Determine model URI based on model name
-    if prompt.model_name.startswith('databricks-'):
-      model_uri = f'databricks:/{prompt.model_name}'
-    elif prompt.model_name.startswith('openai-'):
-      model_name = prompt.model_name.replace('openai-', '')
-      model_uri = f'openai:/{model_name}'
-    else:
-      raise ValueError(f'Unsupported model: {prompt.model_name}')
+            # Test the connection by trying to get experiment info
+            try:
+                current_exp = mlflow.get_experiment(experiment_id)
+                print(f"Successfully connected to MLflow experiment: {current_exp.name if current_exp else 'Default'}")
+            except Exception as test_err:
+                print(f"Warning: Could not verify MLflow experiment connection: {test_err}")
 
-    # MLflow expects the prompt TEMPLATE with placeholders, not a formatted prompt
-    # Replace {input} with {inputs} and {output} with {outputs} for MLflow compatibility
-    mlflow_prompt_template = prompt.prompt_text.replace('{input}', '{inputs}').replace('{output}', '{outputs}')
+        except Exception as e:
+            # Provide helpful error messages for common issues
+            error_msg = str(e)
+            if "401" in error_msg or "credential" in error_msg.lower():
+                raise ValueError(
+                    f"MLflow authentication failed. Please check your Databricks token. Error: {error_msg}"
+                ) from e
+            if "404" in error_msg or "not found" in error_msg.lower():
+                raise ValueError(
+                    f"MLflow tracking server not found. Please verify your Databricks host URL. Error: {error_msg}"
+                ) from e
+            if "databricks-sdk" in error_msg:
+                raise ValueError(f"Databricks SDK authentication issue. Using direct URL method but got: {error_msg}") from e
+            raise ValueError(f"Failed to initialize MLflow experiment: {error_msg}") from e
 
-    # Create the metric with the TEMPLATE (MLflow will do the formatting)
-    try:
-      metric = make_genai_metric_from_prompt(
-        name='workshop_judge',
-        judge_prompt=mlflow_prompt_template,  # Pass template, not formatted prompt!
-        model=model_uri,
-        parameters=prompt.model_parameters or {'temperature': 0.0, 'max_tokens': 10},
-      )
-    except Exception as e:
-      raise ValueError(f'Failed to create MLflow metric: {str(e)}')
+        # Determine model URI based on model name
+        if prompt.model_name.startswith("databricks-"):
+            model_uri = f"databricks:/{prompt.model_name}"
+        elif prompt.model_name.startswith("openai-"):
+            model_name = prompt.model_name.replace("openai-", "")
+            model_uri = f"openai:/{model_name}"
+        else:
+            raise ValueError(f"Unsupported model: {prompt.model_name}")
 
-    # Evaluate single trace using MLflow
-    import pandas as pd
+        # MLflow expects the prompt TEMPLATE with placeholders, not a formatted prompt
+        # Replace {input} with {inputs} and {output} with {outputs} for MLflow compatibility
+        mlflow_prompt_template = prompt.prompt_text.replace("{input}", "{inputs}").replace("{output}", "{outputs}")
 
-    # Create single-row evaluation dataset
-    # Use 'input' and 'output' (singular) as column names
-    eval_df = pd.DataFrame([{'input': input_text, 'output': output_text}])
+        # Create the metric with the TEMPLATE (MLflow will do the formatting)
+        try:
+            metric = make_genai_metric_from_prompt(
+                name="workshop_judge",
+                judge_prompt=mlflow_prompt_template,  # Pass template, not formatted prompt!
+                model=model_uri,
+                parameters=prompt.model_parameters or {"temperature": 0.0, "max_tokens": 10},
+            )
+        except Exception as e:
+            raise ValueError(f"Failed to create MLflow metric: {e!s}") from e
 
-    try:
-      # Run MLflow evaluation with explicit column mapping
-      results = mlflow.evaluate(
-        data=eval_df,
-        predictions='output',
-        model_type='text',
-        extra_metrics=[metric],
-        evaluator_config={
-          'col_mapping': {
-            'inputs': 'input',  # Map 'inputs' in prompt to 'input' column
-            'outputs': 'output',  # Map 'outputs' in prompt to 'output' column
-          }
-        },
-      )
-    except Exception as e:
-      raise ValueError(f'MLflow evaluation failed: {str(e)}')
+        # Evaluate single trace using MLflow
+        import pandas as pd
 
-    # Extract rating from results - fail explicitly if not found
-    if not hasattr(results, 'metrics') or not results.metrics:
-      raise ValueError('MLflow evaluation returned no metrics')
+        # Create single-row evaluation dataset
+        # Use 'input' and 'output' (singular) as column names
+        eval_df = pd.DataFrame([{"input": input_text, "output": output_text}])
 
-    metric_results = results.metrics
+        try:
+            # Run MLflow evaluation with explicit column mapping
+            results = mlflow.evaluate(
+                data=eval_df,
+                predictions="output",
+                model_type="text",
+                extra_metrics=[metric],
+                evaluator_config={
+                    "col_mapping": {
+                        "inputs": "input",  # Map 'inputs' in prompt to 'input' column
+                        "outputs": "output",  # Map 'outputs' in prompt to 'output' column
+                    }
+                },
+            )
+        except Exception as e:
+            raise ValueError(f"MLflow evaluation failed: {e!s}") from e
 
-    # Debug: Log what MLflow returned
-    print(f'MLflow metrics available: {list(metric_results.keys())}')
-    print(f'Full metrics: {metric_results}')
+        # Extract rating from results - fail explicitly if not found
+        if not hasattr(results, "metrics") or not results.metrics:
+            raise ValueError("MLflow evaluation returned no metrics")
 
-    # Look for the specific workshop_judge/mean key
-    expected_key = 'workshop_judge/mean'
+        metric_results = results.metrics
 
-    if expected_key not in metric_results:
-      # Log all available keys for debugging
-      available_keys = list(metric_results.keys())
-      raise ValueError(
-        f"Expected '{expected_key}' not found in MLflow results. "
-        f'Available keys: {available_keys}. '
-        f'This indicates either a bug in our metric creation or an MLflow API change.'
-      )
+        # Debug: Log what MLflow returned
+        print(f"MLflow metrics available: {list(metric_results.keys())}")
+        print(f"Full metrics: {metric_results}")
 
-    score = metric_results[expected_key]
-    print(f'MLflow score for trace: {score}')
+        # Look for the specific workshop_judge/mean key
+        expected_key = "workshop_judge/mean"
 
-    # Validate score is numeric (but don't assume range - user controls this)
-    if not isinstance(score, (int, float)):
-      raise ValueError(f'Expected numeric score, got {type(score)}: {score}')
+        if expected_key not in metric_results:
+            # Log all available keys for debugging
+            available_keys = list(metric_results.keys())
+            raise ValueError(
+                f"Expected '{expected_key}' not found in MLflow results. "
+                f"Available keys: {available_keys}. "
+                f"This indicates either a bug in our metric creation or an MLflow API change."
+            )
 
-    # Check for NaN values which can occur if MLflow evaluation fails
-    import math
+        score = metric_results[expected_key]
+        print(f"MLflow score for trace: {score}")
 
-    if math.isnan(score):
-      raise ValueError(
-        'MLflow returned NaN for the judge score. This typically means the LLM could not parse a numeric rating from the response. '
-        'Check the MLflow run at the Databricks URL in the logs to see the actual LLM response. '
-        'Make sure your judge prompt clearly instructs the model to return a numeric rating.'
-      )
+        # Validate score is numeric (but don't assume range - user controls this)
+        if not isinstance(score, (int, float)):
+            raise ValueError(f"Expected numeric score, got {type(score)}: {score}")
 
-    # Convert to integer rating (user's prompt should produce appropriate range)
-    rating = int(round(score))
-    reasoning = f'MLflow judge evaluation (score: {score:.2f})'
+        # Check for NaN values which can occur if MLflow evaluation fails
+        import math
 
-    return rating, reasoning
+        if math.isnan(score):
+            raise ValueError(
+                "MLflow returned NaN for the judge score. This typically means the LLM could not parse a numeric rating from the response. "
+                "Check the MLflow run at the Databricks URL in the logs to see the actual LLM response. "
+                "Make sure your judge prompt clearly instructs the model to return a numeric rating."
+            )
 
-  def _simulate_judge_rating(self, prompt: str, input_text: str, output_text: str, human_rating: int) -> int:
-    """Simulate an LLM judge rating for demo mode."""
-    # Baseline simulation: GPT-3.5-level performance
-    # Creates ~70-80% correlation with human ratings
-    base_rating = human_rating
+        # Convert to integer rating (user's prompt should produce appropriate range)
+        rating = round(score)
+        reasoning = f"MLflow judge evaluation (score: {score:.2f})"
 
-    # Simulate systematic bias: baseline judge tends to be slightly more lenient
-    bias = 0.3  # Slight upward bias
+        return rating, reasoning
 
-    # Add variation based on prompt quality
-    if 'specific' in prompt.lower() or 'detailed' in prompt.lower():
-      # Better prompts have higher correlation (simulating GPT-4 level)
-      variation = random.choice([-1, 0, 0, 0, 1])
-    else:
-      # Basic prompts have more variation (simulating GPT-3.5 level)
-      variation = random.choice([-2, -1, 0, 1, 2])
+    def _simulate_judge_rating(self, prompt: str, input_text: str, output_text: str, human_rating: int) -> int:
+        """Simulate an LLM judge rating for demo mode."""
+        # Baseline simulation: GPT-3.5-level performance
+        # Creates ~70-80% correlation with human ratings
+        base_rating = human_rating
 
-    # Add occasional random noise (10% chance of bigger disagreement)
-    noise = random.choice([-1, 0, 1]) if random.random() < 0.1 else 0
+        # Simulate systematic bias: baseline judge tends to be slightly more lenient
+        bias = 0.3  # Slight upward bias
 
-    # Calculate final rating
-    predicted_raw = base_rating + bias + variation + noise
-    predicted = max(1, min(5, round(predicted_raw)))
+        # Add variation based on prompt quality
+        if "specific" in prompt.lower() or "detailed" in prompt.lower():
+            # Better prompts have higher correlation (simulating GPT-4 level)
+            variation = random.choice([-1, 0, 0, 0, 1])
+        else:
+            # Basic prompts have more variation (simulating GPT-3.5 level)
+            variation = random.choice([-2, -1, 0, 1, 2])
 
-    return predicted
+        # Add occasional random noise (10% chance of bigger disagreement)
+        noise = random.choice([-1, 0, 1]) if random.random() < 0.1 else 0
 
-  def _calculate_performance_metrics(self, evaluations: List[JudgeEvaluation]) -> JudgePerformanceMetrics:
-    """Calculate performance metrics for judge evaluations."""
-    if not evaluations:
-      raise ValueError('No evaluations to calculate metrics from')
+        # Calculate final rating
+        predicted_raw = base_rating + bias + variation + noise
+        predicted = max(1, min(5, round(predicted_raw)))
 
-    human_ratings = [e.human_rating for e in evaluations]
-    predicted_ratings = [e.predicted_rating for e in evaluations]
+        return predicted
 
-    # Debug logging
-    print(f'🔍 Calculating metrics for {len(evaluations)} evaluations')
-    print(f'🔍 Human ratings: {human_ratings}')
-    print(f'🔍 Predicted ratings: {predicted_ratings}')
-    print(f'🔍 Human ratings variance: {np.var(human_ratings)}')
-    print(f'🔍 Predicted ratings variance: {np.var(predicted_ratings)}')
+    def _calculate_performance_metrics(self, evaluations: list[JudgeEvaluation]) -> JudgePerformanceMetrics:
+        """Calculate performance metrics for judge evaluations."""
+        if not evaluations:
+            raise ValueError("No evaluations to calculate metrics from")
 
-    # Calculate Cohen's kappa (inter-rater reliability for categorical data)
-    try:
-      kappa = cohen_kappa_score(human_ratings, predicted_ratings)
-      print(f"🔍 Cohen's kappa: {kappa}")
+        human_ratings = [e.human_rating for e in evaluations]
+        predicted_ratings = [e.predicted_rating for e in evaluations]
 
-      # Handle edge cases where kappa might be NaN or undefined
-      if np.isnan(kappa):
-        # Fallback to simple agreement when kappa is undefined
-        matches = sum(1 for h, p in zip(human_ratings, predicted_ratings) if h == p)
-        kappa = matches / len(evaluations)  # Simple agreement ratio
-        print(f'🔍 Kappa undefined, using agreement ratio: {kappa}')
-    except Exception as e:
-      # If kappa calculation fails for any reason, use simple agreement
-      print(f'🔍 Kappa calculation failed: {e}, using agreement ratio')
-      matches = sum(1 for h, p in zip(human_ratings, predicted_ratings) if h == p)
-      kappa = matches / len(evaluations)  # Simple agreement ratio
+        # Debug logging
+        print(f"🔍 Calculating metrics for {len(evaluations)} evaluations")
+        print(f"🔍 Human ratings: {human_ratings}")
+        print(f"🔍 Predicted ratings: {predicted_ratings}")
+        print(f"🔍 Human ratings variance: {np.var(human_ratings)}")
+        print(f"🔍 Predicted ratings variance: {np.var(predicted_ratings)}")
 
-    # Calculate accuracy (exact match)
-    accuracy = accuracy_score(human_ratings, predicted_ratings)
+        # Calculate Cohen's kappa (inter-rater reliability for categorical data)
+        try:
+            kappa = cohen_kappa_score(human_ratings, predicted_ratings)
+            print(f"🔍 Cohen's kappa: {kappa}")
 
-    # Calculate agreement by rating level
-    agreement_by_rating = {}
-    for rating in range(1, 6):
-      human_at_rating = [h for h, p in zip(human_ratings, predicted_ratings) if h == rating]
-      predicted_at_rating = [p for h, p in zip(human_ratings, predicted_ratings) if h == rating]
-      if human_at_rating:
-        agreement_by_rating[str(rating)] = accuracy_score(human_at_rating, predicted_at_rating)
-      else:
-        agreement_by_rating[str(rating)] = 0.0
+            # Handle edge cases where kappa might be NaN or undefined
+            if np.isnan(kappa):
+                # Fallback to simple agreement when kappa is undefined
+                matches = sum(1 for h, p in zip(human_ratings, predicted_ratings, strict=False) if h == p)
+                kappa = matches / len(evaluations)  # Simple agreement ratio
+                print(f"🔍 Kappa undefined, using agreement ratio: {kappa}")
+        except Exception as e:
+            # If kappa calculation fails for any reason, use simple agreement
+            print(f"🔍 Kappa calculation failed: {e}, using agreement ratio")
+            matches = sum(1 for h, p in zip(human_ratings, predicted_ratings, strict=False) if h == p)
+            kappa = matches / len(evaluations)  # Simple agreement ratio
 
-    # Calculate confusion matrix
-    cm = confusion_matrix(human_ratings, predicted_ratings, labels=[1, 2, 3, 4, 5])
+        # Calculate accuracy (exact match)
+        accuracy = accuracy_score(human_ratings, predicted_ratings)
 
-    return JudgePerformanceMetrics(
-      prompt_id=evaluations[0].prompt_id,
-      correlation=float(kappa) if not np.isnan(kappa) else 0.0,  # Using kappa instead of correlation
-      accuracy=float(accuracy),
-      mean_absolute_error=0.0,  # Deprecated, kept for backwards compatibility
-      agreement_by_rating=agreement_by_rating,
-      confusion_matrix=cm.tolist(),
-      total_evaluations=len(evaluations),
-    )
+        # Calculate agreement by rating level
+        agreement_by_rating = {}
+        for rating in range(1, 6):
+            human_at_rating = [h for h, p in zip(human_ratings, predicted_ratings, strict=False) if h == rating]
+            predicted_at_rating = [p for h, p in zip(human_ratings, predicted_ratings, strict=False) if h == rating]
+            if human_at_rating:
+                agreement_by_rating[str(rating)] = accuracy_score(human_at_rating, predicted_at_rating)
+            else:
+                agreement_by_rating[str(rating)] = 0.0
 
-  def export_judge(self, workshop_id: str, export_config: JudgeExportConfig) -> Dict[str, Any]:
-    """Export a judge configuration for production use."""
-    # Get the prompt
-    prompt = self.db_service.get_judge_prompt(workshop_id, export_config.prompt_id)
-    if not prompt:
-      raise ValueError(f'Judge prompt {export_config.prompt_id} not found')
+        # Calculate confusion matrix
+        cm = confusion_matrix(human_ratings, predicted_ratings, labels=[1, 2, 3, 4, 5])
 
-    # Get rubric for context
-    rubric = self.db_service.get_rubric(workshop_id)
+        return JudgePerformanceMetrics(
+            prompt_id=evaluations[0].prompt_id,
+            correlation=float(kappa) if not np.isnan(kappa) else 0.0,  # Using kappa instead of correlation
+            accuracy=float(accuracy),
+            mean_absolute_error=0.0,  # Deprecated, kept for backwards compatibility
+            agreement_by_rating=agreement_by_rating,
+            confusion_matrix=cm.tolist(),
+            total_evaluations=len(evaluations),
+        )
 
-    # Get few-shot examples if requested
-    few_shot_examples = []
-    if export_config.include_examples and prompt.few_shot_examples:
-      for trace_id in prompt.few_shot_examples:
-        trace = self.db_service.get_trace(trace_id)
-        annotations = self.db_service.get_annotations(workshop_id, user_id=None)
-        trace_annotations = [a for a in annotations if a.trace_id == trace_id]
+    def export_judge(self, workshop_id: str, export_config: JudgeExportConfig) -> dict[str, Any]:
+        """Export a judge configuration for production use."""
+        # Get the prompt
+        prompt = self.db_service.get_judge_prompt(workshop_id, export_config.prompt_id)
+        if not prompt:
+            raise ValueError(f"Judge prompt {export_config.prompt_id} not found")
 
-        if trace and trace_annotations:
-          # Use the most common rating if multiple annotations
-          ratings = [a.rating for a in trace_annotations]
-          most_common_rating = max(set(ratings), key=ratings.count)
+        # Get rubric for context
+        rubric = self.db_service.get_rubric(workshop_id)
 
-          few_shot_examples.append(
-            {
-              'input': trace.input,
-              'output': trace.output,
-              'rating': most_common_rating,
-              'reasoning': f'This response rates {most_common_rating}/5 based on the evaluation criteria.',
+        # Get few-shot examples if requested
+        few_shot_examples = []
+        if export_config.include_examples and prompt.few_shot_examples:
+            for trace_id in prompt.few_shot_examples:
+                trace = self.db_service.get_trace(trace_id)
+                annotations = self.db_service.get_annotations(workshop_id, user_id=None)
+                trace_annotations = [a for a in annotations if a.trace_id == trace_id]
+
+                if trace and trace_annotations:
+                    # Use the most common rating if multiple annotations
+                    ratings = [a.rating for a in trace_annotations]
+                    most_common_rating = max(set(ratings), key=ratings.count)
+
+                    few_shot_examples.append(
+                        {
+                            "input": trace.input,
+                            "output": trace.output,
+                            "rating": most_common_rating,
+                            "reasoning": f"This response rates {most_common_rating}/5 based on the evaluation criteria.",
+                        }
+                    )
+
+        # Format based on export type
+        if export_config.export_format == "json":
+            return {
+                "judge_config": {
+                    "prompt": prompt.prompt_text,
+                    "rubric_question": rubric.question if rubric else None,
+                    "few_shot_examples": few_shot_examples,
+                    "rating_scale": "1-5",
+                    "performance_metrics": prompt.performance_metrics,
+                },
+                "metadata": {
+                    "workshop_id": workshop_id,
+                    "prompt_id": prompt.id,
+                    "version": prompt.version,
+                    "created_at": prompt.created_at.isoformat(),
+                    "created_by": prompt.created_by,
+                },
             }
-          )
 
-    # Format based on export type
-    if export_config.export_format == 'json':
-      return {
-        'judge_config': {
-          'prompt': prompt.prompt_text,
-          'rubric_question': rubric.question if rubric else None,
-          'few_shot_examples': few_shot_examples,
-          'rating_scale': '1-5',
-          'performance_metrics': prompt.performance_metrics,
-        },
-        'metadata': {
-          'workshop_id': workshop_id,
-          'prompt_id': prompt.id,
-          'version': prompt.version,
-          'created_at': prompt.created_at.isoformat(),
-          'created_by': prompt.created_by,
-        },
-      }
+        if export_config.export_format == "python":
+            # Generate Python code for MLflow
+            model_str = (
+                f"'{prompt.model_name}'" if prompt.model_name != "demo" else "'databricks-dbrx-instruct'"
+            )  # Default to DBRX
 
-    elif export_config.export_format == 'python':
-      # Generate Python code for MLflow
-      model_str = f"'{prompt.model_name}'" if prompt.model_name != 'demo' else "'databricks-dbrx-instruct'"  # Default to DBRX
-
-      python_code = f'''
+            python_code = f'''
 """
 MLflow Judge Metric
 Generated from Workshop: {workshop_id}
 Prompt Version: {prompt.version}
 Model: {prompt.model_name}
-Performance: {prompt.performance_metrics.get('correlation', 0) * 100:.1f}% correlation with human ratings
+Performance: {prompt.performance_metrics.get("correlation", 0) * 100:.1f}% correlation with human ratings
 """
 
 import mlflow
@@ -584,7 +606,7 @@ JUDGE_PROMPT = """{prompt.prompt_text}"""
 
 # Model configuration
 MODEL_NAME = {model_str}
-MODEL_PARAMETERS = {json.dumps(prompt.model_parameters or {'temperature': 0.0, 'max_tokens': 10}, indent=4)}
+MODEL_PARAMETERS = {json.dumps(prompt.model_parameters or {"temperature": 0.0, "max_tokens": 10}, indent=4)}
 
 # Create the judge metric
 judge_metric = make_genai_metric_from_prompt(
@@ -606,101 +628,100 @@ judge_metric = make_genai_metric_from_prompt(
 # Few-shot examples from workshop:
 examples = {json.dumps(few_shot_examples[:3], indent=4)}
 '''
-      return {'code': python_code, 'filename': f'mlflow_judge_{prompt.version}.py'}
+            return {"code": python_code, "filename": f"mlflow_judge_{prompt.version}.py"}
 
-    elif export_config.export_format == 'mlflow' or export_config.export_format == 'json':
-      # Generate MLflow metric configuration
-      return {
-        'mlflow_metric': {
-          'metric_name': f'workshop_judge_v{prompt.version}',
-          'prompt_template': prompt.prompt_text,
-          'model': prompt.model_name,
-          'model_parameters': prompt.model_parameters or {'temperature': 0.0, 'max_tokens': 10},
-          'few_shot_examples': few_shot_examples,
-          'performance_metrics': prompt.performance_metrics,
-        },
-        'metadata': {
-          'workshop_id': workshop_id,
-          'prompt_id': prompt.id,
-          'version': prompt.version,
-          'created_at': prompt.created_at.isoformat(),
-          'created_by': prompt.created_by,
-        },
-      }
+        if export_config.export_format == "mlflow" or export_config.export_format == "json":
+            # Generate MLflow metric configuration
+            return {
+                "mlflow_metric": {
+                    "metric_name": f"workshop_judge_v{prompt.version}",
+                    "prompt_template": prompt.prompt_text,
+                    "model": prompt.model_name,
+                    "model_parameters": prompt.model_parameters or {"temperature": 0.0, "max_tokens": 10},
+                    "few_shot_examples": few_shot_examples,
+                    "performance_metrics": prompt.performance_metrics,
+                },
+                "metadata": {
+                    "workshop_id": workshop_id,
+                    "prompt_id": prompt.id,
+                    "version": prompt.version,
+                    "created_at": prompt.created_at.isoformat(),
+                    "created_by": prompt.created_by,
+                },
+            }
 
-    elif export_config.export_format == 'notebook':
-      # Generate Databricks notebook format
-      notebook_content = {
-        'version': '1',
-        'cells': [
-          {
-            'cell_type': 'markdown',
-            'source': f"""# MLflow Judge from Workshop\n\nThis judge was trained on {len(few_shot_examples)}
-            annotated examples with {(prompt.performance_metrics.get('correlation', 0) * 100):.1f}%
-            correlation to human ratings.""",  # noqa: E501
-          },
-          {
-            'cell_type': 'code',
-            'source': """# Install dependencies\n%pip install mlflow[genai]>=2.0\ndbutils.library.restartPython()""",
-          },
-          {
-            'cell_type': 'code',
-            'source': f"""import mlflow\nfrom mlflow.metrics.genai import make_genai_metric_from_prompt\nimport pandas as pd\n\n
+        if export_config.export_format == "notebook":
+            # Generate Databricks notebook format
+            notebook_content = {
+                "version": "1",
+                "cells": [
+                    {
+                        "cell_type": "markdown",
+                        "source": f"""# MLflow Judge from Workshop\n\nThis judge was trained on {len(few_shot_examples)}
+            annotated examples with {(prompt.performance_metrics.get("correlation", 0) * 100):.1f}%
+            correlation to human ratings.""",
+                    },
+                    {
+                        "cell_type": "code",
+                        "source": """# Install dependencies\n%pip install mlflow[genai]>=2.0\ndbutils.library.restartPython()""",
+                    },
+                    {
+                        "cell_type": "code",
+                        "source": f"""import mlflow\nfrom mlflow.metrics.genai import make_genai_metric_from_prompt\nimport pandas as pd\n\n
             # Judge configuration\nJUDGE_PROMPT = \"\"\"{prompt.prompt_text}\"\"\"\n\nMODEL_NAME = '{prompt.model_name}'\n
-            # MODEL_PARAMETERS = {json.dumps(prompt.model_parameters or {'temperature': 0.0})}""",  # noqa: E501
-          },
-          {
-            'cell_type': 'code',
-            'source': """# Create the judge metric\njudge_metric = make_genai_metric_from_prompt(\n    judge_prompt=JUDGE_PROMPT,\n
-            model=MODEL_NAME,\n    parameters=MODEL_PARAMETERS\n)""",  # noqa: E501
-          },
-          {
-            'cell_type': 'code',
-            'source': """# Example evaluation\neval_df = pd.DataFrame([\n
+            # MODEL_PARAMETERS = {json.dumps(prompt.model_parameters or {"temperature": 0.0})}""",
+                    },
+                    {
+                        "cell_type": "code",
+                        "source": """# Create the judge metric\njudge_metric = make_genai_metric_from_prompt(\n    judge_prompt=JUDGE_PROMPT,\n
+            model=MODEL_NAME,\n    parameters=MODEL_PARAMETERS\n)""",
+                    },
+                    {
+                        "cell_type": "code",
+                        "source": """# Example evaluation\neval_df = pd.DataFrame([\n
             {{"input": "What is MLflow?", "output": "MLflow is an open-source platform for ML lifecycle management."}},\n
             {{"input": "Explain transformers", "output": "Transformers are a neural network architecture..."}}\n])
             \n\nresults = mlflow.evaluate(\n    data=eval_df,\n    predictions="output",\n    model_type="text",\n
-            extra_metrics=[judge_metric]\n)\n\nprint(results.metrics)\nresults.tables['eval_results_table'].show()""",  # noqa: E501
-          },
-        ],
-      }
-      return {
-        'notebook': notebook_content,
-        'filename': f'mlflow_judge_workshop_{prompt.version}.ipynb',
-      }
+            extra_metrics=[judge_metric]\n)\n\nprint(results.metrics)\nresults.tables['eval_results_table'].show()""",
+                    },
+                ],
+            }
+            return {
+                "notebook": notebook_content,
+                "filename": f"mlflow_judge_workshop_{prompt.version}.ipynb",
+            }
 
-    else:
-      raise ValueError(f'Unsupported export format: {export_config.export_format}')
+        raise ValueError(f"Unsupported export format: {export_config.export_format}")
 
-  def select_few_shot_examples(self, workshop_id: str, num_examples: int = 3) -> List[str]:
-    """Intelligently select few-shot examples from annotations."""
-    annotations = self.db_service.get_annotations(workshop_id)
+    def select_few_shot_examples(self, workshop_id: str, num_examples: int = 3) -> list[str]:
+        """Intelligently select few-shot examples from annotations."""
+        annotations = self.db_service.get_annotations(workshop_id)
 
-    if len(annotations) < num_examples:
-      return [a.trace_id for a in annotations]
+        if len(annotations) < num_examples:
+            return [a.trace_id for a in annotations]
 
-    # Group by rating to get diverse examples
-    by_rating = {}
-    for annotation in annotations:
-      if annotation.rating not in by_rating:
-        by_rating[annotation.rating] = []
-      by_rating[annotation.rating].append(annotation)
+        # Group by rating to get diverse examples
+        by_rating = {}
+        for annotation in annotations:
+            if annotation.rating not in by_rating:
+                by_rating[annotation.rating] = []
+            by_rating[annotation.rating].append(annotation)
 
-    selected = []
-    ratings = sorted(by_rating.keys())
+        selected = []
+        ratings = sorted(by_rating.keys())
 
-    # Try to get examples from different rating levels
-    for rating in ratings:
-      if len(selected) >= num_examples:
-        break
-      # Select one example from this rating level
-      examples_at_rating = by_rating[rating]
-      selected.append(random.choice(examples_at_rating).trace_id)
+        # Try to get examples from different rating levels
+        for rating in ratings:
+            if len(selected) >= num_examples:
+                break
+            # Select one example from this rating level
+            examples_at_rating = by_rating[rating]
+            selected.append(random.choice(examples_at_rating).trace_id)
 
-    # Fill remaining slots randomly if needed
-    remaining_annotations = [a for a in annotations if a.trace_id not in selected]
-    while len(selected) < num_examples and remaining_annotations:
-      selected.append(random.choice(remaining_annotations).trace_id)
-      remaining_annotations = [a for a in remaining_annotations if a.trace_id != selected[-1]]
+        # Fill remaining slots randomly if needed
+        remaining_annotations = [a for a in annotations if a.trace_id not in selected]
+        while len(selected) < num_examples and remaining_annotations:
+            selected.append(random.choice(remaining_annotations).trace_id)
+            remaining_annotations = [a for a in remaining_annotations if a.trace_id != selected[-1]]
 
-    return selected
+        return selected

--- a/server/services/krippendorff_alpha.py
+++ b/server/services/krippendorff_alpha.py
@@ -16,345 +16,340 @@ Where:
 
 import logging
 from collections import defaultdict
-from typing import Dict, List, Tuple
 
 from server.models import Annotation
 
 logger = logging.getLogger(__name__)
 
 
-def get_unique_question_ids(annotations: List[Annotation]) -> List[str]:
-  """Extract all unique question IDs from annotations.
-  
-  Args:
-      annotations: List of annotations
-      
-  Returns:
-      List of unique question IDs found in the annotations
-  """
-  question_ids = set()
-  for annotation in annotations:
-    if annotation.ratings:
-      question_ids.update(annotation.ratings.keys())
-  return sorted(list(question_ids))
+def get_unique_question_ids(annotations: list[Annotation]) -> list[str]:
+    """Extract all unique question IDs from annotations.
+
+    Args:
+        annotations: List of annotations
+
+    Returns:
+        List of unique question IDs found in the annotations
+    """
+    question_ids = set()
+    for annotation in annotations:
+        if annotation.ratings:
+            question_ids.update(annotation.ratings.keys())
+    return sorted(question_ids)
 
 
-def calculate_krippendorff_alpha_per_metric(annotations: List[Annotation]) -> Dict[str, float]:
-  """Calculate Krippendorff's Alpha for each metric/question separately.
-  
-  Args:
-      annotations: List of annotations with multiple ratings
-      
-  Returns:
-      Dict mapping question_id to Krippendorff's Alpha score
-  """
-  question_ids = get_unique_question_ids(annotations)
-  
-  if not question_ids:
-    # No ratings dictionary found - annotations are using old format
-    logger.warning("No ratings dictionary found in annotations. Cannot calculate per-metric IRR.")
-    return {}
-  
-  logger.info(f"🔍 Calculating IRR for {len(question_ids)} metrics: {question_ids}")
-  logger.info(f"🔍 Sample annotation ratings: {annotations[0].ratings if annotations else 'No annotations'}")
-  
-  results = {}
-  for question_id in question_ids:
-    try:
-      alpha = calculate_krippendorff_alpha(annotations, question_id=question_id)
-      results[question_id] = alpha
-      logger.info(f"✅ IRR for {question_id}: {alpha:.3f}")
-    except Exception as e:
-      logger.warning(f"Failed to calculate IRR for question {question_id}: {e}")
-      results[question_id] = 0.0
-  
-  return results
+def calculate_krippendorff_alpha_per_metric(annotations: list[Annotation]) -> dict[str, float]:
+    """Calculate Krippendorff's Alpha for each metric/question separately.
+
+    Args:
+        annotations: List of annotations with multiple ratings
+
+    Returns:
+        Dict mapping question_id to Krippendorff's Alpha score
+    """
+    question_ids = get_unique_question_ids(annotations)
+
+    if not question_ids:
+        # No ratings dictionary found - annotations are using old format
+        logger.warning("No ratings dictionary found in annotations. Cannot calculate per-metric IRR.")
+        return {}
+
+    logger.info(f"🔍 Calculating IRR for {len(question_ids)} metrics: {question_ids}")
+    logger.info(f"🔍 Sample annotation ratings: {annotations[0].ratings if annotations else 'No annotations'}")
+
+    results = {}
+    for question_id in question_ids:
+        try:
+            alpha = calculate_krippendorff_alpha(annotations, question_id=question_id)
+            results[question_id] = alpha
+            logger.info(f"✅ IRR for {question_id}: {alpha:.3f}")
+        except Exception as e:
+            logger.warning(f"Failed to calculate IRR for question {question_id}: {e}")
+            results[question_id] = 0.0
+
+    return results
 
 
-def calculate_krippendorff_alpha(annotations: List[Annotation], question_id: str = None) -> float:
-  """Calculate Krippendorff's Alpha for rating data.
-  
-  Supports both:
-  - Ordinal data (1-5 Likert scale)
-  - Binary data (0/1 Pass/Fail)
+def calculate_krippendorff_alpha(annotations: list[Annotation], question_id: str = None) -> float:
+    """Calculate Krippendorff's Alpha for rating data.
 
-  Args:
-      annotations: List of annotations from any number of raters
-      question_id: Optional question ID to calculate IRR for a specific metric.
-                  If None, uses the legacy 'rating' field. If specified, uses
-                  the 'ratings' dict with this question_id.
+    Supports both:
+    - Ordinal data (1-5 Likert scale)
+    - Binary data (0/1 Pass/Fail)
 
-  Returns:
-      float: Krippendorff's Alpha value (-1 to 1)
-      - 1.0 = Perfect agreement
-      - 0.0 = Agreement equal to chance
-      - <0.0 = Systematic disagreement (raters disagree more than by chance)
+    Args:
+        annotations: List of annotations from any number of raters
+        question_id: Optional question ID to calculate IRR for a specific metric.
+                    If None, uses the legacy 'rating' field. If specified, uses
+                    the 'ratings' dict with this question_id.
 
-  Mathematical approach:
-      1. Create coincidence matrix of all rating pairs
-      2. Calculate observed disagreement using squared distance function
-      3. Calculate expected disagreement from marginal distributions
-      4. Alpha = 1 - (observed_disagreement / expected_disagreement)
-      
-  Note: For binary (0/1) data, squared distance equals nominal distance,
-  so the calculation is equivalent to using nominal Krippendorff's Alpha.
+    Returns:
+        float: Krippendorff's Alpha value (-1 to 1)
+        - 1.0 = Perfect agreement
+        - 0.0 = Agreement equal to chance
+        - <0.0 = Systematic disagreement (raters disagree more than by chance)
 
-  Example (Likert):
-      >>> annotations = [
-      ...     Annotation(trace_id="t1", user_id="u1", rating=4),
-      ...     Annotation(trace_id="t1", user_id="u2", rating=4),
-      ... ]
-      
-  Example (Binary):
-      >>> annotations = [
-      ...     Annotation(trace_id="t1", user_id="u1", ratings={"q1": 1}),  # Pass
-      ...     Annotation(trace_id="t1", user_id="u2", ratings={"q1": 0}),  # Fail
-      ... ]
-  """
-  if len(annotations) < 2:
-    return 0.0
+    Mathematical approach:
+        1. Create coincidence matrix of all rating pairs
+        2. Calculate observed disagreement using squared distance function
+        3. Calculate expected disagreement from marginal distributions
+        4. Alpha = 1 - (observed_disagreement / expected_disagreement)
 
-  # Create coincidence matrix
-  coincidence_matrix = _create_coincidence_matrix(annotations, question_id)
+    Note: For binary (0/1) data, squared distance equals nominal distance,
+    so the calculation is equivalent to using nominal Krippendorff's Alpha.
 
-  if _is_trivial_agreement(coincidence_matrix):
-    return 1.0
+    Example (Likert):
+        >>> annotations = [
+        ...     Annotation(trace_id="t1", user_id="u1", rating=4),
+        ...     Annotation(trace_id="t1", user_id="u2", rating=4),
+        ... ]
 
-  # Calculate observed disagreement
-  observed_disagreement = _calculate_observed_disagreement_ordinal(coincidence_matrix)
+    Example (Binary):
+        >>> annotations = [
+        ...     Annotation(trace_id="t1", user_id="u1", ratings={"q1": 1}),  # Pass
+        ...     Annotation(trace_id="t1", user_id="u2", ratings={"q1": 0}),  # Fail
+        ... ]
+    """
+    if len(annotations) < 2:
+        return 0.0
 
-  # Calculate expected disagreement
-  expected_disagreement = _calculate_expected_disagreement_ordinal(coincidence_matrix)
+    # Create coincidence matrix
+    coincidence_matrix = _create_coincidence_matrix(annotations, question_id)
 
-  if expected_disagreement == 0:
-    return 1.0 if observed_disagreement == 0 else 0.0
+    if _is_trivial_agreement(coincidence_matrix):
+        return 1.0
 
-  alpha = 1 - (observed_disagreement / expected_disagreement)
-  return max(-1.0, min(1.0, alpha))  # Clamp to [-1, 1]
+    # Calculate observed disagreement
+    observed_disagreement = _calculate_observed_disagreement_ordinal(coincidence_matrix)
 
+    # Calculate expected disagreement
+    expected_disagreement = _calculate_expected_disagreement_ordinal(coincidence_matrix)
 
-def _create_coincidence_matrix(annotations: List[Annotation], question_id: str = None) -> Dict[Tuple[int, int], float]:
-  """Create coincidence matrix for Krippendorff's Alpha calculation.
+    if expected_disagreement == 0:
+        return 1.0 if observed_disagreement == 0 else 0.0
 
-  Args:
-      annotations: List of annotations
-      question_id: Optional question ID to extract ratings for a specific metric
-
-  Returns:
-      Dict[Tuple[int, int], float]: Matrix of (rating1, rating2) -> frequency
-
-  The coincidence matrix counts how often each pair of ratings co-occurs,
-  accounting for missing data by weighting each pairing appropriately.
-  """
-  # Organize annotations by trace
-  traces = defaultdict(list)
-  for annotation in annotations:
-    # Get the rating for this annotation
-    if question_id is not None:
-      # Use ratings dict for specific question
-      if annotation.ratings and question_id in annotation.ratings:
-        rating = annotation.ratings[question_id]
-        traces[annotation.trace_id].append(rating)
-    else:
-      # Use legacy rating field
-      traces[annotation.trace_id].append(annotation.rating)
-
-  # Build coincidence matrix
-  coincidence_matrix = defaultdict(float)
-
-  for trace_ratings in traces.values():
-    n_ratings = len(trace_ratings)
-
-    if n_ratings < 2:
-      continue  # Skip traces with only one rating
-
-    # Weight for each pair in this trace
-    weight = 1.0 / (n_ratings - 1)
-
-    # Add all pairs from this trace
-    for i in range(n_ratings):
-      for j in range(n_ratings):
-        if i != j:
-          rating1, rating2 = trace_ratings[i], trace_ratings[j]
-          coincidence_matrix[(rating1, rating2)] += weight
-
-  return dict(coincidence_matrix)
+    alpha = 1 - (observed_disagreement / expected_disagreement)
+    return max(-1.0, min(1.0, alpha))  # Clamp to [-1, 1]
 
 
-def _is_trivial_agreement(coincidence_matrix: Dict[Tuple[int, int], float]) -> bool:
-  """Check if all ratings are identical (trivial perfect agreement).
+def _create_coincidence_matrix(annotations: list[Annotation], question_id: str = None) -> dict[tuple[int, int], float]:
+    """Create coincidence matrix for Krippendorff's Alpha calculation.
 
-  Args:
-      coincidence_matrix: Coincidence matrix
+    Args:
+        annotations: List of annotations
+        question_id: Optional question ID to extract ratings for a specific metric
 
-  Returns:
-      bool: True if all ratings are the same
-  """
-  # If only diagonal elements exist, all ratings are identical
-  for (r1, r2), count in coincidence_matrix.items():
-    if r1 != r2 and count > 0:
-      return False
-  return True
+    Returns:
+        Dict[Tuple[int, int], float]: Matrix of (rating1, rating2) -> frequency
+
+    The coincidence matrix counts how often each pair of ratings co-occurs,
+    accounting for missing data by weighting each pairing appropriately.
+    """
+    # Organize annotations by trace
+    traces = defaultdict(list)
+    for annotation in annotations:
+        # Get the rating for this annotation
+        if question_id is not None:
+            # Use ratings dict for specific question
+            if annotation.ratings and question_id in annotation.ratings:
+                rating = annotation.ratings[question_id]
+                traces[annotation.trace_id].append(rating)
+        else:
+            # Use legacy rating field
+            traces[annotation.trace_id].append(annotation.rating)
+
+    # Build coincidence matrix
+    coincidence_matrix = defaultdict(float)
+
+    for trace_ratings in traces.values():
+        n_ratings = len(trace_ratings)
+
+        if n_ratings < 2:
+            continue  # Skip traces with only one rating
+
+        # Weight for each pair in this trace
+        weight = 1.0 / (n_ratings - 1)
+
+        # Add all pairs from this trace
+        for i in range(n_ratings):
+            for j in range(n_ratings):
+                if i != j:
+                    rating1, rating2 = trace_ratings[i], trace_ratings[j]
+                    coincidence_matrix[(rating1, rating2)] += weight
+
+    return dict(coincidence_matrix)
+
+
+def _is_trivial_agreement(coincidence_matrix: dict[tuple[int, int], float]) -> bool:
+    """Check if all ratings are identical (trivial perfect agreement).
+
+    Args:
+        coincidence_matrix: Coincidence matrix
+
+    Returns:
+        bool: True if all ratings are the same
+    """
+    # If only diagonal elements exist, all ratings are identical
+    return all(not (r1 != r2 and count > 0) for (r1, r2), count in coincidence_matrix.items())
 
 
 def _calculate_observed_disagreement_ordinal(
-  coincidence_matrix: Dict[Tuple[int, int], float],
+    coincidence_matrix: dict[tuple[int, int], float],
 ) -> float:
-  """Calculate observed disagreement using ordinal distance function.
+    """Calculate observed disagreement using ordinal distance function.
 
-  Args:
-      coincidence_matrix: Coincidence matrix
+    Args:
+        coincidence_matrix: Coincidence matrix
 
-  Returns:
-      float: Observed disagreement
+    Returns:
+        float: Observed disagreement
 
-  For ordinal data, disagreement is proportional to squared distance:
-  δ(r1, r2) = (r1 - r2)²
-  """
-  total_pairs = sum(coincidence_matrix.values())
+    For ordinal data, disagreement is proportional to squared distance:
+    δ(r1, r2) = (r1 - r2)²
+    """
+    total_pairs = sum(coincidence_matrix.values())
 
-  if total_pairs == 0:
-    return 0.0
+    if total_pairs == 0:
+        return 0.0
 
-  disagreement = 0.0
+    disagreement = 0.0
 
-  for (r1, r2), count in coincidence_matrix.items():
-    # Ordinal distance function: squared difference
-    distance = (r1 - r2) ** 2
-    disagreement += count * distance
+    for (r1, r2), count in coincidence_matrix.items():
+        # Ordinal distance function: squared difference
+        distance = (r1 - r2) ** 2
+        disagreement += count * distance
 
-  return disagreement / total_pairs
+    return disagreement / total_pairs
 
 
 def _calculate_expected_disagreement_ordinal(
-  coincidence_matrix: Dict[Tuple[int, int], float],
+    coincidence_matrix: dict[tuple[int, int], float],
 ) -> float:
-  """Calculate expected disagreement based on marginal distributions.
+    """Calculate expected disagreement based on marginal distributions.
 
-  Uses Krippendorff's formula: D_e = sum(n_c * n_k * delta^2) / (n * (n-1))
-  where n_c are marginal frequencies and n is total values.
-  The n*(n-1) denominator is the finite-sample correction for sampling
-  without replacement from the value pool.
+    Uses Krippendorff's formula: D_e = sum(n_c * n_k * delta^2) / (n * (n-1))
+    where n_c are marginal frequencies and n is total values.
+    The n*(n-1) denominator is the finite-sample correction for sampling
+    without replacement from the value pool.
 
-  Args:
-      coincidence_matrix: Coincidence matrix
+    Args:
+        coincidence_matrix: Coincidence matrix
 
-  Returns:
-      float: Expected disagreement by chance
-  """
-  # Calculate marginal frequencies as row sums of the coincidence matrix.
-  # Since the matrix stores both directions (c,k) and (k,c), the row sum
-  # for value c is: n_c = sum over all k of o(c,k).
-  marginal_counts = defaultdict(float)
+    Returns:
+        float: Expected disagreement by chance
+    """
+    # Calculate marginal frequencies as row sums of the coincidence matrix.
+    # Since the matrix stores both directions (c,k) and (k,c), the row sum
+    # for value c is: n_c = sum over all k of o(c,k).
+    marginal_counts = defaultdict(float)
 
-  for (r1, _r2), count in coincidence_matrix.items():
-    marginal_counts[r1] += count
+    for (r1, _r2), count in coincidence_matrix.items():
+        marginal_counts[r1] += count
 
-  n = sum(marginal_counts.values())
+    n = sum(marginal_counts.values())
 
-  if n <= 1:
-    return 0.0
+    if n <= 1:
+        return 0.0
 
-  # Calculate expected disagreement using Krippendorff's formula:
-  # D_e = sum_{c != k} n_c * n_k * delta^2(c,k) / (n * (n - 1))
-  expected_disagreement = 0.0
+    # Calculate expected disagreement using Krippendorff's formula:
+    # D_e = sum_{c != k} n_c * n_k * delta^2(c,k) / (n * (n - 1))
+    expected_disagreement = 0.0
 
-  for r1 in marginal_counts:
-    for r2 in marginal_counts:
-      if r1 != r2:
-        distance = (r1 - r2) ** 2
-        expected_disagreement += marginal_counts[r1] * marginal_counts[r2] * distance
+    for r1 in marginal_counts:
+        for r2 in marginal_counts:
+            if r1 != r2:
+                distance = (r1 - r2) ** 2
+                expected_disagreement += marginal_counts[r1] * marginal_counts[r2] * distance
 
-  return expected_disagreement / (n * (n - 1))
+    return expected_disagreement / (n * (n - 1))
 
 
 def interpret_krippendorff_alpha(alpha: float) -> str:
-  """Provide human-readable interpretation of Krippendorff's Alpha score.
+    """Provide human-readable interpretation of Krippendorff's Alpha score.
 
-  Args:
-      alpha: Krippendorff's Alpha value
+    Args:
+        alpha: Krippendorff's Alpha value
 
-  Returns:
-      str: Human-readable interpretation
+    Returns:
+        str: Human-readable interpretation
 
-  Interpretation scale based on Krippendorff (2004):
-  - α ≥ 0.800: Excellent agreement (reliable)
-  - α ≥ 0.667: Good agreement (tentative conclusions acceptable)
-  - α ≥ 0.300: Acceptable agreement (for exploratory research)
-  - α < 0.300: Poor agreement (unreliable)
-  """
-  if alpha >= 0.800:
-    return 'Excellent agreement (reliable for all purposes)'
-  elif alpha >= 0.667:
-    return 'Good agreement (tentative conclusions acceptable)'
-  elif alpha >= 0.300:
-    return 'Acceptable agreement (for exploratory research)'
-  elif alpha >= 0.0:
-    return 'Poor agreement (unreliable)'
-  else:
-    return 'Systematic disagreement'
+    Interpretation scale based on Krippendorff (2004):
+    - α ≥ 0.800: Excellent agreement (reliable)
+    - α ≥ 0.667: Good agreement (tentative conclusions acceptable)
+    - α ≥ 0.300: Acceptable agreement (for exploratory research)
+    - α < 0.300: Poor agreement (unreliable)
+    """
+    if alpha >= 0.800:
+        return "Excellent agreement (reliable for all purposes)"
+    if alpha >= 0.667:
+        return "Good agreement (tentative conclusions acceptable)"
+    if alpha >= 0.300:
+        return "Acceptable agreement (for exploratory research)"
+    if alpha >= 0.0:
+        return "Poor agreement (unreliable)"
+    return "Systematic disagreement"
 
 
 def is_krippendorff_alpha_acceptable(alpha: float, threshold: float = 0.3) -> bool:
-  """Check if Krippendorff's Alpha meets acceptable threshold for workshop progression.
+    """Check if Krippendorff's Alpha meets acceptable threshold for workshop progression.
 
-  Args:
-      alpha: Krippendorff's Alpha value
-      threshold: Minimum acceptable threshold (default: 0.3)
+    Args:
+        alpha: Krippendorff's Alpha value
+        threshold: Minimum acceptable threshold (default: 0.3)
 
-  Returns:
-      bool: True if alpha meets threshold, False otherwise
+    Returns:
+        bool: True if alpha meets threshold, False otherwise
 
-  Note:
-      Krippendorff suggests α ≥ 0.800 for reliable conclusions,
-      α ≥ 0.667 for tentative conclusions, and α ≥ 0.300 as the
-      lowest acceptable limit for exploratory research.
-  """
-  return alpha >= threshold
+    Note:
+        Krippendorff suggests α ≥ 0.800 for reliable conclusions,
+        α ≥ 0.667 for tentative conclusions, and α ≥ 0.300 as the
+        lowest acceptable limit for exploratory research.
+    """
+    return alpha >= threshold
 
 
-def get_krippendorff_improvement_suggestions(alpha: float, is_binary: bool = False) -> List[str]:
-  """Provide specific suggestions for improving Krippendorff's Alpha when it's low.
+def get_krippendorff_improvement_suggestions(alpha: float, is_binary: bool = False) -> list[str]:
+    """Provide specific suggestions for improving Krippendorff's Alpha when it's low.
 
-  Args:
-      alpha: Krippendorff's Alpha value
-      is_binary: Whether this is a binary (Pass/Fail) scale vs Likert scale
+    Args:
+        alpha: Krippendorff's Alpha value
+        is_binary: Whether this is a binary (Pass/Fail) scale vs Likert scale
 
-  Returns:
-      List[str]: List of improvement suggestions
+    Returns:
+        List[str]: List of improvement suggestions
 
-  Suggestions are tailored to the specific alpha range and scale type to provide
-  actionable guidance for workshop facilitators.
-  """
-  if alpha >= 0.3:
-    return []  # No suggestions needed for acceptable agreement
+    Suggestions are tailored to the specific alpha range and scale type to provide
+    actionable guidance for workshop facilitators.
+    """
+    if alpha >= 0.3:
+        return []  # No suggestions needed for acceptable agreement
 
-  suggestions = [
-    'Clarify the rubric question - ensure all annotators interpret it identically',
-    'Conduct group discussion on traces where annotators strongly disagreed',
-    'Consider simplifying the rubric to reduce subjective interpretation',
-    'Provide additional calibration training with gold standard examples',
-  ]
+    suggestions = [
+        "Clarify the rubric question - ensure all annotators interpret it identically",
+        "Conduct group discussion on traces where annotators strongly disagreed",
+        "Consider simplifying the rubric to reduce subjective interpretation",
+        "Provide additional calibration training with gold standard examples",
+    ]
 
-  if alpha < 0.0:
-    if is_binary:
-      suggestions.extend(
-        [
-          'Systematic disagreement detected - raters are giving opposite judgments',
-          'Check if annotators have the same understanding of what constitutes Pass vs Fail',
-          'Review the criteria for Pass/Fail - they may be ambiguous',
-        ]
-      )
-    else:
-      suggestions.extend(
-        [
-          'Systematic disagreement detected - consider completely revising the rubric',
-          'Check if annotators understood the rating scale direction (1=worst vs 1=best)',
-          'Verify that all annotators are evaluating the same aspect of responses',
-        ]
-      )
+    if alpha < 0.0:
+        if is_binary:
+            suggestions.extend(
+                [
+                    "Systematic disagreement detected - raters are giving opposite judgments",
+                    "Check if annotators have the same understanding of what constitutes Pass vs Fail",
+                    "Review the criteria for Pass/Fail - they may be ambiguous",
+                ]
+            )
+        else:
+            suggestions.extend(
+                [
+                    "Systematic disagreement detected - consider completely revising the rubric",
+                    "Check if annotators understood the rating scale direction (1=worst vs 1=best)",
+                    "Verify that all annotators are evaluating the same aspect of responses",
+                ]
+            )
 
-  if 0.0 <= alpha < 0.15:
-    suggestions.append('Agreement is very low - consider starting over with a clearer rubric')
+    if 0.0 <= alpha < 0.15:
+        suggestions.append("Agreement is very low - consider starting over with a clearer rubric")
 
-  return suggestions
+    return suggestions

--- a/server/services/mlflow_intake_service.py
+++ b/server/services/mlflow_intake_service.py
@@ -1,6 +1,6 @@
 """MLflow intake service for pulling traces from MLflow experiments."""
 
-from typing import Any, Dict, List, Literal
+from typing import Any, Literal
 
 import mlflow
 import mlflow.genai
@@ -10,451 +10,459 @@ from server.services.database_service import DatabaseService
 
 
 class MLflowIntakeService:
-  """Service for MLflow trace intake operations."""
+    """Service for MLflow trace intake operations."""
 
-  def __init__(self, db_service: DatabaseService):
-    self.db_service = db_service
+    def __init__(self, db_service: DatabaseService):
+        self.db_service = db_service
 
-  def configure_mlflow(self, config: MLflowIntakeConfig) -> None:
-    """Configure MLflow with Databricks credentials."""
-    try:
-      # Validate configuration
-      if not config.databricks_host or not config.databricks_token:
-        raise ValueError('Databricks host and token are required')
-
-      # Validate host format
-      if not config.databricks_host.startswith('https://'):
-        raise ValueError('Databricks host must start with https://')
-
-      # Set tracking URI to Databricks
-      mlflow.set_tracking_uri('databricks')
-
-      # Set authentication
-      import os
-
-      os.environ['DATABRICKS_HOST'] = config.databricks_host.rstrip('/')
-      os.environ['DATABRICKS_TOKEN'] = config.databricks_token
-
-    except Exception as e:
-      raise ValueError(f'Failed to configure MLflow: {str(e)}')
-
-  def search_traces(self, config: MLflowIntakeConfig) -> List[MLflowTraceInfo]:
-    """Search for traces in MLflow experiment with proper error handling."""
-    try:
-      # Configure MLflow
-      self.configure_mlflow(config)
-
-      # Search for traces with error handling
-      traces = mlflow.search_traces(
-        experiment_ids=[config.experiment_id],
-        max_results=config.max_traces or 100,
-        filter_string=config.filter_string,
-        return_type='list',
-      )
-
-      trace_info_list = []
-      for trace in traces:
+    def configure_mlflow(self, config: MLflowIntakeConfig) -> None:
+        """Configure MLflow with Databricks credentials."""
         try:
-          if hasattr(trace, 'info') and hasattr(trace.info, 'request_id'):
-            # Extract content from JSON for previews
-            # Safely handle traces with missing or incomplete data
-            input_content = self._extract_content_from_json(
-              getattr(trace.data, 'request', None) if hasattr(trace, 'data') else None
-            )
-            output_content = self._extract_content_from_json(
-              getattr(trace.data, 'response', None) if hasattr(trace, 'data') else None
-            )
+            # Validate configuration
+            if not config.databricks_host or not config.databricks_token:
+                raise ValueError("Databricks host and token are required")
 
-            trace_info = MLflowTraceInfo(
-              trace_id=trace.info.request_id,
-              request_preview=self._truncate_text(input_content, 200),
-              response_preview=self._truncate_text(output_content, 200),
-              execution_time_ms=getattr(trace.info, 'execution_time_ms', None),
-              status=getattr(trace.info, 'status', 'UNKNOWN'),
-              timestamp_ms=getattr(trace.info, 'timestamp_ms', 0),
-              tags=dict(trace.info.tags) if hasattr(trace.info, 'tags') and trace.info.tags else None,
-              mlflow_url=self._generate_mlflow_url(config.databricks_host, config.experiment_id, trace.info.request_id),
-            )
-            trace_info_list.append(trace_info)
-        except Exception as trace_error:
-          # Log individual trace processing errors but continue
-          trace_id = getattr(trace.info, 'request_id', 'unknown') if hasattr(trace, 'info') else 'unknown'
-          error_type = type(trace_error).__name__
-          # Provide more context for common errors
-          if 'NoneType' in str(trace_error):
-            print(f'Warning: Trace {trace_id} has incomplete data (missing request/response)')
-          else:
-            print(f'Warning: Failed to process trace {trace_id} ({error_type}): {str(trace_error)}')
-          continue
+            # Validate host format
+            if not config.databricks_host.startswith("https://"):
+                raise ValueError("Databricks host must start with https://")
 
-      return trace_info_list
+            # Set tracking URI to Databricks
+            mlflow.set_tracking_uri("databricks")
 
-    except Exception as e:
-      error_msg = str(e)
-      if '401' in error_msg or 'Credential' in error_msg:
-        raise ValueError(f'MLflow authentication failed. Please check your Databricks token: {error_msg}')
-      elif '404' in error_msg:
-        raise ValueError(f'MLflow experiment not found. Please check your experiment ID: {error_msg}')
-      else:
-        raise ValueError(f'Failed to search MLflow traces: {error_msg}')
+            # Set authentication
+            import os
 
-  def ingest_traces(self, workshop_id: str, config: MLflowIntakeConfig) -> int:
-    """Ingest traces from MLflow into the workshop."""
-    try:
-      # Search for traces
-      trace_infos = self.search_traces(config)
+            os.environ["DATABRICKS_HOST"] = config.databricks_host.rstrip("/")
+            os.environ["DATABRICKS_TOKEN"] = config.databricks_token
 
-      if not trace_infos:
-        return 0  # No traces found, return 0 instead of erroring
+        except Exception as e:
+            raise ValueError(f"Failed to configure MLflow: {e!s}") from e
 
-      # Convert to TraceUpload objects
-      trace_uploads = []
-      for trace_info in trace_infos:
+    def search_traces(self, config: MLflowIntakeConfig) -> list[MLflowTraceInfo]:
+        """Search for traces in MLflow experiment with proper error handling."""
         try:
-          # Get full trace data
-          full_trace = mlflow.get_trace(trace_info.trace_id)
+            # Configure MLflow
+            self.configure_mlflow(config)
 
-          # Extract content from JSON input/output
-          # Safely handle traces with missing or incomplete data
-          input_content = self._extract_content_from_json(
-            getattr(full_trace.data, 'request', None) if hasattr(full_trace, 'data') else None
-          )
-          output_content = self._extract_content_from_json(
-            getattr(full_trace.data, 'response', None) if hasattr(full_trace, 'data') else None
-          )
+            # Search for traces with error handling
+            traces = mlflow.search_traces(
+                experiment_ids=[config.experiment_id],
+                max_results=config.max_traces or 100,
+                filter_string=config.filter_string,
+                return_type="list",
+            )
 
-          trace_upload = TraceUpload(
-            input=input_content,
-            output=output_content,
-            context={
-              'spans': [
-                {
-                  'name': span.name,
-                  'span_type': span.span_type,
-                  'inputs': span.inputs,
-                  'outputs': span.outputs,
-                  'start_time_ns': span.start_time_ns,
-                  'end_time_ns': span.end_time_ns,
+            trace_info_list = []
+            for trace in traces:
+                try:
+                    if hasattr(trace, "info") and hasattr(trace.info, "request_id"):
+                        # Extract content from JSON for previews
+                        # Safely handle traces with missing or incomplete data
+                        input_content = self._extract_content_from_json(
+                            getattr(trace.data, "request", None) if hasattr(trace, "data") else None
+                        )
+                        output_content = self._extract_content_from_json(
+                            getattr(trace.data, "response", None) if hasattr(trace, "data") else None
+                        )
+
+                        trace_info = MLflowTraceInfo(
+                            trace_id=trace.info.request_id,
+                            request_preview=self._truncate_text(input_content, 200),
+                            response_preview=self._truncate_text(output_content, 200),
+                            execution_time_ms=getattr(trace.info, "execution_time_ms", None),
+                            status=getattr(trace.info, "status", "UNKNOWN"),
+                            timestamp_ms=getattr(trace.info, "timestamp_ms", 0),
+                            tags=dict(trace.info.tags) if hasattr(trace.info, "tags") and trace.info.tags else None,
+                            mlflow_url=self._generate_mlflow_url(
+                                config.databricks_host, config.experiment_id, trace.info.request_id
+                            ),
+                        )
+                        trace_info_list.append(trace_info)
+                except Exception as trace_error:
+                    # Log individual trace processing errors but continue
+                    trace_id = getattr(trace.info, "request_id", "unknown") if hasattr(trace, "info") else "unknown"
+                    error_type = type(trace_error).__name__
+                    # Provide more context for common errors
+                    if "NoneType" in str(trace_error):
+                        print(f"Warning: Trace {trace_id} has incomplete data (missing request/response)")
+                    else:
+                        print(f"Warning: Failed to process trace {trace_id} ({error_type}): {trace_error!s}")
+                    continue
+
+            return trace_info_list
+
+        except Exception as e:
+            error_msg = str(e)
+            if "401" in error_msg or "Credential" in error_msg:
+                raise ValueError(f"MLflow authentication failed. Please check your Databricks token: {error_msg}") from e
+            if "404" in error_msg:
+                raise ValueError(f"MLflow experiment not found. Please check your experiment ID: {error_msg}") from e
+            raise ValueError(f"Failed to search MLflow traces: {error_msg}") from e
+
+    def ingest_traces(self, workshop_id: str, config: MLflowIntakeConfig) -> int:
+        """Ingest traces from MLflow into the workshop."""
+        try:
+            # Search for traces
+            trace_infos = self.search_traces(config)
+
+            if not trace_infos:
+                return 0  # No traces found, return 0 instead of erroring
+
+            # Convert to TraceUpload objects
+            trace_uploads = []
+            for trace_info in trace_infos:
+                try:
+                    # Get full trace data
+                    full_trace = mlflow.get_trace(trace_info.trace_id)
+
+                    # Extract content from JSON input/output
+                    # Safely handle traces with missing or incomplete data
+                    input_content = self._extract_content_from_json(
+                        getattr(full_trace.data, "request", None) if hasattr(full_trace, "data") else None
+                    )
+                    output_content = self._extract_content_from_json(
+                        getattr(full_trace.data, "response", None) if hasattr(full_trace, "data") else None
+                    )
+
+                    trace_upload = TraceUpload(
+                        input=input_content,
+                        output=output_content,
+                        context={
+                            "spans": [
+                                {
+                                    "name": span.name,
+                                    "span_type": span.span_type,
+                                    "inputs": span.inputs,
+                                    "outputs": span.outputs,
+                                    "start_time_ns": span.start_time_ns,
+                                    "end_time_ns": span.end_time_ns,
+                                }
+                                for span in full_trace.data.spans
+                            ],
+                            "execution_time_ms": full_trace.info.execution_time_ms,
+                            "status": full_trace.info.status,
+                            "tags": dict(full_trace.info.tags) if full_trace.info.tags else {},
+                        },
+                        trace_metadata={
+                            "mlflow_trace_id": trace_info.trace_id,
+                            "mlflow_host": config.databricks_host,
+                            "mlflow_experiment_id": config.experiment_id,
+                        },
+                        mlflow_trace_id=trace_info.trace_id,
+                        mlflow_url=self._generate_mlflow_url(
+                            config.databricks_host, config.experiment_id, trace_info.trace_id
+                        ),
+                        mlflow_host=config.databricks_host,
+                        mlflow_experiment_id=config.experiment_id,
+                    )
+                    trace_uploads.append(trace_upload)
+
+                except Exception as trace_error:
+                    # Log individual trace processing errors but continue
+                    error_type = type(trace_error).__name__
+                    # Provide more context for common errors
+                    if "NoneType" in str(trace_error):
+                        print(f"Warning: Trace {trace_info.trace_id} has incomplete data (missing request/response)")
+                    else:
+                        print(f"Warning: Failed to process trace {trace_info.trace_id} ({error_type}): {trace_error!s}")
+                    continue
+
+            # Add traces to workshop
+            if trace_uploads:
+                self.db_service.add_traces(workshop_id, trace_uploads)
+
+            return len(trace_uploads)
+
+        except ValueError as e:
+            # Re-raise ValueError (authentication, etc.) as-is
+            raise e
+        except Exception as e:
+            error_msg = str(e)
+            if "401" in error_msg or "Credential" in error_msg:
+                raise ValueError(f"MLflow authentication failed during ingestion: {error_msg}") from e
+            raise ValueError(f"Failed to ingest traces: {error_msg}") from e
+
+    def _truncate_text(self, text: str, max_length: int) -> str:
+        """Truncate text to specified length."""
+        if len(text) <= max_length:
+            return text
+        return text[:max_length] + "..."
+
+    def _clean_extracted_text(self, text: str) -> str:
+        """Clean extracted text by removing surrounding quotes and handling escapes."""
+        if not text:
+            return ""
+        # Strip whitespace
+        text = text.strip()
+        # Remove surrounding double quotes repeatedly
+        while text.startswith('"') and text.endswith('"') and len(text) > 1:
+            text = text[1:-1].strip()
+        # Remove surrounding single quotes
+        while text.startswith("'") and text.endswith("'") and len(text) > 1:
+            text = text[1:-1].strip()
+        # Handle escaped quotes
+        text = text.replace('\\"', '"')
+        text = text.replace("\\'", "'")
+        # Handle escaped newlines
+        text = text.replace("\\n", "\n")
+        return text
+
+    def _extract_content_from_json(self, json_text: str) -> str:
+        """Extract content from JSON input/output format."""
+        try:
+            import json
+
+            # Handle None or empty trace data gracefully
+            if json_text is None or json_text == "":
+                return ""
+
+            data = json.loads(json_text)
+
+            # Handle the specific MLflow trace format with request.input structure
+            if isinstance(data, dict) and "request" in data:
+                request_data = data["request"]
+                if isinstance(request_data, dict) and "input" in request_data:
+                    input_list = request_data["input"]
+                    if isinstance(input_list, list) and input_list:
+                        # Extract content from the first user message
+                        for item in input_list:
+                            if isinstance(item, dict) and item.get("role") == "user" and "content" in item:
+                                content = item["content"]
+                                # Replace escaped newlines with actual newlines
+                                if isinstance(content, str):
+                                    content = content.replace("\\n", "\n")
+                                return content
+                        # If no user message found, return the first item's content
+                        if input_list[0].get("content"):
+                            content = input_list[0]["content"]
+                            # Replace escaped newlines with actual newlines
+                            if isinstance(content, str):
+                                content = content.replace("\\n", "\n")
+                            return content
+
+            # Handle messages format: {"messages": [...]}
+            if isinstance(data, dict) and "messages" in data:
+                messages = data["messages"]
+                if not messages:
+                    return json_text
+
+                # First, try to find an assistant message (for output)
+                for message in reversed(messages):
+                    if isinstance(message, dict) and message.get("role") == "assistant" and "content" in message:
+                        content = message["content"]
+                        # Replace escaped newlines with actual newlines
+                        if isinstance(content, str):
+                            content = content.replace("\\n", "\n")
+                        return content
+
+                # If no assistant message found, return the first user message (for input)
+                for message in messages:
+                    if isinstance(message, dict) and message.get("role") == "user" and "content" in message:
+                        content = message["content"]
+                        # Replace escaped newlines with actual newlines
+                        if isinstance(content, str):
+                            content = content.replace("\\n", "\n")
+                        return content
+
+                # If no specific role found, return the last message content
+                if messages and isinstance(messages[-1], dict) and "content" in messages[-1]:
+                    content = messages[-1]["content"]
+                    # Replace escaped newlines with actual newlines
+                    if isinstance(content, str):
+                        content = content.replace("\\n", "\n")
+                    return content
+
+            # Handle output format that is a list of items
+            if isinstance(data, list):
+                # First, prefer the last assistant message with output_text content
+                for item in reversed(data):
+                    if isinstance(item, dict) and item.get("type") == "message" and item.get("role") == "assistant":
+                        content = item.get("content")
+                        if isinstance(content, list):
+                            texts = []
+                            for content_item in content:
+                                if isinstance(content_item, dict) and content_item.get("type") == "output_text":
+                                    text_value = content_item.get("text")
+                                    if isinstance(text_value, str) and text_value:
+                                        # Replace escaped newlines with actual newlines
+                                        text_value = text_value.replace("\\n", "\n")
+                                        texts.append(text_value)
+                            if texts:
+                                return "\n".join(texts)
+
+                # Fallback: Look for response.output_item.done type items
+                for item in data:
+                    if isinstance(item, dict) and item.get("type") == "response.output_item.done":
+                        item_data = item.get("item", {})
+                        if isinstance(item_data, dict) and "content" in item_data:
+                            content_list = item_data["content"]
+                            if isinstance(content_list, list):
+                                for content_item in content_list:
+                                    if isinstance(content_item, dict) and content_item.get("type") == "output_text":
+                                        text = content_item.get("text", "")
+                                        # Replace escaped newlines with actual newlines
+                                        if isinstance(text, str):
+                                            text = text.replace("\\n", "\n")
+                                        return text
+
+            # Handle new output format with object: "response"
+            if isinstance(data, dict) and data.get("object") == "response" and "output" in data:
+                output_list = data["output"]
+                if isinstance(output_list, list):
+                    # Prefer the last assistant message in the output list
+                    for output_item in reversed(output_list):
+                        if (
+                            isinstance(output_item, dict)
+                            and output_item.get("type") == "message"
+                            and output_item.get("role") == "assistant"
+                        ):
+                            content_list = output_item.get("content", [])
+                            if isinstance(content_list, list):
+                                texts = []
+                                for content_item in content_list:
+                                    if isinstance(content_item, dict) and content_item.get("type") == "output_text":
+                                        text_value = content_item.get("text", "")
+                                        if isinstance(text_value, str) and text_value:
+                                            # Replace escaped newlines with actual newlines
+                                            text_value = text_value.replace("\\n", "\n")
+                                            texts.append(text_value)
+                                if texts:
+                                    return "\n".join(texts)
+
+            # If no specific format found, try to clean the original text
+            # It might be a plain string with quotes from JSON serialization
+            if isinstance(data, str):
+                return self._clean_extracted_text(data)
+            return self._clean_extracted_text(json_text)
+
+        except (json.JSONDecodeError, KeyError, IndexError):
+            # If JSON parsing fails, try to clean and return the original text
+            return self._clean_extracted_text(json_text)
+
+    def _extract_content_from_json_2(self, data: str, side: Literal["input", "output"] = "output") -> str:
+        """Extracts display friendly content from MLflow trace JSON."""
+        try:
+            import json
+
+            from mlflow.types.agent import ChatAgentRequest, ChatAgentResponse
+            from mlflow.types.responses import ResponsesAgentRequest, ResponsesAgentResponse
+
+            data = json.loads(data)
+
+            if side == "input":
+                # Try ResponsesAgentRequest first
+                try:
+                    inputs = ResponsesAgentRequest.model_validate(data).request.input
+                    return inputs[-1].content
+                except Exception as e:
+                    pass
+                    # maybe logging info
+                    print(f"Error with ResponsesAgentRequest: {e}")
+
+                # Fallback to ChatAgentRequest
+                try:
+                    chat_request = ChatAgentRequest.model_validate(data)
+                    return chat_request.messages[-1].content
+                except Exception as e:
+                    pass
+                    # maybe logging info
+                    print(f"Error with ChatAgentRequest: {e}")
+                    return data
+
+            if side == "output":
+                # Try ResponsesAgentResponse first
+                try:
+                    outputs = ResponsesAgentResponse.model_validate(data)
+                    # Access the first content item's text field
+                    if outputs and outputs[0].content and len(outputs[0].content) > 0:
+                        first_content = outputs[0].content[0]
+                        # Check if it's an output_text type content with a text field
+                        if (
+                            isinstance(first_content, dict)
+                            and first_content.get("type") == "output_text"
+                            and "text" in first_content
+                        ):
+                            return first_content["text"]
+                except Exception:
+                    pass
+                    # maybe logging info
+                    # print(f'Error with ResponsesAgentResponse: {e}')
+
+                # Fallback to ChatAgentResponse
+                try:
+                    outputs = ChatAgentResponse.model_validate(data).messages
+                    if isinstance(outputs[0].content, str):
+                        return outputs[0].content
+                except Exception:
+                    pass
+                    # maybe logging info
+                    # print(f'Error with ChatAgentResponse: {e}')
+
+                return data
+
+        except Exception as e:
+            print(f"Error parsing JSON: {e}")
+            return str(data)
+
+        except (KeyError, IndexError, TypeError):
+            # If fallback processing fails, return the original text
+            return data
+
+    def _generate_mlflow_url(self, databricks_host: str, experiment_id: str, trace_id: str) -> str:
+        """Generate MLflow URL for an experiment."""
+        # Remove protocol if present and trailing slash
+        host = databricks_host.replace("https://", "").replace("http://", "").rstrip("/")
+        # Use the experiment URL format: https://{host}/ml/experiments/{experiment_id}
+        return f"https://{host}/ml/experiments/{experiment_id}/traces?selectedEvaluationId={trace_id}"
+
+    def test_connection(self, config: MLflowIntakeConfig) -> dict[str, Any]:
+        """Test MLflow connection and return experiment info."""
+        try:
+            # Configure MLflow
+            self.configure_mlflow(config)
+
+            # Try to get experiment info
+            experiment = mlflow.get_experiment(config.experiment_id)
+            if not experiment:
+                return {
+                    "success": False,
+                    "error": "Experiment not found",
+                    "message": f"Experiment {config.experiment_id} not found",
                 }
-                for span in full_trace.data.spans
-              ],
-              'execution_time_ms': full_trace.info.execution_time_ms,
-              'status': full_trace.info.status,
-              'tags': dict(full_trace.info.tags) if full_trace.info.tags else {},
-            },
-            trace_metadata={
-              'mlflow_trace_id': trace_info.trace_id,
-              'mlflow_host': config.databricks_host,
-              'mlflow_experiment_id': config.experiment_id,
-            },
-            mlflow_trace_id=trace_info.trace_id,
-            mlflow_url=self._generate_mlflow_url(config.databricks_host, config.experiment_id, trace_info.trace_id),
-            mlflow_host=config.databricks_host,
-            mlflow_experiment_id=config.experiment_id,
-          )
-          trace_uploads.append(trace_upload)
 
-        except Exception as trace_error:
-          # Log individual trace processing errors but continue
-          error_type = type(trace_error).__name__
-          # Provide more context for common errors
-          if 'NoneType' in str(trace_error):
-            print(f'Warning: Trace {trace_info.trace_id} has incomplete data (missing request/response)')
-          else:
-            print(f'Warning: Failed to process trace {trace_info.trace_id} ({error_type}): {str(trace_error)}')
-          continue
+            # Try to search for traces to verify access (with minimal request)
+            try:
+                traces = mlflow.search_traces(
+                    experiment_ids=[config.experiment_id],
+                    max_results=1,  # Just get one trace to test access
+                    return_type="list",
+                )
+                trace_count = len(traces)
+            except Exception as trace_error:
+                # If we can access experiment but not traces, still consider it a partial success
+                trace_count = 0
+                print(f"Warning: Could not search traces: {trace_error!s}")
 
-      # Add traces to workshop
-      if trace_uploads:
-        self.db_service.add_traces(workshop_id, trace_uploads)
+            return {
+                "success": True,
+                "experiment_name": experiment.name,
+                "experiment_id": config.experiment_id,
+                "trace_count": trace_count,
+                "message": f"Connection successful. Found experiment '{experiment.name}' accessible traces.",
+            }
 
-      return len(trace_uploads)
-
-    except ValueError as e:
-      # Re-raise ValueError (authentication, etc.) as-is
-      raise e
-    except Exception as e:
-      error_msg = str(e)
-      if '401' in error_msg or 'Credential' in error_msg:
-        raise ValueError(f'MLflow authentication failed during ingestion: {error_msg}')
-      else:
-        raise ValueError(f'Failed to ingest traces: {error_msg}')
-
-  def _truncate_text(self, text: str, max_length: int) -> str:
-    """Truncate text to specified length."""
-    if len(text) <= max_length:
-      return text
-    return text[:max_length] + '...'
-
-
-  def _clean_extracted_text(self, text: str) -> str:
-    """Clean extracted text by removing surrounding quotes and handling escapes."""
-    if not text:
-      return ""
-    # Strip whitespace
-    text = text.strip()
-    # Remove surrounding double quotes repeatedly
-    while text.startswith('"') and text.endswith('"') and len(text) > 1:
-      text = text[1:-1].strip()
-    # Remove surrounding single quotes
-    while text.startswith("'") and text.endswith("'") and len(text) > 1:
-      text = text[1:-1].strip()
-    # Handle escaped quotes
-    text = text.replace('\\"', '"')
-    text = text.replace("\\'", "'")
-    # Handle escaped newlines
-    text = text.replace('\\n', '\n')
-    return text
-
-  def _extract_content_from_json(self, json_text: str) -> str:
-    """Extract content from JSON input/output format."""
-    try:
-      import json
-
-      # Handle None or empty trace data gracefully
-      if json_text is None or json_text == "":
-        return ""
-
-      data = json.loads(json_text)
-
-      # Handle the specific MLflow trace format with request.input structure
-      if isinstance(data, dict) and 'request' in data:
-        request_data = data['request']
-        if isinstance(request_data, dict) and 'input' in request_data:
-          input_list = request_data['input']
-          if isinstance(input_list, list) and input_list:
-            # Extract content from the first user message
-            for item in input_list:
-              if isinstance(item, dict) and item.get('role') == 'user' and 'content' in item:
-                content = item['content']
-                # Replace escaped newlines with actual newlines
-                if isinstance(content, str):
-                  content = content.replace('\\n', '\n')
-                return content
-            # If no user message found, return the first item's content
-            if input_list[0].get('content'):
-              content = input_list[0]['content']
-              # Replace escaped newlines with actual newlines
-              if isinstance(content, str):
-                content = content.replace('\\n', '\n')
-              return content
-
-      # Handle messages format: {"messages": [...]}
-      if isinstance(data, dict) and 'messages' in data:
-        messages = data['messages']
-        if not messages:
-          return json_text
-
-        # First, try to find an assistant message (for output)
-        for message in reversed(messages):
-          if isinstance(message, dict) and message.get('role') == 'assistant' and 'content' in message:
-            content = message['content']
-            # Replace escaped newlines with actual newlines
-            if isinstance(content, str):
-              content = content.replace('\\n', '\n')
-            return content
-
-        # If no assistant message found, return the first user message (for input)
-        for message in messages:
-          if isinstance(message, dict) and message.get('role') == 'user' and 'content' in message:
-            content = message['content']
-            # Replace escaped newlines with actual newlines
-            if isinstance(content, str):
-              content = content.replace('\\n', '\n')
-            return content
-
-        # If no specific role found, return the last message content
-        if messages and isinstance(messages[-1], dict) and 'content' in messages[-1]:
-          content = messages[-1]['content']
-          # Replace escaped newlines with actual newlines
-          if isinstance(content, str):
-            content = content.replace('\\n', '\n')
-          return content
-
-      # Handle output format that is a list of items
-      if isinstance(data, list):
-        # First, prefer the last assistant message with output_text content
-        for item in reversed(data):
-          if isinstance(item, dict) and item.get('type') == 'message' and item.get('role') == 'assistant':
-            content = item.get('content')
-            if isinstance(content, list):
-              texts = []
-              for content_item in content:
-                if isinstance(content_item, dict) and content_item.get('type') == 'output_text':
-                  text_value = content_item.get('text')
-                  if isinstance(text_value, str) and text_value:
-                    # Replace escaped newlines with actual newlines
-                    text_value = text_value.replace('\\n', '\n')
-                    texts.append(text_value)
-              if texts:
-                return '\n'.join(texts)
-
-        # Fallback: Look for response.output_item.done type items
-        for item in data:
-          if isinstance(item, dict) and item.get('type') == 'response.output_item.done':
-            item_data = item.get('item', {})
-            if isinstance(item_data, dict) and 'content' in item_data:
-              content_list = item_data['content']
-              if isinstance(content_list, list):
-                for content_item in content_list:
-                  if isinstance(content_item, dict) and content_item.get('type') == 'output_text':
-                    text = content_item.get('text', '')
-                    # Replace escaped newlines with actual newlines
-                    if isinstance(text, str):
-                      text = text.replace('\\n', '\n')
-                    return text
-
-      # Handle new output format with object: "response"
-      if isinstance(data, dict) and data.get('object') == 'response' and 'output' in data:
-        output_list = data['output']
-        if isinstance(output_list, list):
-          # Prefer the last assistant message in the output list
-          for output_item in reversed(output_list):
-            if isinstance(output_item, dict) and output_item.get('type') == 'message' and output_item.get('role') == 'assistant':
-              content_list = output_item.get('content', [])
-              if isinstance(content_list, list):
-                texts = []
-                for content_item in content_list:
-                  if isinstance(content_item, dict) and content_item.get('type') == 'output_text':
-                    text_value = content_item.get('text', '')
-                    if isinstance(text_value, str) and text_value:
-                      # Replace escaped newlines with actual newlines
-                      text_value = text_value.replace('\\n', '\n')
-                      texts.append(text_value)
-                if texts:
-                  return '\n'.join(texts)
-
-      # If no specific format found, try to clean the original text
-      # It might be a plain string with quotes from JSON serialization
-      if isinstance(data, str):
-        return self._clean_extracted_text(data)
-      return self._clean_extracted_text(json_text)
-
-    except (json.JSONDecodeError, KeyError, IndexError):
-      # If JSON parsing fails, try to clean and return the original text
-      return self._clean_extracted_text(json_text)
-
-  def _extract_content_from_json_2(self, data: str, side: Literal['input', 'output'] = 'output') -> str:
-    """Extracts display friendly content from MLflow trace JSON."""
-    try:
-      import json
-
-      from mlflow.types.agent import ChatAgentRequest, ChatAgentResponse
-      from mlflow.types.responses import ResponsesAgentRequest, ResponsesAgentResponse
-
-      data = json.loads(data)
-
-      if side == 'input':
-        # Try ResponsesAgentRequest first
-        try:
-          inputs = ResponsesAgentRequest.model_validate(data).request.input
-          return inputs[-1].content
         except Exception as e:
-          pass
-          # maybe logging info
-          print(f'Error with ResponsesAgentRequest: {e}')
-
-        # Fallback to ChatAgentRequest
-        try:
-          chat_request = ChatAgentRequest.model_validate(data)
-          return chat_request.messages[-1].content
-        except Exception as e:
-          pass
-          # maybe logging info
-          print(f'Error with ChatAgentRequest: {e}')
-          return data
-
-      if side == 'output':
-        # Try ResponsesAgentResponse first
-        try:
-          outputs = ResponsesAgentResponse.model_validate(data)
-          # Access the first content item's text field
-          if outputs and outputs[0].content and len(outputs[0].content) > 0:
-            first_content = outputs[0].content[0]
-            # Check if it's an output_text type content with a text field
-            if isinstance(first_content, dict) and first_content.get('type') == 'output_text' and 'text' in first_content:
-              return first_content['text']
-        except Exception:
-          pass
-          # maybe logging info
-          # print(f'Error with ResponsesAgentResponse: {e}')
-
-        # Fallback to ChatAgentResponse
-        try:
-          outputs = ChatAgentResponse.model_validate(data).messages
-          if isinstance(outputs[0].content, str):
-            return outputs[0].content
-        except Exception:
-          pass
-          # maybe logging info
-          # print(f'Error with ChatAgentResponse: {e}')
-
-        return data
-
-    except Exception as e:
-      print(f'Error parsing JSON: {e}')
-      return str(data)
-
-    except (KeyError, IndexError, TypeError):
-      # If fallback processing fails, return the original text
-      return data
-
-  def _generate_mlflow_url(self, databricks_host: str, experiment_id: str, trace_id: str) -> str:
-    """Generate MLflow URL for an experiment."""
-    # Remove protocol if present and trailing slash
-    host = databricks_host.replace('https://', '').replace('http://', '').rstrip('/')
-    # Use the experiment URL format: https://{host}/ml/experiments/{experiment_id}
-    return f'https://{host}/ml/experiments/{experiment_id}/traces?selectedEvaluationId={trace_id}'
-
-  def test_connection(self, config: MLflowIntakeConfig) -> Dict[str, Any]:
-    """Test MLflow connection and return experiment info."""
-    try:
-      # Configure MLflow
-      self.configure_mlflow(config)
-
-      # Try to get experiment info
-      experiment = mlflow.get_experiment(config.experiment_id)
-      if not experiment:
-        return {
-          'success': False,
-          'error': 'Experiment not found',
-          'message': f'Experiment {config.experiment_id} not found',
-        }
-
-      # Try to search for traces to verify access (with minimal request)
-      try:
-        traces = mlflow.search_traces(
-          experiment_ids=[config.experiment_id],
-          max_results=1,  # Just get one trace to test access
-          return_type='list',
-        )
-        trace_count = len(traces)
-      except Exception as trace_error:
-        # If we can access experiment but not traces, still consider it a partial success
-        trace_count = 0
-        print(f'Warning: Could not search traces: {str(trace_error)}')
-
-      return {
-        'success': True,
-        'experiment_name': experiment.name,
-        'experiment_id': config.experiment_id,
-        'trace_count': trace_count,
-        'message': f"Connection successful. Found experiment '{experiment.name}' accessible traces.",
-      }
-
-    except Exception as e:
-      error_msg = str(e)
-      if '401' in error_msg or 'Credential' in error_msg:
-        return {
-          'success': False,
-          'error': 'Authentication failed',
-          'message': 'MLflow authentication failed. Please check your Databricks token and permissions.',
-        }
-      elif '404' in error_msg:
-        return {
-          'success': False,
-          'error': 'Experiment not found',
-          'message': f'Experiment {config.experiment_id} not found. Please check your experiment ID.',
-        }
-      else:
-        return {'success': False, 'error': str(e), 'message': f'Connection failed: {str(e)}'}
+            error_msg = str(e)
+            if "401" in error_msg or "Credential" in error_msg:
+                return {
+                    "success": False,
+                    "error": "Authentication failed",
+                    "message": "MLflow authentication failed. Please check your Databricks token and permissions.",
+                }
+            if "404" in error_msg:
+                return {
+                    "success": False,
+                    "error": "Experiment not found",
+                    "message": f"Experiment {config.experiment_id} not found. Please check your experiment ID.",
+                }
+            return {"success": False, "error": str(e), "message": f"Connection failed: {e!s}"}

--- a/server/services/token_storage_service.py
+++ b/server/services/token_storage_service.py
@@ -2,88 +2,87 @@
 
 import threading
 from datetime import datetime, timedelta
-from typing import Dict, Optional
 
 
 class TokenStorageService:
-  """Service for storing Databricks tokens in memory with expiration."""
+    """Service for storing Databricks tokens in memory with expiration."""
 
-  def __init__(self):
-    self._tokens: Dict[str, Dict[str, any]] = {}
-    self._lock = threading.Lock()
-    self._default_expiry_hours = 24  # Tokens expire after 24 hours by default
+    def __init__(self):
+        self._tokens: dict[str, dict[str, any]] = {}
+        self._lock = threading.Lock()
+        self._default_expiry_hours = 24  # Tokens expire after 24 hours by default
 
-  def store_token(self, workshop_id: str, token: str, expiry_hours: int = None) -> None:
-    """Store a token for a workshop with optional expiration."""
-    if expiry_hours is None:
-      expiry_hours = self._default_expiry_hours
+    def store_token(self, workshop_id: str, token: str, expiry_hours: int = None) -> None:
+        """Store a token for a workshop with optional expiration."""
+        if expiry_hours is None:
+            expiry_hours = self._default_expiry_hours
 
-    expiry_time = datetime.now() + timedelta(hours=expiry_hours)
+        expiry_time = datetime.now() + timedelta(hours=expiry_hours)
 
-    with self._lock:
-      self._tokens[workshop_id] = {'token': token, 'expires_at': expiry_time, 'created_at': datetime.now()}
+        with self._lock:
+            self._tokens[workshop_id] = {"token": token, "expires_at": expiry_time, "created_at": datetime.now()}
 
-  def get_token(self, workshop_id: str) -> Optional[str]:
-    """Retrieve a token for a workshop if it exists and hasn't expired."""
-    with self._lock:
-      if workshop_id not in self._tokens:
-        return None
+    def get_token(self, workshop_id: str) -> str | None:
+        """Retrieve a token for a workshop if it exists and hasn't expired."""
+        with self._lock:
+            if workshop_id not in self._tokens:
+                return None
 
-      token_data = self._tokens[workshop_id]
+            token_data = self._tokens[workshop_id]
 
-      # Check if token has expired
-      if datetime.now() > token_data['expires_at']:
-        # Remove expired token
-        del self._tokens[workshop_id]
-        return None
+            # Check if token has expired
+            if datetime.now() > token_data["expires_at"]:
+                # Remove expired token
+                del self._tokens[workshop_id]
+                return None
 
-      return token_data['token']
+            return token_data["token"]
 
-  def remove_token(self, workshop_id: str) -> bool:
-    """Remove a token for a workshop."""
-    with self._lock:
-      if workshop_id in self._tokens:
-        del self._tokens[workshop_id]
-        return True
-      return False
+    def remove_token(self, workshop_id: str) -> bool:
+        """Remove a token for a workshop."""
+        with self._lock:
+            if workshop_id in self._tokens:
+                del self._tokens[workshop_id]
+                return True
+            return False
 
-  def delete_token(self, key: str) -> bool:
-    """Alias for remove_token for API consistency."""
-    return self.remove_token(key)
+    def delete_token(self, key: str) -> bool:
+        """Alias for remove_token for API consistency."""
+        return self.remove_token(key)
 
-  def has_token(self, workshop_id: str) -> bool:
-    """Check if a valid (non-expired) token exists for a workshop."""
-    return self.get_token(workshop_id) is not None
+    def has_token(self, workshop_id: str) -> bool:
+        """Check if a valid (non-expired) token exists for a workshop."""
+        return self.get_token(workshop_id) is not None
 
-  def cleanup_expired_tokens(self) -> int:
-    """Remove all expired tokens and return count of removed tokens."""
-    current_time = datetime.now()
-    expired_workshops = []
+    def cleanup_expired_tokens(self) -> int:
+        """Remove all expired tokens and return count of removed tokens."""
+        current_time = datetime.now()
+        expired_workshops = []
 
-    with self._lock:
-      for workshop_id, token_data in self._tokens.items():
-        if current_time > token_data['expires_at']:
-          expired_workshops.append(workshop_id)
+        with self._lock:
+            for workshop_id, token_data in self._tokens.items():
+                if current_time > token_data["expires_at"]:
+                    expired_workshops.append(workshop_id)
 
-      for workshop_id in expired_workshops:
-        del self._tokens[workshop_id]
+            for workshop_id in expired_workshops:
+                del self._tokens[workshop_id]
 
-    return len(expired_workshops)
+        return len(expired_workshops)
 
-  def get_token_info(self, workshop_id: str) -> Optional[Dict[str, any]]:
-    """Get token information including creation and expiry times."""
-    with self._lock:
-      if workshop_id not in self._tokens:
-        return None
+    def get_token_info(self, workshop_id: str) -> dict[str, any] | None:
+        """Get token information including creation and expiry times."""
+        with self._lock:
+            if workshop_id not in self._tokens:
+                return None
 
-      token_data = self._tokens[workshop_id]
+            token_data = self._tokens[workshop_id]
 
-      # Check if token has expired
-      if datetime.now() > token_data['expires_at']:
-        del self._tokens[workshop_id]
-        return None
+            # Check if token has expired
+            if datetime.now() > token_data["expires_at"]:
+                del self._tokens[workshop_id]
+                return None
 
-      return {'created_at': token_data['created_at'], 'expires_at': token_data['expires_at'], 'is_expired': False}
+            return {"created_at": token_data["created_at"], "expires_at": token_data["expires_at"], "is_expired": False}
 
 
 # Global instance for the application

--- a/server/sqlite_rescue.py
+++ b/server/sqlite_rescue.py
@@ -283,20 +283,19 @@ def restore_from_volume() -> bool:
         # File doesn't exist on volume - this is normal for first run
         logger.info(f"No backup found at {volume_backup_path} - starting fresh")
         return False
-    elif result is False:
+    if result is False:
         # An actual error occurred
         logger.error(f"Failed to restore database from {volume_backup_path}")
         return False
-    else:
-        # Success! Try to restore WAL file too (if it exists on volume)
-        wal_volume = volume_backup_path + "-wal"
-        wal_local = str(local_path) + "-wal"
-        wal_result = _download_from_volume(wal_volume, wal_local)
-        if wal_result is True:
-            logger.info(f"Also restored WAL file from {wal_volume}")
+    # Success! Try to restore WAL file too (if it exists on volume)
+    wal_volume = volume_backup_path + "-wal"
+    wal_local = str(local_path) + "-wal"
+    wal_result = _download_from_volume(wal_volume, wal_local)
+    if wal_result is True:
+        logger.info(f"Also restored WAL file from {wal_volume}")
 
-        logger.info(f"Successfully restored database from {volume_backup_path}")
-        return True
+    logger.info(f"Successfully restored database from {volume_backup_path}")
+    return True
 
 
 def backup_to_volume(force: bool = False) -> bool:
@@ -434,8 +433,7 @@ def start_backup_timer() -> None:
         _backup_timer.start()
 
     logger.info(
-        f"Periodic backup timer started - backing up to {volume_backup_path} "
-        f"every {backup_interval_minutes} minutes"
+        f"Periodic backup timer started - backing up to {volume_backup_path} every {backup_interval_minutes} minutes"
     )
 
 
@@ -491,19 +489,13 @@ def install_shutdown_handlers() -> None:
     _, volume_backup_path, _ = _get_config()
 
     if not volume_backup_path:
-        logger.info(
-            "SQLITE_VOLUME_BACKUP_PATH not configured - "
-            "shutdown backup handlers not installed"
-        )
+        logger.info("SQLITE_VOLUME_BACKUP_PATH not configured - shutdown backup handlers not installed")
         return
 
     # Validate volume path format early to catch misconfiguration at startup
     is_valid, error_msg = _validate_volume_path(volume_backup_path)
     if not is_valid:
-        logger.error(
-            f"Invalid SQLITE_VOLUME_BACKUP_PATH: {error_msg}. "
-            "Shutdown backup handlers NOT installed."
-        )
+        logger.error(f"Invalid SQLITE_VOLUME_BACKUP_PATH: {error_msg}. Shutdown backup handlers NOT installed.")
         return
 
     # Verify we can create a WorkspaceClient (SDK is available)
@@ -531,8 +523,7 @@ def install_shutdown_handlers() -> None:
 
     _shutdown_handlers_installed = True
     logger.info(
-        f"Shutdown backup handlers installed - "
-        f"database will be backed up to {volume_backup_path} on SIGTERM/SIGINT"
+        f"Shutdown backup handlers installed - database will be backed up to {volume_backup_path} on SIGTERM/SIGINT"
     )
 
 

--- a/server/utils/config.py
+++ b/server/utils/config.py
@@ -2,88 +2,88 @@
 
 import os
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any
 
 import yaml
 
 
-def load_auth_config(config_path: Optional[str] = None) -> Dict[str, Any]:
-  """Load authentication configuration from YAML file.
+def load_auth_config(config_path: str | None = None) -> dict[str, Any]:
+    """Load authentication configuration from YAML file.
 
-  Args:
-      config_path: Path to config file. If None, uses default location.
+    Args:
+        config_path: Path to config file. If None, uses default location.
 
-  Returns:
-      Configuration dictionary
-  """
-  if config_path is None:
-    # Default to config/auth.yaml relative to project root
-    project_root = Path(__file__).parent.parent.parent
-    config_path = project_root / 'config' / 'auth.yaml'
+    Returns:
+        Configuration dictionary
+    """
+    if config_path is None:
+        # Default to config/auth.yaml relative to project root
+        project_root = Path(__file__).parent.parent.parent
+        config_path = project_root / "config" / "auth.yaml"
 
-  if not os.path.exists(config_path):
-    # Return default configuration if file doesn't exist
-    return {
-      'facilitators': [
-        {
-          'email': 'facilitator@databricks.com',
-          'password': 'facilitator123',
-          'name': 'Databricks Facilitator',
-          'description': 'Primary workshop facilitator',
+    if not os.path.exists(config_path):
+        # Return default configuration if file doesn't exist
+        return {
+            "facilitators": [
+                {
+                    "email": "facilitator@databricks.com",
+                    "password": "facilitator123",
+                    "name": "Databricks Facilitator",
+                    "description": "Primary workshop facilitator",
+                }
+            ],
+            "security": {
+                "default_user_password": "changeme123",
+                "password_requirements": {
+                    "min_length": 8,
+                    "require_uppercase": True,
+                    "require_lowercase": True,
+                    "require_numbers": True,
+                    "require_special_chars": False,
+                },
+                "session": {"token_expiry_hours": 24, "refresh_token_expiry_days": 7},
+            },
         }
-      ],
-      'security': {
-        'default_user_password': 'changeme123',
-        'password_requirements': {
-          'min_length': 8,
-          'require_uppercase': True,
-          'require_lowercase': True,
-          'require_numbers': True,
-          'require_special_chars': False,
-        },
-        'session': {'token_expiry_hours': 24, 'refresh_token_expiry_days': 7},
-      },
-    }
 
-  try:
-    with open(config_path, 'r') as f:
-      config = yaml.safe_load(f)
-    return config or {}
-  except Exception as e:
-    print(f'Warning: Could not load auth config from {config_path}: {e}')
-    return {}
+    try:
+        with open(config_path) as f:
+            config = yaml.safe_load(f)
+        return config or {}
+    except Exception as e:
+        print(f"Warning: Could not load auth config from {config_path}: {e}")
+        return {}
 
 
-def get_facilitator_config(email: str, config_path: Optional[str] = None) -> Optional[Dict[str, Any]]:
-  """Get facilitator configuration for a specific email.
+def get_facilitator_config(email: str, config_path: str | None = None) -> dict[str, Any] | None:
+    """Get facilitator configuration for a specific email.
 
-  Args:
-      email: Facilitator email
-      config_path: Path to config file
+    Args:
+        email: Facilitator email
+        config_path: Path to config file
 
-  Returns:
-      Facilitator config dict or None if not found
-  """
-  config = load_auth_config(config_path)
-  facilitators = config.get('facilitators', [])
+    Returns:
+        Facilitator config dict or None if not found
+    """
+    config = load_auth_config(config_path)
+    facilitators = config.get("facilitators", [])
 
-  # Case-insensitive email comparison
-  email_lower = email.lower()
-  for facilitator in facilitators:
-    if facilitator.get('email', '').lower() == email_lower:
-      return facilitator
+    # Case-insensitive email comparison
+    email_lower = email.lower()
+    for facilitator in facilitators:
+        if facilitator.get("email", "").lower() == email_lower:
+            return facilitator
 
-  return None
+    return None
 
 
-def get_security_config(config_path: Optional[str] = None) -> Dict[str, Any]:
-  """Get security configuration.
+def get_security_config(config_path: str | None = None) -> dict[str, Any]:
+    """Get security configuration.
 
-  Args:
-      config_path: Path to config file
+    Args:
+        config_path: Path to config file
 
-  Returns:
-      Security configuration dict
-  """
-  config = load_auth_config(config_path)
-  return config.get('security', {})
+    Returns:
+        Security configuration dict
+    """
+    config = load_auth_config(config_path)
+    return config.get("security", {})

--- a/server/utils/encryption.py
+++ b/server/utils/encryption.py
@@ -10,103 +10,105 @@ logger = logging.getLogger(__name__)
 
 
 class EncryptionManager:
-  """Manages encryption and decryption of sensitive data."""
+    """Manages encryption and decryption of sensitive data."""
 
-  def __init__(self, secret_key: str = None):
-    """Initialize encryption manager.
+    def __init__(self, secret_key: str = None):
+        """Initialize encryption manager.
 
-    Args:
-        secret_key: Optional secret key. If not provided, will use environment variable ENCRYPTION_KEY
-    """
-    if secret_key:
-      self.secret_key = secret_key
-    else:
-      self.secret_key = os.getenv('ENCRYPTION_KEY')
+        Args:
+            secret_key: Optional secret key. If not provided, will use environment variable ENCRYPTION_KEY
+        """
+        if secret_key:
+            self.secret_key = secret_key
+        else:
+            self.secret_key = os.getenv("ENCRYPTION_KEY")
 
-    if not self.secret_key:
-      # Generate a new key if none exists
-      self.secret_key = self._generate_key()
-      logger.warning('No encryption key found. Generated new key. Please set ENCRYPTION_KEY environment variable for production.')
+        if not self.secret_key:
+            # Generate a new key if none exists
+            self.secret_key = self._generate_key()
+            logger.warning(
+                "No encryption key found. Generated new key. Please set ENCRYPTION_KEY environment variable for production."
+            )
 
-    # Create Fernet cipher
-    self.cipher = Fernet(self.secret_key.encode())
+        # Create Fernet cipher
+        self.cipher = Fernet(self.secret_key.encode())
 
-  def _generate_key(self) -> str:
-    """Generate a new encryption key."""
-    key = Fernet.generate_key()
-    return key.decode()
+    def _generate_key(self) -> str:
+        """Generate a new encryption key."""
+        key = Fernet.generate_key()
+        return key.decode()
 
-  def encrypt(self, data: str) -> str:
-    """Encrypt a string.
+    def encrypt(self, data: str) -> str:
+        """Encrypt a string.
 
-    Args:
-        data: String to encrypt
+        Args:
+            data: String to encrypt
 
-    Returns:
-        Encrypted string (base64 encoded)
-    """
-    if not data:
-      return ''
+        Returns:
+            Encrypted string (base64 encoded)
+        """
+        if not data:
+            return ""
 
-    try:
-      encrypted_data = self.cipher.encrypt(data.encode())
-      return base64.b64encode(encrypted_data).decode()
-    except Exception as e:
-      logger.error(f'Encryption failed: {e}')
-      raise ValueError(f'Failed to encrypt data: {e}')
-
-  def decrypt(self, encrypted_data: str) -> str:
-    """Decrypt a string.
-
-    Args:
-        encrypted_data: Encrypted string (base64 encoded)
-
-    Returns:
-        Decrypted string
-    """
-    if not encrypted_data:
-      return ''
-
-    try:
-      # Decode from base64
-      encrypted_bytes = base64.b64decode(encrypted_data.encode())
-      decrypted_data = self.cipher.decrypt(encrypted_bytes)
-      return decrypted_data.decode()
-    except Exception as e:
-      logger.error(f'Decryption failed: {e}')
-      raise ValueError(f'Failed to decrypt data: {e}')
-
-  def is_encrypted(self, data: str) -> bool:
-    """Check if data appears to be encrypted.
-
-    Args:
-        data: String to check
-
-    Returns:
-        True if data appears to be encrypted
-    """
-    if not data:
-      return False
-
-    try:
-      # Try to decode as base64
-      decoded = base64.b64decode(data.encode())
-
-      # Check if it's a valid Fernet token (32 bytes + signature)
-      if len(decoded) >= 32:
-        # Try to decrypt with our cipher to see if it's our encrypted data
         try:
-          self.cipher.decrypt(decoded)
-          return True
-        except Exception:
-          # If decryption fails, it's not our encrypted data
-          pass
+            encrypted_data = self.cipher.encrypt(data.encode())
+            return base64.b64encode(encrypted_data).decode()
+        except Exception as e:
+            logger.error(f"Encryption failed: {e}")
+            raise ValueError(f"Failed to encrypt data: {e}") from e
 
-      # If it's base64 but not our encrypted format, it's probably not encrypted
-      return False
-    except Exception:
-      # If base64 decode fails, it's probably not encrypted
-      return False
+    def decrypt(self, encrypted_data: str) -> str:
+        """Decrypt a string.
+
+        Args:
+            encrypted_data: Encrypted string (base64 encoded)
+
+        Returns:
+            Decrypted string
+        """
+        if not encrypted_data:
+            return ""
+
+        try:
+            # Decode from base64
+            encrypted_bytes = base64.b64decode(encrypted_data.encode())
+            decrypted_data = self.cipher.decrypt(encrypted_bytes)
+            return decrypted_data.decode()
+        except Exception as e:
+            logger.error(f"Decryption failed: {e}")
+            raise ValueError(f"Failed to decrypt data: {e}") from e
+
+    def is_encrypted(self, data: str) -> bool:
+        """Check if data appears to be encrypted.
+
+        Args:
+            data: String to check
+
+        Returns:
+            True if data appears to be encrypted
+        """
+        if not data:
+            return False
+
+        try:
+            # Try to decode as base64
+            decoded = base64.b64decode(data.encode())
+
+            # Check if it's a valid Fernet token (32 bytes + signature)
+            if len(decoded) >= 32:
+                # Try to decrypt with our cipher to see if it's our encrypted data
+                try:
+                    self.cipher.decrypt(decoded)
+                    return True
+                except Exception:
+                    # If decryption fails, it's not our encrypted data
+                    pass
+
+            # If it's base64 but not our encrypted format, it's probably not encrypted
+            return False
+        except Exception:
+            # If base64 decode fails, it's probably not encrypted
+            return False
 
 
 # Global encryption manager instance
@@ -114,50 +116,48 @@ _encryption_manager = None
 
 
 def get_encryption_manager() -> EncryptionManager:
-  """Get the global encryption manager instance."""
-  global _encryption_manager
-  if _encryption_manager is None:
-    _encryption_manager = EncryptionManager()
-  return _encryption_manager
+    """Get the global encryption manager instance."""
+    global _encryption_manager
+    if _encryption_manager is None:
+        _encryption_manager = EncryptionManager()
+    return _encryption_manager
 
 
 def encrypt_sensitive_data(data: str) -> str:
-  """Encrypt sensitive data.
+    """Encrypt sensitive data.
 
-  Args:
-      data: Data to encrypt
+    Args:
+        data: Data to encrypt
 
-  Returns:
-      Encrypted data
-  """
-  if not data:
-    return ''
+    Returns:
+        Encrypted data
+    """
+    if not data:
+        return ""
 
-  manager = get_encryption_manager()
+    manager = get_encryption_manager()
 
-  # Only encrypt if not already encrypted
-  if not manager.is_encrypted(data):
-    return manager.encrypt(data)
-  else:
+    # Only encrypt if not already encrypted
+    if not manager.is_encrypted(data):
+        return manager.encrypt(data)
     return data
 
 
 def decrypt_sensitive_data(data: str) -> str:
-  """Decrypt sensitive data.
+    """Decrypt sensitive data.
 
-  Args:
-      data: Data to decrypt
+    Args:
+        data: Data to decrypt
 
-  Returns:
-      Decrypted data
-  """
-  if not data:
-    return ''
+    Returns:
+        Decrypted data
+    """
+    if not data:
+        return ""
 
-  manager = get_encryption_manager()
+    manager = get_encryption_manager()
 
-  # Only decrypt if it appears to be encrypted
-  if manager.is_encrypted(data):
-    return manager.decrypt(data)
-  else:
+    # Only decrypt if it appears to be encrypted
+    if manager.is_encrypted(data):
+        return manager.decrypt(data)
     return data

--- a/server/utils/jsonpath_utils.py
+++ b/server/utils/jsonpath_utils.py
@@ -1,13 +1,12 @@
 """JSONPath utility functions for extracting values from trace data."""
 
 import json
-from typing import Optional, Tuple
 
 from jsonpath_ng import parse
 from jsonpath_ng.exceptions import JsonPathParserError
 
 
-def apply_jsonpath(data_str: str, jsonpath_expr: Optional[str]) -> Tuple[Optional[str], bool]:
+def apply_jsonpath(data_str: str, jsonpath_expr: str | None) -> tuple[str | None, bool]:
     """
     Apply JSONPath expression to a JSON string.
 
@@ -77,7 +76,7 @@ def apply_jsonpath(data_str: str, jsonpath_expr: Optional[str]) -> Tuple[Optiona
     return result, True
 
 
-def validate_jsonpath(jsonpath_expr: str) -> Tuple[bool, Optional[str]]:
+def validate_jsonpath(jsonpath_expr: str) -> tuple[bool, str | None]:
     """
     Validate a JSONPath expression.
 
@@ -96,6 +95,6 @@ def validate_jsonpath(jsonpath_expr: str) -> Tuple[bool, Optional[str]]:
         parse(jsonpath_expr.strip())
         return True, None
     except JsonPathParserError as e:
-        return False, f"Invalid JSONPath syntax: {str(e)}"
+        return False, f"Invalid JSONPath syntax: {e!s}"
     except Exception as e:
-        return False, f"JSONPath parsing error: {str(e)}"
+        return False, f"JSONPath parsing error: {e!s}"

--- a/server/utils/password.py
+++ b/server/utils/password.py
@@ -1,101 +1,100 @@
 """Password utilities for authentication."""
 
 import re
-from typing import Optional
 
 import bcrypt
 
 
 def hash_password(password: str) -> str:
-  """Hash a password using bcrypt.
+    """Hash a password using bcrypt.
 
-  Args:
-      password: Plain text password (can be empty for SME/participant accounts)
+    Args:
+        password: Plain text password (can be empty for SME/participant accounts)
 
-  Returns:
-      Hashed password string
-  """
-  # Allow empty passwords for SME/participant accounts (email-only login)
-  if not password:
-    # Return a special hash for empty passwords
-    # This will never match any real password input
-    return bcrypt.hashpw(b'', bcrypt.gensalt()).decode('utf-8')
+    Returns:
+        Hashed password string
+    """
+    # Allow empty passwords for SME/participant accounts (email-only login)
+    if not password:
+        # Return a special hash for empty passwords
+        # This will never match any real password input
+        return bcrypt.hashpw(b"", bcrypt.gensalt()).decode("utf-8")
 
-  # Generate salt and hash
-  salt = bcrypt.gensalt()
-  hashed = bcrypt.hashpw(password.encode('utf-8'), salt)
-  return hashed.decode('utf-8')
+    # Generate salt and hash
+    salt = bcrypt.gensalt()
+    hashed = bcrypt.hashpw(password.encode("utf-8"), salt)
+    return hashed.decode("utf-8")
 
 
 def verify_password(password: str, hashed_password: str) -> bool:
-  """Verify a password against its hash.
+    """Verify a password against its hash.
 
-  Args:
-      password: Plain text password to verify
-      hashed_password: Hashed password to check against
+    Args:
+        password: Plain text password to verify
+        hashed_password: Hashed password to check against
 
-  Returns:
-      True if password matches, False otherwise
-  """
-  if not password or not hashed_password:
-    return False
+    Returns:
+        True if password matches, False otherwise
+    """
+    if not password or not hashed_password:
+        return False
 
-  try:
-    return bcrypt.checkpw(password.encode('utf-8'), hashed_password.encode('utf-8'))
-  except Exception:
-    return False
+    try:
+        return bcrypt.checkpw(password.encode("utf-8"), hashed_password.encode("utf-8"))
+    except Exception:
+        return False
 
 
 def validate_password_strength(
-  password: str,
-  min_length: int = 8,
-  require_uppercase: bool = True,
-  require_lowercase: bool = True,
-  require_numbers: bool = True,
-  require_special_chars: bool = False,
-) -> tuple[bool, Optional[str]]:
-  """Validate password strength according to requirements.
+    password: str,
+    min_length: int = 8,
+    require_uppercase: bool = True,
+    require_lowercase: bool = True,
+    require_numbers: bool = True,
+    require_special_chars: bool = False,
+) -> tuple[bool, str | None]:
+    """Validate password strength according to requirements.
 
-  Args:
-      password: Password to validate
-      min_length: Minimum password length
-      require_uppercase: Whether to require uppercase letters
-      require_lowercase: Whether to require lowercase letters
-      require_numbers: Whether to require numbers
-      require_special_chars: Whether to require special characters
+    Args:
+        password: Password to validate
+        min_length: Minimum password length
+        require_uppercase: Whether to require uppercase letters
+        require_lowercase: Whether to require lowercase letters
+        require_numbers: Whether to require numbers
+        require_special_chars: Whether to require special characters
 
-  Returns:
-      Tuple of (is_valid, error_message)
-  """
-  if len(password) < min_length:
-    return False, f'Password must be at least {min_length} characters long'
+    Returns:
+        Tuple of (is_valid, error_message)
+    """
+    if len(password) < min_length:
+        return False, f"Password must be at least {min_length} characters long"
 
-  if require_uppercase and not re.search(r'[A-Z]', password):
-    return False, 'Password must contain at least one uppercase letter'
+    if require_uppercase and not re.search(r"[A-Z]", password):
+        return False, "Password must contain at least one uppercase letter"
 
-  if require_lowercase and not re.search(r'[a-z]', password):
-    return False, 'Password must contain at least one lowercase letter'
+    if require_lowercase and not re.search(r"[a-z]", password):
+        return False, "Password must contain at least one lowercase letter"
 
-  if require_numbers and not re.search(r'\d', password):
-    return False, 'Password must contain at least one number'
+    if require_numbers and not re.search(r"\d", password):
+        return False, "Password must contain at least one number"
 
-  if require_special_chars and not re.search(r'[!@#$%^&*(),.?":{}|<>]', password):
-    return False, 'Password must contain at least one special character'
+    if require_special_chars and not re.search(r'[!@#$%^&*(),.?":{}|<>]', password):
+        return False, "Password must contain at least one special character"
 
-  return True, None
+    return True, None
 
 
 def generate_default_password(email: str) -> str:
-  """Generate a default password for new users.
-  SMEs and participants don't need passwords (email-only login).
+    """Generate a default password for new users.
+    SMEs and participants don't need passwords (email-only login).
 
-  Args:
-      email: User's email address
+    Args:
+        email: User's email address
 
-  Returns:
-      Default password string (empty for participants/SMEs)
-  """
-  # For workshop participants and SMEs, no password needed
-  # They authenticate with email only
-  # This will be hashed and stored but never used for authentication
-  return ''
+    Returns:
+        Default password string (empty for participants/SMEs)
+    """
+    # For workshop participants and SMEs, no password needed
+    # They authenticate with email only
+    # This will be hashed and stored but never used for authentication
+    return ""


### PR DESCRIPTION
Activates the full ruff ruleset (E, W, F, I, B, C4, UP, SIM, RET, RUF, PERF) and enforces it across the server codebase. Previously only `--select F` was run via the `lint-ruff-deadcode` recipe.

- Auto-fix 1,071 violations (whitespace, modern annotations, import sorting, pyupgrade modernizations)
- Manually fix 54 B904 raise-without-from-inside-except violations
- Fix bare excepts (E722), mutable argument defaults (B006), unused loop vars (B007), zip-without-strict (B905), unnecessary int casts (RUF046)
- Add `just lint-ruff` recipe for full ruff linting
- Add sensible ignores for intentional patterns (unicode chars, conditional imports, implicit optional)

Closes #109

## Summary

<!-- Brief description of what this PR does -->

## Related Spec

<!-- Which spec(s) does this PR implement or affect? -->
- Spec: `SPEC_NAME` (from `/specs/`)

## Changes

<!-- List the key changes made -->
-

## Testing

<!-- How was this tested? -->
- [ ] Tests tagged with `@pytest.mark.spec("SPEC_NAME")` or equivalent
- [ ] `just test-server` passes
- [ ] `just ui-test-unit` passes
- [ ] `just ui-lint` passes
- [ ] E2E tests pass (if applicable)

## Checklist

- [ ] Read the relevant spec before implementing
- [ ] No changes to `/specs/` without approval
- [ ] No new database migrations without approval
- [ ] Coverage map updated if new tests added (`uv run spec-coverage-analyzer`)
