### PR TITLE
fix: address eval-mode intake and Databricks host regressions

### DIFF
--- a/server/services/databricks_service.py
+++ b/server/services/databricks_service.py
@@ -25,6 +25,18 @@ def _get_token_hash(token: str) -> str:
     return hashlib.sha256(token.encode()).hexdigest()[:16]
 
 
+def _normalize_databricks_host(host: str | None) -> str | None:
+    """Normalize Databricks host to include scheme and no trailing slash."""
+    if not host:
+        return None
+    normalized = host.strip().rstrip("/")
+    if not normalized:
+        return None
+    if not normalized.startswith(("http://", "https://")):
+        normalized = f"https://{normalized}"
+    return normalized
+
+
 def normalize_experiment_id(experiment_id: str | None) -> str | None:
     """Normalize MLflow experiment IDs from env/form inputs.
 
@@ -99,15 +111,16 @@ def get_databricks_host() -> str:
     Raises:
         RuntimeError: If no host can be resolved.
     """
-    host = os.getenv("DATABRICKS_HOST")
+    host = _normalize_databricks_host(os.getenv("DATABRICKS_HOST"))
     if host:
-        return host.rstrip("/")
+        return host
     try:
         from databricks.sdk import WorkspaceClient
 
         w = WorkspaceClient()
-        if w.config.host:
-            return w.config.host.rstrip("/")
+        host = _normalize_databricks_host(w.config.host)
+        if host:
+            return host
     except Exception:
         pass
     raise RuntimeError(

--- a/server/services/mlflow_intake_service.py
+++ b/server/services/mlflow_intake_service.py
@@ -54,7 +54,7 @@ class MLflowIntakeService:
 
       # Search for traces with error handling
       traces = mlflow.search_traces(
-        experiment_ids=[experiment_id],
+        locations=[experiment_id],
         max_results=config.max_traces or 100,
         filter_string=config.filter_string,
         return_type='list',
@@ -111,6 +111,10 @@ class MLflowIntakeService:
   def ingest_traces(self, workshop_id: str, config: MLflowIntakeConfig) -> int:
     """Ingest traces from MLflow into the workshop."""
     try:
+      experiment_id = normalize_experiment_id(config.experiment_id)
+      if not experiment_id:
+        raise ValueError("MLflow experiment ID is empty after normalization.")
+
       # Search for traces
       trace_infos = self.search_traces(config)
 

--- a/tests/unit/services/test_databricks_service.py
+++ b/tests/unit/services/test_databricks_service.py
@@ -1,6 +1,6 @@
 import pytest
 
-from server.services.databricks_service import get_experiment_id, normalize_experiment_id
+from server.services.databricks_service import get_databricks_host, get_experiment_id, normalize_experiment_id
 
 
 def test_normalize_experiment_id_strips_wrapping_quotes_and_whitespace():
@@ -17,3 +17,13 @@ def test_get_experiment_id_raises_for_empty_after_normalization(monkeypatch):
     monkeypatch.setenv("MLFLOW_EXPERIMENT_ID", '""')
     with pytest.raises(RuntimeError, match="MLFLOW_EXPERIMENT_ID not set"):
         get_experiment_id()
+
+
+def test_get_databricks_host_adds_https_when_scheme_missing(monkeypatch):
+    monkeypatch.setenv("DATABRICKS_HOST", "adb-1234567890123456.7.azuredatabricks.net/")
+    assert get_databricks_host() == "https://adb-1234567890123456.7.azuredatabricks.net"
+
+
+def test_get_databricks_host_preserves_existing_scheme(monkeypatch):
+    monkeypatch.setenv("DATABRICKS_HOST", "https://dbc-example.cloud.databricks.com/")
+    assert get_databricks_host() == "https://dbc-example.cloud.databricks.com"

--- a/tests/unit/services/test_mlflow_intake_service.py
+++ b/tests/unit/services/test_mlflow_intake_service.py
@@ -1,0 +1,80 @@
+from types import SimpleNamespace
+
+from server.models import MLflowIntakeConfig, MLflowTraceInfo
+from server.services.mlflow_intake_service import MLflowIntakeService
+
+
+class _DummyDbService:
+    def __init__(self):
+        self.added_workshop_id = None
+        self.added_traces = None
+
+    def add_traces(self, workshop_id, traces):
+        self.added_workshop_id = workshop_id
+        self.added_traces = traces
+
+
+def test_ingest_traces_sets_normalized_experiment_id(monkeypatch):
+    db_service = _DummyDbService()
+    service = MLflowIntakeService(db_service)
+    config = MLflowIntakeConfig(experiment_id=' "12345" ', max_traces=1, filter_string=None)
+
+    monkeypatch.setattr(
+        service,
+        "search_traces",
+        lambda _config: [
+            MLflowTraceInfo(
+                trace_id="tr-1",
+                request_preview="request",
+                response_preview="response",
+                status="OK",
+                timestamp_ms=1,
+            )
+        ],
+    )
+
+    span = SimpleNamespace(
+        name="span-1",
+        span_type="LLM",
+        inputs={"a": 1},
+        outputs={"b": 2},
+        start_time_ns=1,
+        end_time_ns=2,
+    )
+    full_trace = SimpleNamespace(
+        data=SimpleNamespace(spans=[span], request='{"messages": []}', response='{"messages": []}'),
+        info=SimpleNamespace(execution_time_ms=10, status="OK", tags={"x": "y"}),
+    )
+
+    import server.services.mlflow_intake_service as intake_module
+
+    monkeypatch.setattr(intake_module.mlflow, "get_trace", lambda trace_id: full_trace)
+    monkeypatch.setattr(intake_module, "get_databricks_host", lambda: "https://dbc.example.com")
+
+    ingested = service.ingest_traces("ws-1", config)
+
+    assert ingested == 1
+    assert db_service.added_workshop_id == "ws-1"
+    assert len(db_service.added_traces) == 1
+    assert db_service.added_traces[0].mlflow_experiment_id == "12345"
+    assert db_service.added_traces[0].trace_metadata["mlflow_experiment_id"] == "12345"
+
+
+def test_search_traces_uses_locations_argument(monkeypatch):
+    db_service = _DummyDbService()
+    service = MLflowIntakeService(db_service)
+    config = MLflowIntakeConfig(experiment_id="exp-1", max_traces=5, filter_string=None)
+    captured = {}
+
+    def _fake_search_traces(**kwargs):
+        captured.update(kwargs)
+        return []
+
+    import server.services.mlflow_intake_service as intake_module
+
+    monkeypatch.setattr(intake_module.mlflow, "search_traces", _fake_search_traces)
+
+    service.search_traces(config)
+
+    assert captured["locations"] == ["exp-1"]
+    assert "experiment_ids" not in captured


### PR DESCRIPTION
## Summary
- fix MLflow intake regression by normalizing/defining `experiment_id` during ingestion to avoid `NameError` and preserve metadata/links
- switch MLflow trace search to `locations=[experiment_id]` to align with the non-deprecated API and remove warning noise
- normalize Databricks host resolution to always include protocol so serving-endpoint listing works when `DATABRICKS_HOST` is provided without scheme
- add targeted unit tests for both regressions in intake and Databricks host resolution paths

## Test plan
- [x] `uv run --no-project --python /Users/forrest.murray/Documents/project-0xfffff/.venv/bin/python pytest -q /Users/forrest.murray/Documents/project-0xfffff-hotfix-eval-mode/tests/unit/services/test_mlflow_intake_service.py /Users/forrest.murray/Documents/project-0xfffff-hotfix-eval-mode/tests/unit/services/test_databricks_service.py --json-report --json-report-file=/Users/forrest.murray/Documents/project-0xfffff-hotfix-eval-mode/.test-results/pytest.json`
- [x] `uv run --no-project --python /Users/forrest.murray/Documents/project-0xfffff/.venv/bin/python alembic -c /Users/forrest.murray/Documents/project-0xfffff-hotfix-eval-mode/alembic.ini heads`