### PR TITLE
fix(migration): use dialect-agnostic boolean defaults for Lakebase co…

### DIFF
--- a/migrations/versions/0002_legacy_schema_fixes.py
+++ b/migrations/versions/0002_legacy_schema_fixes.py
@@ -80,7 +80,7 @@ def upgrade() -> None:
 
     # traces.include_in_alignment / sme_feedback (alignment filtering + concatenated feedback)
     # Use dialect-specific default for boolean: 1 for SQLite, TRUE for PostgreSQL
-    bool_default = sa.text("TRUE") if _is_postgres() else sa.text("1")
+    bool_default = sa.true()
     _add_column_if_missing(
         "traces",
         sa.Column("include_in_alignment", sa.Boolean(), server_default=bool_default),

--- a/migrations/versions/0004_add_randomization_columns.py
+++ b/migrations/versions/0004_add_randomization_columns.py
@@ -19,26 +19,17 @@ branch_labels = None
 depends_on = None
 
 
-def _is_postgres() -> bool:
-    """Check if the current database is PostgreSQL."""
-    bind = op.get_bind()
-    return bind.dialect.name == "postgresql"
-
-
 def upgrade() -> None:
-    # Use dialect-specific default for boolean: 0 for SQLite, FALSE for PostgreSQL
-    bool_false_default = sa.text("FALSE") if _is_postgres() else sa.text("0")
-
     # Add discovery_randomize_traces column with default False
     op.add_column(
         "workshops",
-        sa.Column("discovery_randomize_traces", sa.Boolean(), nullable=True, server_default=bool_false_default)
+        sa.Column("discovery_randomize_traces", sa.Boolean(), nullable=True, server_default=sa.false())
     )
 
     # Add annotation_randomize_traces column with default False
     op.add_column(
         "workshops",
-        sa.Column("annotation_randomize_traces", sa.Boolean(), nullable=True, server_default=bool_false_default)
+        sa.Column("annotation_randomize_traces", sa.Boolean(), nullable=True, server_default=sa.false())
     )
 
 

--- a/migrations/versions/0010_add_participant_notes.py
+++ b/migrations/versions/0010_add_participant_notes.py
@@ -18,12 +18,6 @@ branch_labels = None
 depends_on = None
 
 
-def _is_postgres() -> bool:
-    """Check if the current database is PostgreSQL."""
-    bind = op.get_bind()
-    return bind.dialect.name == "postgresql"
-
-
 def upgrade() -> None:
     op.create_table(
         "participant_notes",
@@ -57,12 +51,10 @@ def upgrade() -> None:
         ["workshop_id", "user_id"],
     )
 
-    # Add facilitator toggle to workshops table. PostgreSQL requires boolean
-    # defaults to be boolean literals, not SQLite-style 0/1 integers.
-    bool_false_default = sa.text("FALSE") if _is_postgres() else sa.text("0")
+    # Add facilitator toggle to workshops table.
     with op.batch_alter_table("workshops") as batch_op:
         batch_op.add_column(
-            sa.Column("show_participant_notes", sa.Boolean(), server_default=bool_false_default, nullable=False)
+            sa.Column("show_participant_notes", sa.Boolean(), server_default=sa.false(), nullable=False)
         )
 
 

--- a/tests/unit/test_build_deploy.py
+++ b/tests/unit/test_build_deploy.py
@@ -301,21 +301,22 @@ class TestLakebaseMigrationSchemaSetup:
         assert "version_num_width" in content
 
     def test_boolean_migration_defaults_are_postgres_safe(self):
-        """Boolean columns in migrations must not use SQLite-only integer defaults unconditionally."""
+        """Boolean columns in migrations must use sa.true()/sa.false() for server defaults."""
         versions_dir = PROJECT_ROOT / "migrations" / "versions"
         offenders: list[str] = []
         for migration_file in versions_dir.glob("*.py"):
             content = migration_file.read_text()
             if "sa.Boolean()" not in content:
                 continue
+            # Reject any sa.text() used for boolean defaults — use sa.true()/sa.false() instead
             if 'server_default=sa.text("0")' in content or "server_default=sa.text('0')" in content:
-                if "if _is_postgres()" not in content and "bind.dialect.name" not in content:
-                    offenders.append(migration_file.name)
+                offenders.append(migration_file.name)
             if 'server_default=sa.text("1")' in content or "server_default=sa.text('1')" in content:
-                if "if _is_postgres()" not in content and "bind.dialect.name" not in content:
-                    offenders.append(migration_file.name)
+                offenders.append(migration_file.name)
 
-        assert offenders == []
+        assert offenders == [], (
+            f"Migrations using sa.text() for boolean defaults (use sa.true()/sa.false() instead): {offenders}"
+        )
 
 
 @pytest.mark.spec("BUILD_AND_DEPLOY_SPEC")


### PR DESCRIPTION
…mpatibility

Migrations 0002, 0004, and 0010 used _is_postgres() to branch between sa.text("0")/sa.text("FALSE") for boolean server_default values. This check returned False on Lakebase (likely due to render_as_batch=True context), causing PostgreSQL to reject DEFAULT 0 for BOOLEAN columns with DatatypeMismatch.

Replace with sa.false()/sa.true() — SQLAlchemy's dialect-agnostic boolean literals that render correctly on both SQLite and PostgreSQL. This matches the pattern already used by migration 0021.

Strengthened the guard test to reject the _is_postgres() branching pattern and require sa.true()/sa.false() going forward.

Co-authored-by: Claude

## Summary

<!-- Brief description of what this PR does -->

## Related Spec

<!-- Which spec(s) does this PR implement or affect? -->
- Spec: `SPEC_NAME` (from `/specs/`)

## Changes

<!-- List the key changes made -->
-

## Testing

<!-- How was this tested? -->
- [ ] Tests tagged with `@pytest.mark.spec("SPEC_NAME")` or equivalent
- [ ] `just test-server` passes
- [ ] `just ui-test-unit` passes
- [ ] `just ui-lint` passes
- [ ] E2E tests pass (if applicable)

## Checklist

- [ ] Read the relevant spec before implementing
- [ ] No changes to `/specs/` without approval
- [ ] No new database migrations without approval
- [ ] Coverage map updated if new tests added (`uv run spec-coverage-analyzer`)
