### PR TITLE
feat(summarization): add cancel button for stuck jobs

### DIFF
--- a/client/src/components/SummarizationSettings.tsx
+++ b/client/src/components/SummarizationSettings.tsx
@@ -14,7 +14,7 @@ import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
 import { Badge } from '@/components/ui/badge';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Sparkles, Save, CheckCircle, RefreshCw, BarChart3 } from 'lucide-react';
+import { Sparkles, Save, CheckCircle, RefreshCw, BarChart3, XCircle } from 'lucide-react';
 import { toast } from 'sonner';
 import { useWorkshopContext } from '@/context/WorkshopContext';
 import {
@@ -24,6 +24,7 @@ import {
   useSummarizationJob,
   useSummarizationStatus,
   useResummarize,
+  useCancelSummarizationJob,
 } from '@/hooks/useWorkshopApi';
 import { buildModelOptions } from '@/utils/modelMapping';
 
@@ -34,6 +35,7 @@ export const SummarizationSettings: React.FC = () => {
   const updateSettings = useUpdateSummarizationSettings(workshopId!);
   const { data: summaryStatus } = useSummarizationStatus(workshopId!);
   const resummarize = useResummarize(workshopId!);
+  const cancelJob = useCancelSummarizationJob(workshopId!);
 
   const [enabled, setEnabled] = useState(false);
   const [model, setModel] = useState<string>('');
@@ -104,6 +106,17 @@ export const SummarizationSettings: React.FC = () => {
       toast.error(message);
     }
     setShowConfirmDialog(false);
+  };
+
+  const handleCancel = async () => {
+    if (!activeJobId) return;
+    try {
+      await cancelJob.mutateAsync(activeJobId);
+      toast.success('Summarization job cancelled');
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Failed to cancel job';
+      toast.error(message);
+    }
   };
 
   const totalTraces = summaryStatus
@@ -226,12 +239,24 @@ export const SummarizationSettings: React.FC = () => {
                     <div className="w-3.5 h-3.5 border-2 border-indigo-300 border-t-indigo-600 rounded-full animate-spin" />
                     Summarizing traces...
                   </span>
-                  <span className="text-indigo-700">
-                    {activeJob.completed}/{activeJob.total} complete
-                    {activeJob.failed > 0 && (
-                      <span className="text-red-600 ml-1">({activeJob.failed} failed)</span>
-                    )}
-                  </span>
+                  <div className="flex items-center gap-3">
+                    <span className="text-indigo-700">
+                      {activeJob.completed}/{activeJob.total} complete
+                      {activeJob.failed > 0 && (
+                        <span className="text-red-600 ml-1">({activeJob.failed} failed)</span>
+                      )}
+                    </span>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="h-6 px-2 text-xs text-red-600 hover:text-red-700 hover:bg-red-50"
+                      onClick={handleCancel}
+                      disabled={cancelJob.isPending}
+                    >
+                      <XCircle className="w-3.5 h-3.5 mr-1" />
+                      Cancel
+                    </Button>
+                  </div>
                 </div>
                 <div className="w-full bg-indigo-200 rounded-full h-1.5">
                   <div
@@ -283,6 +308,21 @@ export const SummarizationSettings: React.FC = () => {
                     </Button>
                   </div>
                 )}
+              </div>
+            )}
+
+            {/* Cancelled job result */}
+            {activeJob && activeJob.status === 'cancelled' && (
+              <div className="bg-amber-50 border border-amber-200 rounded-lg p-3 space-y-2">
+                <div className="flex items-center justify-between text-sm">
+                  <span className="font-medium text-amber-900 flex items-center gap-2">
+                    <XCircle className="w-3.5 h-3.5 text-amber-600" />
+                    Summarization cancelled
+                  </span>
+                  <span className="text-amber-700">
+                    {activeJob.completed}/{activeJob.total} completed before cancellation
+                  </span>
+                </div>
               </div>
             )}
 

--- a/client/src/hooks/useWorkshopApi.ts
+++ b/client/src/hooks/useWorkshopApi.ts
@@ -902,7 +902,7 @@ export function useSummarizationJob(workshopId: string, jobId: string | null) {
     enabled: !!jobId,
     refetchInterval: (query) => {
       const status = query.state.data?.status;
-      if (status === 'completed' || status === 'failed') return false;
+      if (status === 'completed' || status === 'failed' || status === 'cancelled') return false;
       return 2000;
     },
   });
@@ -948,6 +948,27 @@ export function useResummarize(workshopId: string) {
       return response.json();
     },
     onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.summarizationStatus(workshopId) });
+    },
+  });
+}
+
+export function useCancelSummarizationJob(workshopId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (jobId: string): Promise<{ status: string; job_id: string }> => {
+      const response = await fetch(`/workshops/${workshopId}/cancel-summarization-job/${jobId}`, {
+        method: 'POST',
+      });
+      if (!response.ok) {
+        const error = await response.json().catch(() => ({ detail: 'Failed to cancel job' }));
+        throw new Error(error.detail || 'Failed to cancel job');
+      }
+      return response.json();
+    },
+    onSuccess: (_data, jobId) => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.summarizationJob(workshopId, jobId) });
       queryClient.invalidateQueries({ queryKey: QUERY_KEYS.summarizationStatus(workshopId) });
     },
   });

--- a/server/models.py
+++ b/server/models.py
@@ -202,7 +202,7 @@ class Trace(BaseModel):
 class SummarizationJob(BaseModel):
     id: str
     workshop_id: str
-    status: str = "pending"  # pending, running, completed, failed
+    status: str = "pending"  # pending, running, completed, failed, cancelled
     total: int = 0
     completed_traces: list[str] = Field(default_factory=list)
     failed_traces: list[dict] = Field(default_factory=list)

--- a/server/routers/workshops.py
+++ b/server/routers/workshops.py
@@ -175,12 +175,18 @@ from server.services.irr_service import calculate_irr_for_workshop
 # before completion.  Tasks remove themselves from this set when done.
 _background_tasks: set[asyncio.Task] = set()
 
+# Map summarization job IDs to their asyncio tasks so they can be cancelled.
+_job_tasks: dict[str, asyncio.Task] = {}
 
-def _fire_background_task(coro) -> asyncio.Task:
+
+def _fire_background_task(coro, job_id: str | None = None) -> asyncio.Task:
     """Schedule a coroutine as a background task with GC protection."""
     task = asyncio.create_task(coro)
     _background_tasks.add(task)
     task.add_done_callback(_background_tasks.discard)
+    if job_id is not None:
+        _job_tasks[job_id] = task
+        task.add_done_callback(lambda _t: _job_tasks.pop(job_id, None))
     return task
 
 
@@ -563,6 +569,13 @@ async def _run_summarization_background(
             succeeded = len([r for r in results if r["summary"]])
             failed = len([r for r in results if not r["summary"]])
             logger.info("Summarization job %s complete: %d succeeded, %d failed", job_id, succeeded, failed)
+    except asyncio.CancelledError:
+        logger.info("Summarization job %s was cancelled", job_id)
+        try:
+            with SessionLocal() as cancel_db:
+                DatabaseService(cancel_db).update_summarization_job_status(job_id, "cancelled")
+        except Exception:
+            logger.exception("Could not mark job %s as cancelled", job_id)
     except Exception:
         logger.exception("Summarization job %s failed", job_id)
         try:
@@ -635,7 +648,8 @@ async def resummarize_traces(
             guidance=workshop.summarization_guidance,
             use_case_description=workshop.description,
             batch=batch,
-        )
+        ),
+        job_id=job.id,
     )
 
     return {
@@ -670,6 +684,32 @@ async def get_summarization_job_status(
         "created_at": job.created_at.isoformat(),
         "updated_at": job.updated_at.isoformat(),
     }
+
+
+@router.post("/{workshop_id}/cancel-summarization-job/{job_id}")
+async def cancel_summarization_job(
+    workshop_id: str,
+    job_id: str,
+    db: Session = Depends(get_db),
+) -> dict:
+    """Cancel a running summarization job."""
+    db_service = DatabaseService(db)
+    job = db_service.get_summarization_job(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Summarization job not found")
+    if job.workshop_id != workshop_id:
+        raise HTTPException(status_code=403, detail="Job does not belong to this workshop")
+    if job.status not in ("pending", "running"):
+        raise HTTPException(status_code=400, detail=f"Job is already {job.status}")
+
+    task = _job_tasks.get(job_id)
+    if task and not task.done():
+        task.cancel()
+    else:
+        # Task not found in memory (e.g. server restarted) — just mark it cancelled
+        db_service.update_summarization_job_status(job_id, "cancelled")
+
+    return {"status": "cancelled", "job_id": job_id}
 
 
 @router.get("/{workshop_id}/summarization-status")
@@ -3108,7 +3148,8 @@ async def ingest_mlflow_traces(workshop_id: str, ingest_request: dict, db: Sessi
                             model_name=workshop.summarization_model,
                             guidance=workshop.summarization_guidance,
                             batch=batch,
-                        )
+                        ),
+                        job_id=summ_job.id,
                     )
             except Exception as e:
                 logger.warning(f"Failed to start background summarization: {e}")


### PR DESCRIPTION
## Summary
- Adds `POST /workshops/{id}/cancel-summarization-job/{job_id}` endpoint that cancels the asyncio background task and marks the job as `cancelled`
- Adds a cancel button in the SummarizationSettings progress indicator so facilitators can stop stuck or unwanted summarization jobs
- Handles graceful cancellation: partial results (traces already summarized) are preserved, and the UI shows a "cancelled" state with how many traces completed

## Test plan
- [x] `just test-server` — 810 passed
- [x] `just ui-lint` — 0 errors
- [ ] Manual: start a summarization job, click Cancel, verify job stops and UI shows cancelled state
- [ ] Manual: verify a cancelled job allows re-summarization (button re-enables)
- [ ] Manual: verify cancelling a job that completed a server restart (task not in memory) still marks it cancelled in DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)