### PR TITLE
fix(llm): enable cross-provider interop and cache serving endpoints

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -20,3 +20,5 @@ env:
     value: "2"
   - name: MLFLOW_EXPERIMENT_ID
     valueFrom: experiment
+  - name: ENDPOINT_NAME
+    valueFrom: postgres

--- a/app.yaml
+++ b/app.yaml
@@ -21,4 +21,4 @@ env:
   - name: MLFLOW_EXPERIMENT_ID
     valueFrom: experiment
   - name: ENDPOINT_NAME
-    valueFrom: postgres
+    valueFrom: database

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "databricks-sdk>=0.14.0",
     "databricks-sql-connector>=3.1.0",
     "pydantic>=2.5.0",
-    "pydantic-ai-slim[openai]>=0.2",
+    "pydantic-ai-slim[openai,google]>=0.2",
     "python-multipart>=0.0.6",
     "python-dotenv>=1.0.0",
     "httpx>=0.25.0",
@@ -44,7 +44,7 @@ dependencies = [
     "psycopg-binary>=3.1.0", # Pre-built binary for psycopg
     "psycopg-pool>=3.1.0", # Connection pooling for psycopg
     "dspy>=3.1.3",
-    "pydantic-ai-slim[openai]>=0.2",
+    "pydantic-ai-slim[openai,google]>=0.2",
 ]
 
 [tool.alembic]

--- a/requirements.txt
+++ b/requirements.txt
@@ -120,6 +120,7 @@ anyio==4.12.1 \
     # via
     #   asyncer
     #   dspy
+    #   google-genai
     #   httpx
     #   openai
     #   starlette
@@ -733,7 +734,9 @@ distlib==0.4.0 \
 distro==1.9.0 \
     --hash=sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed \
     --hash=sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2
-    # via openai
+    # via
+    #   google-genai
+    #   openai
 docker==7.1.0 \
     --hash=sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c \
     --hash=sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0
@@ -996,14 +999,15 @@ google-api-core==2.30.0 \
     # via
     #   google-cloud-core
     #   google-cloud-storage
-google-auth==2.48.0 \
-    --hash=sha256:2e2a537873d449434252a9632c28bfc268b0adb1e53f9fb62afc5333a975903f \
-    --hash=sha256:4f7e706b0cd3208a3d940a19a822c37a476ddba5450156c3e6624a71f7c841ce
+google-auth==2.53.0 \
+    --hash=sha256:6e7449917c599b35126a99ec268ec6880301f2fea41dce198fe8fd83ff642b68 \
+    --hash=sha256:e7e6aa16f6bee7b2b264830fd04f08087a1d5a836df516251a5d15327b246c9c
     # via
     #   databricks-sdk
     #   google-api-core
     #   google-cloud-core
     #   google-cloud-storage
+    #   google-genai
 google-cloud-core==2.5.0 \
     --hash=sha256:67d977b41ae6c7211ee830c7912e41003ea8194bff15ae7d72fd6f51e57acabc \
     --hash=sha256:7c1b7ef5c92311717bd05301aa1a91ffbc565673d3b0b4163a52d8413a186963
@@ -1039,6 +1043,10 @@ google-crc32c==1.8.0 \
     # via
     #   google-cloud-storage
     #   google-resumable-media
+google-genai==2.4.0 \
+    --hash=sha256:3f8d4bd618be2801e805dc698726731a70f34b438ea25a6c92800eef5b1f513e \
+    --hash=sha256:48df1c44190b05b834fee9cffd360af6d6fd7f68164588e7ebd670fa34f71ee1
+    # via pydantic-ai-slim
 google-resumable-media==2.8.0 \
     --hash=sha256:dd14a116af303845a8d932ddae161a26e86cc229645bc98b39f026f9b1717582 \
     --hash=sha256:f1157ed8b46994d60a1bc432544db62352043113684d4e030ee02e77ebe9a1ae
@@ -1184,6 +1192,7 @@ httpx==0.28.1 \
     # via
     #   databricks-sdk
     #   genai-prices
+    #   google-genai
     #   huggingface-hub
     #   human-eval-workshop
     #   langsmith
@@ -2548,9 +2557,7 @@ pyarrow==23.0.1 \
 pyasn1==0.6.2 \
     --hash=sha256:1eb26d860996a18e9b6ed05e7aae0e9fc21619fcee6af91cca9bad4fbea224bf \
     --hash=sha256:9b59a2b25ba7e4f8197db7686c09fb33e658b98339fadb826e9512629017833b
-    # via
-    #   pyasn1-modules
-    #   rsa
+    # via pyasn1-modules
 pyasn1-modules==0.4.2 \
     --hash=sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a \
     --hash=sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6
@@ -2571,6 +2578,7 @@ pydantic==2.12.5 \
     #   dspy
     #   fastapi
     #   genai-prices
+    #   google-genai
     #   human-eval-workshop
     #   langchain-core
     #   langsmith
@@ -3010,7 +3018,9 @@ requests==2.32.5 \
     #   docker
     #   dspy
     #   google-api-core
+    #   google-auth
     #   google-cloud-storage
+    #   google-genai
     #   human-eval-workshop
     #   langsmith
     #   mlflow-skinny
@@ -3131,10 +3141,6 @@ rpds-py==0.30.0 \
     # via
     #   jsonschema
     #   referencing
-rsa==4.9.1 \
-    --hash=sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762 \
-    --hash=sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75
-    # via google-auth
 ruff==0.15.2 \
     --hash=sha256:120691a6fdae2f16d65435648160f5b81a9625288f75544dc40637436b5d3c0d \
     --hash=sha256:14b965afee0969e68bb871eba625343b8673375f457af4abe98553e8bbb98342 \
@@ -3292,7 +3298,9 @@ smmap==5.0.2 \
 sniffio==1.3.1 \
     --hash=sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2 \
     --hash=sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc
-    # via openai
+    # via
+    #   google-genai
+    #   openai
 sqlalchemy==2.0.46 \
     --hash=sha256:181903fe8c1b9082995325f1b2e84ac078b1189e2819380c2303a5f90e114a62 \
     --hash=sha256:2347c3f0efc4de367ba00218e0ae5c4ba2306e47216ef80d6e31761ac97cb0b9 \
@@ -3354,6 +3362,7 @@ tenacity==9.1.4 \
     # via
     #   databricks-agents
     #   dspy
+    #   google-genai
     #   langchain-core
 testcontainers==4.14.1 \
     --hash=sha256:03dfef4797b31c82e7b762a454b6afec61a2a512ad54af47ab41e4fa5415f891 \
@@ -3535,6 +3544,7 @@ typing-extensions==4.15.0 \
     #   azure-storage-blob
     #   azure-storage-file-datalake
     #   fastapi
+    #   google-genai
     #   graphene
     #   huggingface-hub
     #   ipython
@@ -3803,7 +3813,9 @@ websockets==16.0 \
     --hash=sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89 \
     --hash=sha256:f4a32d1bd841d4bcbffdcb3d2ce50c09c3909fbead375ab28d0181af89fd04da \
     --hash=sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4
-    # via uvicorn
+    # via
+    #   google-genai
+    #   uvicorn
 werkzeug==3.1.6 \
     --hash=sha256:210c6bede5a420a913956b4791a7f4d6843a43b6fcee4dfa08a65e93007d0d25 \
     --hash=sha256:7ddf3357bb9564e407607f988f683d72038551200c704012bb9a4c523d42f131

--- a/server/database.py
+++ b/server/database.py
@@ -735,7 +735,12 @@ class DiscoveryAgentRunDB(Base):
     trace = relationship("TraceDB")
 
 
-# Common PostgreSQL serverless connection error markers
+# Common PostgreSQL serverless connection error markers.
+# NB: do not add substrings that also appear in pool-exhaustion messages
+# (e.g. "connection timed out" — SQLAlchemy's QueuePool TimeoutError message
+# contains that phrase, and treating saturation as a transient connection
+# error triggers engine.dispose() which drops in-flight connections held by
+# other concurrent requests, amplifying the outage.  See gh#163.
 _PG_CONNECTION_ERRORS = (
     "connection is closed",
     "server closed the connection unexpectedly",
@@ -744,16 +749,23 @@ _PG_CONNECTION_ERRORS = (
     "ssl connection has been closed unexpectedly",
     "could not connect to server",
     "connection refused",
-    "connection timed out",
     "invalid authorization",  # Lakebase: expired OAuth token
     "database is locked",  # SQLite
 )
 
 
 def _is_connection_error(exc: Exception) -> bool:
-    """Check if an exception is a transient connection error."""
-    from sqlalchemy.exc import DisconnectionError, OperationalError
+    """Check if an exception is a transient connection error.
 
+    Pool exhaustion (SQLAlchemy's TimeoutError) is intentionally excluded —
+    it is a saturation signal, not a connection-level fault, and the right
+    response is to surface a 503 rather than dispose the engine.
+    """
+    from sqlalchemy.exc import DisconnectionError, OperationalError
+    from sqlalchemy.exc import TimeoutError as SATimeoutError
+
+    if isinstance(exc, SATimeoutError):
+        return False
     if isinstance(exc, (DisconnectionError, OperationalError)):
         return True
     msg = str(exc).lower()

--- a/server/db_config.py
+++ b/server/db_config.py
@@ -12,8 +12,10 @@ When using PostgreSQL, these environment variables configure the connection:
 - PGPORT: Port (default 5432)
 - PGSSLMODE: SSL mode (default 'require')
 - PGAPPNAME: Application name for connection tracking
-- ENDPOINT_NAME: Lakebase endpoint for credential generation
-  (format: projects/<id>/branches/<id>/endpoints/<id>)
+- ENDPOINT_NAME: Lakebase endpoint identifier for credential generation.
+  Supplied by the Databricks Apps platform via a `valueFrom: <resource-alias>`
+  binding in app.yaml (e.g. `valueFrom: postgres`).  Required for
+  DATABASE_ENV=postgres — engine creation fails loudly if it is unset.
 
 OAuth credentials for Lakebase are generated via the Databricks SDK
 ``WorkspaceClient().postgres.generate_database_credential()`` and injected
@@ -130,12 +132,13 @@ class LakebaseCredentialManager:
             self._workspace_client = WorkspaceClient()
         return self._workspace_client
 
-    def get_password(self, endpoint_name: str | None = None) -> str:
-        """Get a database credential, refreshing if near expiry.
+    def get_password(self, endpoint_name: str) -> str:
+        """Get a Lakebase database credential, refreshing if near expiry.
 
         Args:
-            endpoint_name: Lakebase endpoint name for generate_database_credential().
-                If None, falls back to workspace OAuth token.
+            endpoint_name: Lakebase endpoint resource identifier supplied by
+                Databricks Apps via `valueFrom: postgres` (or equivalent
+                resource alias) in app.yaml.
         """
         now = time.time()
 
@@ -145,36 +148,25 @@ class LakebaseCredentialManager:
         client = self._get_workspace_client()
 
         try:
-            if endpoint_name:
-                cred = client.postgres.generate_database_credential(endpoint=endpoint_name)
-                token = cred.token
-                if not token:
-                    raise RuntimeError(
-                        "generate_database_credential returned empty token "
-                        f"(endpoint={endpoint_name})"
-                    )
-                self._token = token
-                # expire_time is a google.protobuf.Timestamp (absolute UTC),
-                # not a Duration — use .seconds directly as the epoch expiry.
-                try:
-                    self._token_expiry = cred.expire_time.seconds
-                except (AttributeError, TypeError):
-                    self._token_expiry = now + 3600
-                logger.info(
-                    "Refreshed Lakebase credential via generate_database_credential "
-                    "(expires in %.0fs)",
-                    self._token_expiry - now,
+            cred = client.postgres.generate_database_credential(endpoint=endpoint_name)
+            token = cred.token
+            if not token:
+                raise RuntimeError(
+                    "generate_database_credential returned empty token "
+                    f"(endpoint={endpoint_name})"
                 )
-            else:
-                oauth = client.config.oauth_token()
-                token = oauth.access_token
-                if not token:
-                    raise RuntimeError("oauth_token() returned empty access_token")
-                self._token = token
+            self._token = token
+            # expire_time is a google.protobuf.Timestamp (absolute UTC),
+            # not a Duration — use .seconds directly as the epoch expiry.
+            try:
+                self._token_expiry = cred.expire_time.seconds
+            except (AttributeError, TypeError):
                 self._token_expiry = now + 3600
-                logger.info(
-                    "Refreshed Lakebase credential via workspace OAuth token (no ENDPOINT_NAME)"
-                )
+            logger.info(
+                "Refreshed Lakebase credential via generate_database_credential "
+                "(expires in %.0fs)",
+                self._token_expiry - now,
+            )
         except Exception as e:
             logger.error("Failed to refresh Lakebase credential: %s", e)
             if self._token is None:
@@ -288,13 +280,19 @@ def create_engine_for_backend(backend: DatabaseBackend) -> Engine:
 
     credential_manager = get_credential_manager()
     endpoint_name = os.getenv("ENDPOINT_NAME")
-    if endpoint_name:
-        logger.info("ENDPOINT_NAME=%s — will use generate_database_credential()", endpoint_name)
-    else:
-        logger.warning(
-            "ENDPOINT_NAME not set — falling back to workspace OAuth token. "
-            "Set ENDPOINT_NAME for Lakebase Autoscaling deployments."
+    if not endpoint_name:
+        # ENDPOINT_NAME is supplied by the Databricks Apps platform via a
+        # `valueFrom: <resource-alias>` binding in app.yaml (typically
+        # `valueFrom: postgres`). It is required for Lakebase Autoscaling
+        # because `generate_database_credential(endpoint=...)` cannot succeed
+        # without it. Fail loudly at engine creation rather than degrading
+        # to a different credential type silently.
+        raise RuntimeError(
+            "ENDPOINT_NAME is required for DATABASE_ENV=postgres but is not set. "
+            "Bind the Lakebase resource in app.yaml: "
+            "`- name: ENDPOINT_NAME / valueFrom: <resource-alias>`."
         )
+    logger.info("ENDPOINT_NAME=%s — will use generate_database_credential()", endpoint_name)
 
     schema_name = get_lakebase_schema_name(config)
 
@@ -313,8 +311,8 @@ def create_engine_for_backend(backend: DatabaseBackend) -> Engine:
         pool_size=5,
         max_overflow=5,  # Cap at 10/worker, 20 total with 2 gunicorn workers
         pool_timeout=30,
-        pool_recycle=2700,  # 45 min — recycle well before token expiry
-        pool_pre_ping=True,  # Detect stale/expired connections before use
+        pool_recycle=3600,  # 1h — match OAuth token lifetime per spec
+        pool_pre_ping=False,  # Conflicts with do_connect token injection
         echo=False,
     )
 

--- a/server/db_config.py
+++ b/server/db_config.py
@@ -132,14 +132,24 @@ class LakebaseCredentialManager:
             self._workspace_client = WorkspaceClient()
         return self._workspace_client
 
-    def get_password(self, endpoint_name: str) -> str:
+    def get_password(self, endpoint_name: str | None) -> str:
         """Get a Lakebase database credential, refreshing if near expiry.
 
         Args:
             endpoint_name: Lakebase endpoint resource identifier supplied by
-                Databricks Apps via `valueFrom: postgres` (or equivalent
-                resource alias) in app.yaml.
+                Databricks Apps via `valueFrom: <resource-alias>` in
+                app.yaml (e.g. `valueFrom: database`).  An unset or empty
+                value indicates a deployment misconfiguration and raises
+                here so the failure surfaces with an actionable message
+                regardless of which caller hit the credential manager first.
         """
+        if not endpoint_name:
+            raise RuntimeError(
+                "ENDPOINT_NAME is required for DATABASE_ENV=postgres but is unset or empty. "
+                "Bind the Lakebase resource in app.yaml: "
+                "`- name: ENDPOINT_NAME / valueFrom: <resource-alias>`."
+            )
+
         now = time.time()
 
         if self._token is not None and now < (self._token_expiry - self._EXPIRY_BUFFER_SECONDS):

--- a/server/routers/discovery.py
+++ b/server/routers/discovery.py
@@ -14,7 +14,7 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
-from server.database import get_db
+from server.database import SessionLocal, get_db
 from server.models import (
     DiscoveryAgentRun,
     DiscoveryComment,
@@ -441,15 +441,22 @@ async def get_discovery_agent_run(
 async def stream_discovery_agent_run(
     workshop_id: str,
     run_id: str,
-    db: Session = Depends(get_db),
 ) -> StreamingResponse:
-    svc = DiscoveryService(db)
-
+    # Note: no `db: Session = Depends(get_db)` here.  A FastAPI dependency
+    # session would be held for the entire SSE connection lifetime, hoarding
+    # one pool connection per subscriber and saturating the pool.  Instead,
+    # acquire/release a session per poll iteration below.  See gh#163.
     def event_generator():
         sent_started = False
         last_len = 0
         while True:
-            run = svc.get_discovery_agent_run(workshop_id, run_id)
+            db = SessionLocal()
+            try:
+                svc = DiscoveryService(db)
+                run = svc.get_discovery_agent_run(workshop_id, run_id)
+            finally:
+                db.close()
+
             if not sent_started:
                 sent_started = True
                 yield _sse_event("run_started", {"run_id": run.id, "status": run.status})
@@ -484,19 +491,26 @@ async def stream_discovery_comments(
     trace_id: str,
     milestone_ref: str | None = None,
     user_id: str | None = None,
-    db: Session = Depends(get_db),
 ) -> StreamingResponse:
-    svc = DiscoveryService(db)
-
+    # Note: no `db: Session = Depends(get_db)` here.  See companion comment
+    # on stream_discovery_agent_run — this stream is unbounded (runs for the
+    # whole panel session), so holding a Session via FastAPI dependency
+    # injection would permanently park a pool connection per subscriber.
     def event_generator():
         last_signature = ""
         while True:
-            comments = svc.list_discovery_comments(
-                workshop_id=workshop_id,
-                trace_id=trace_id,
-                milestone_ref=milestone_ref,
-                user_id=user_id,
-            )
+            db = SessionLocal()
+            try:
+                svc = DiscoveryService(db)
+                comments = svc.list_discovery_comments(
+                    workshop_id=workshop_id,
+                    trace_id=trace_id,
+                    milestone_ref=milestone_ref,
+                    user_id=user_id,
+                )
+            finally:
+                db.close()
+
             signature = f"{len(comments)}:{comments[-1].updated_at if comments else ''}"
             if signature != last_signature:
                 last_signature = signature

--- a/server/services/databricks_service.py
+++ b/server/services/databricks_service.py
@@ -3,9 +3,11 @@
 This service handles calls to Databricks model serving endpoints using the OpenAI client.
 """
 
+import asyncio
 import hashlib
 import logging
 import os
+import time
 from typing import Any
 
 import httpx
@@ -18,6 +20,22 @@ logger = logging.getLogger(__name__)
 # Global client cache to reuse OpenAI clients across requests
 # Key: (workspace_url, token_hash) -> OpenAI client
 _client_cache = {}
+
+# Serving-endpoints TTL cache. The model list is workspace-global and changes
+# infrequently, but the frontend's React Query cache is keyed per workshop, so
+# without a server-side cache each workshop view triggers a fresh Databricks
+# REST call. We cache at the service layer so all callers (per-workshop and
+# global routes) share one workspace-level entry.
+# Key: (workspace_url, token_hash) -> (monotonic_timestamp, endpoints)
+_ENDPOINTS_CACHE_TTL_S = float(os.getenv("DATABRICKS_ENDPOINTS_CACHE_TTL_S", "300"))
+_endpoints_cache: dict[tuple[str, str], tuple[float, list[dict[str, Any]]]] = {}
+_endpoints_cache_locks: dict[tuple[str, str], asyncio.Lock] = {}
+_endpoints_cache_locks_guard = asyncio.Lock()
+
+
+def clear_serving_endpoints_cache() -> None:
+    """Clear the cached serving-endpoints list. Useful for manual invalidation and tests."""
+    _endpoints_cache.clear()
 
 
 def _get_token_hash(token: str) -> str:
@@ -267,13 +285,49 @@ class DatabricksService:
             raise HTTPException(status_code=500, detail=f"Error calling serving endpoint: {e!s}") from e
 
     async def list_serving_endpoints(self) -> list[dict[str, Any]]:
-        """List all available serving endpoints from the Databricks workspace.
+        """List available serving endpoints, cached per workspace with a TTL.
 
-        Calls the Databricks REST API to fetch real serving endpoints.
-
-        Returns:
-            List of serving endpoint information
+        The model list changes infrequently, so we cache at the service layer
+        keyed by (workspace_url, token_hash). A per-key asyncio.Lock dedupes
+        concurrent in-flight refreshes so a thundering herd of requests
+        triggers only one upstream Databricks call. TTL is configurable via
+        ``DATABRICKS_ENDPOINTS_CACHE_TTL_S`` (default 300s).
         """
+        cache_key = (self.workspace_url, _get_token_hash(self.token))
+        now = time.monotonic()
+
+        cached = _endpoints_cache.get(cache_key)
+        if cached and (now - cached[0]) < _ENDPOINTS_CACHE_TTL_S:
+            logger.debug(
+                "Serving endpoints cache hit workspace=%s age_s=%.1f count=%d",
+                self.workspace_url,
+                now - cached[0],
+                len(cached[1]),
+            )
+            return cached[1]
+
+        async with _endpoints_cache_locks_guard:
+            lock = _endpoints_cache_locks.setdefault(cache_key, asyncio.Lock())
+
+        async with lock:
+            # Re-check inside the lock — another coroutine may have refreshed.
+            cached = _endpoints_cache.get(cache_key)
+            now = time.monotonic()
+            if cached and (now - cached[0]) < _ENDPOINTS_CACHE_TTL_S:
+                return cached[1]
+
+            endpoints = await self._fetch_serving_endpoints()
+            _endpoints_cache[cache_key] = (time.monotonic(), endpoints)
+            logger.info(
+                "Refreshed serving endpoints cache workspace=%s count=%d ttl_s=%.0f",
+                self.workspace_url,
+                len(endpoints),
+                _ENDPOINTS_CACHE_TTL_S,
+            )
+            return endpoints
+
+    async def _fetch_serving_endpoints(self) -> list[dict[str, Any]]:
+        """Fetch the serving-endpoints list from the Databricks REST API (uncached)."""
         try:
             logger.info("Listing Databricks serving endpoints via REST API")
 

--- a/server/services/databricks_service.py
+++ b/server/services/databricks_service.py
@@ -5,9 +5,11 @@ This service handles calls to Databricks model serving endpoints using the OpenA
 
 import asyncio
 import hashlib
+import json
 import logging
 import os
 import time
+import uuid
 from typing import Any
 
 import httpx
@@ -36,6 +38,62 @@ _endpoints_cache_locks_guard = asyncio.Lock()
 def clear_serving_endpoints_cache() -> None:
     """Clear the cached serving-endpoints list. Useful for manual invalidation and tests."""
     _endpoints_cache.clear()
+
+
+def _fix_databricks_shim_response(response: httpx.Response) -> None:
+    """Patch JSON responses from the Databricks OpenAI-compat shim that violate
+    the OpenAI chat completion contract.
+
+    Currently fixes:
+    - ``id: null`` on chat completions. Gemini-backed endpoints leave id null;
+      OpenAI SDK 2.x's Pydantic validator rejects this. Replaced with a
+      generated placeholder so downstream parsing succeeds.
+
+    Other backing models (Claude, gpt-5) return a non-null id and are untouched.
+    """
+    if "application/json" not in response.headers.get("content-type", ""):
+        return
+    try:
+        response.read()
+    except httpx.ResponseNotRead:
+        pass
+    except Exception:
+        return
+    try:
+        body = json.loads(response.content)
+    except Exception:
+        return
+    if not isinstance(body, dict) or "choices" not in body:
+        return
+    if body.get("id") in (None, ""):
+        body["id"] = f"databricks-shim-{uuid.uuid4().hex}"
+        new_body = json.dumps(body).encode()
+        response._content = new_body
+        response.headers["content-length"] = str(len(new_body))
+
+
+def _normalize_shim_content(content: Any) -> Any:
+    """Normalize the Databricks shim's Gemini content shape.
+
+    Gemini-backed endpoints return content as an array of part dicts:
+        ``[{"type": "text", "text": "...", "thoughtSignature": "..."}]``
+    instead of a plain string, which breaks parsers that expect
+    ``response.choices[0].message.content`` to be a ``str``.
+
+    Joins all text parts into a single string. Non-Gemini responses
+    (string content) pass through unchanged.
+    """
+    if not isinstance(content, list):
+        return content
+    parts: list[str] = []
+    for part in content:
+        if not isinstance(part, dict):
+            continue
+        if part.get("type") == "text":
+            text = part.get("text")
+            if text:
+                parts.append(text)
+    return "".join(parts) if parts else content
 
 
 def _get_token_hash(token: str) -> str:
@@ -185,9 +243,16 @@ class DatabricksService:
             if cache_key in _client_cache:
                 self.client = _client_cache[cache_key]
             else:
+                # Install a response hook that normalizes Databricks shim quirks
+                # (e.g. Gemini-backed endpoints return id:null which OpenAI SDK
+                # 2.x's Pydantic validator rejects).
+                http_client = httpx.Client(
+                    event_hooks={"response": [_fix_databricks_shim_response]}
+                )
                 self.client = OpenAI(
                     api_key=self.token,
                     base_url=f"{self.workspace_url}/serving-endpoints",
+                    http_client=http_client,
                 )
                 _client_cache[cache_key] = self.client
         except Exception as e:
@@ -226,6 +291,10 @@ class DatabricksService:
                     "content": response.choices[0].message.content,
                     "role": response.choices[0].message.role,
                 }
+            # Gemini-backed endpoints return content as an array of part dicts;
+            # callers expect a plain string. Other backings pass through unchanged.
+            if "content" in message_dump:
+                message_dump["content"] = _normalize_shim_content(message_dump["content"])
             return {
                 "choices": [
                     {
@@ -467,6 +536,10 @@ class DatabricksService:
                     "content": response.choices[0].message.content,
                     "role": response.choices[0].message.role,
                 }
+            # Gemini-backed endpoints return content as an array of part dicts;
+            # callers expect a plain string. Other backings pass through unchanged.
+            if "content" in message_dump:
+                message_dump["content"] = _normalize_shim_content(message_dump["content"])
 
             result = {
                 "choices": [

--- a/server/services/databricks_service.py
+++ b/server/services/databricks_service.py
@@ -106,6 +106,49 @@ def _looks_like_gemini(model_name: str) -> bool:
     return "gemini" in (model_name or "").lower()
 
 
+def _is_openai_reasoning_model(model_name: str) -> bool:
+    """Detect OpenAI reasoning-model endpoint names.
+
+    Reasoning models (gpt-5 / gpt-5.1 / gpt-5.5 / gpt-5-codex and the o-series
+    o1/o3/o4) reject ``temperature != 1`` with:
+        "Unsupported value: 'temperature' does not support X with this model.
+         Only the default (1) value is supported."
+    We can't drop the param like LiteLLM does for the DSPy path — the OpenAI
+    SDK has no equivalent — so we normalize the request here instead.
+    Databricks prefixes its endpoint names with ``databricks-``.
+    """
+    name = (model_name or "").lower()
+    return (
+        "gpt-5" in name
+        or "-o1" in name
+        or "-o3" in name
+        or "-o4" in name
+        or name.startswith("o1")
+        or name.startswith("o3")
+        or name.startswith("o4")
+    )
+
+
+def _normalize_request_for_reasoning_model(
+    endpoint_name: str, temperature: float
+) -> float:
+    """Return a temperature that the reasoning-model endpoint will accept.
+
+    For gpt-5 / o-series endpoints, force temperature=1.0 (the only value
+    they support). For all other endpoints, return the caller's value
+    unchanged. Logs when an override happens so the normalization is
+    auditable.
+    """
+    if _is_openai_reasoning_model(endpoint_name) and temperature != 1.0:
+        logger.info(
+            "Reasoning model %s only accepts temperature=1.0; overriding caller's %.2f",
+            endpoint_name,
+            temperature,
+        )
+        return 1.0
+    return temperature
+
+
 def _messages_to_genai_contents(messages: list[dict[str, Any]]) -> tuple[list[Any], str | None]:
     """Convert OpenAI chat messages to Gemini ``Content`` objects + an optional
     ``system_instruction``. ``role: system`` collapses into the latter."""
@@ -395,6 +438,8 @@ class DatabricksService:
                 {"role": "system", "content": "You are a helpful assistant."},
                 {"role": "user", "content": prompt},
             ]
+            # gpt-5 / o-series reject any temperature != 1
+            temperature = _normalize_request_for_reasoning_model(endpoint_name, temperature)
             request_params = {"messages": messages, "model": endpoint_name, "temperature": temperature}
 
             if max_tokens:
@@ -681,6 +726,8 @@ class DatabricksService:
                 ) from e
 
         try:
+            # gpt-5 / o-series reject any temperature != 1
+            temperature = _normalize_request_for_reasoning_model(endpoint_name, temperature)
             # Prepare the request parameters
             request_params = {"messages": messages, "model": endpoint_name, "temperature": temperature}
 

--- a/server/services/databricks_service.py
+++ b/server/services/databricks_service.py
@@ -23,6 +23,11 @@ logger = logging.getLogger(__name__)
 # Key: (workspace_url, token_hash) -> OpenAI client
 _client_cache = {}
 
+# Lazy-built cache of ``google.genai.Client`` instances for the Gemini
+# ai-gateway path. Keyed by (workspace_url, token_hash). Constructed on
+# first Gemini call to avoid requiring ``google-genai`` in minimal deploys.
+_gemini_client_cache: dict[tuple[str, str], Any] = {}
+
 # Serving-endpoints TTL cache. The model list is workspace-global and changes
 # infrequently, but the frontend's React Query cache is keyed per workshop, so
 # without a server-side cache each workshop view triggers a fresh Databricks
@@ -94,6 +99,80 @@ def _normalize_shim_content(content: Any) -> Any:
             if text:
                 parts.append(text)
     return "".join(parts) if parts else content
+
+
+def _looks_like_gemini(model_name: str) -> bool:
+    """Detect Gemini-family endpoint names. Databricks names them ``databricks-gemini-*``."""
+    return "gemini" in (model_name or "").lower()
+
+
+def _messages_to_genai_contents(messages: list[dict[str, Any]]) -> tuple[list[Any], str | None]:
+    """Convert OpenAI chat messages to Gemini ``Content`` objects + an optional
+    ``system_instruction``. ``role: system`` collapses into the latter."""
+    from google.genai import types as genai_types
+
+    system_parts: list[str] = []
+    contents: list[Any] = []
+    for msg in messages:
+        role = msg.get("role")
+        content = msg.get("content", "")
+        if role == "system":
+            if isinstance(content, str) and content:
+                system_parts.append(content)
+            continue
+        # Gemini uses "model" instead of "assistant"
+        genai_role = "model" if role == "assistant" else "user"
+        if isinstance(content, str):
+            contents.append(
+                genai_types.Content(role=genai_role, parts=[genai_types.Part(text=content)])
+            )
+        elif isinstance(content, list):
+            # Pre-formatted parts (rare) — pass text through as best-effort.
+            text = "".join(
+                p.get("text", "") for p in content if isinstance(p, dict) and p.get("type") == "text"
+            )
+            contents.append(
+                genai_types.Content(role=genai_role, parts=[genai_types.Part(text=text)])
+            )
+    system_instruction = "\n\n".join(system_parts) if system_parts else None
+    return contents, system_instruction
+
+
+def _genai_response_to_chat_shape(response: Any, model_name: str) -> dict[str, Any]:
+    """Adapt a google.genai ``GenerateContentResponse`` to the chat-completions
+    dict shape callers expect (``choices[0].message.content`` as a string)."""
+    text_parts: list[str] = []
+    finish_reason = "stop"
+    candidates = getattr(response, "candidates", None) or []
+    if candidates:
+        first = candidates[0]
+        for part in getattr(getattr(first, "content", None), "parts", None) or []:
+            t = getattr(part, "text", None)
+            if t:
+                text_parts.append(t)
+        fr = getattr(first, "finish_reason", None)
+        if fr is not None:
+            # google.genai returns an enum; surface its name for visibility.
+            finish_reason = str(getattr(fr, "name", fr) or finish_reason).lower()
+
+    usage = getattr(response, "usage_metadata", None)
+    usage_dict = {
+        "prompt_tokens": getattr(usage, "prompt_token_count", 0) if usage else 0,
+        "completion_tokens": getattr(usage, "candidates_token_count", 0) if usage else 0,
+        "total_tokens": getattr(usage, "total_token_count", 0) if usage else 0,
+    }
+
+    return {
+        "choices": [
+            {
+                "message": {"role": "assistant", "content": "".join(text_parts)},
+                "index": 0,
+                "finish_reason": finish_reason,
+            }
+        ],
+        "model": model_name,
+        "usage": usage_dict,
+    }
 
 
 def _get_token_hash(token: str) -> str:
@@ -491,6 +570,84 @@ class DatabricksService:
                 "message": "Failed to connect to Databricks workspace",
             }
 
+    def _get_gemini_client(self) -> Any:
+        """Lazily build (and cache) a ``google.genai.Client`` pointed at the
+        workspace's ai-gateway/gemini path.
+
+        Gemini chat completions through the OpenAI-compat shim are unreliable
+        — Vertex AI sometimes returns response shapes (safety blocks, empty
+        candidates, etc.) that the shim's JSON-to-OpenAI translator can't
+        round-trip, surfacing as 502 "invalid response from upstream". The
+        native passthrough returns Gemini's response shape directly, which
+        we can adapt cleanly.
+        """
+        cache_key = (self.workspace_url, _get_token_hash(self.token))
+        cached = _gemini_client_cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        # Local imports so the module still loads if the google extras
+        # aren't installed in a minimal environment.
+        import httpx as _httpx
+        from google import genai
+        from google.genai import types as genai_types
+
+        gateway_url = f"{self.workspace_url.rstrip('/')}/ai-gateway/gemini"
+        # google-genai prefers aiohttp when installed; we use the sync
+        # interface here so this is mostly belt-and-suspenders, but passing
+        # an explicit httpx_client also makes future hook installation easy.
+        client = genai.Client(
+            api_key="databricks",  # ignored; auth is in headers
+            http_options=genai_types.HttpOptions(
+                base_url=gateway_url,
+                headers={"Authorization": f"Bearer {self.token}"},
+                httpx_client=_httpx.Client(),
+            ),
+        )
+        _gemini_client_cache[cache_key] = client
+        logger.info("Gemini ai-gateway client cached for workspace=%s", self.workspace_url)
+        return client
+
+    def _call_gemini_chat_via_ai_gateway(
+        self,
+        endpoint_name: str,
+        messages: list[dict[str, Any]],
+        temperature: float = 0.5,
+        max_tokens: int | None = None,
+        response_format: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Single-turn chat completion against Gemini via Databricks' native
+        ai-gateway/gemini passthrough. Returns the chat-completions dict shape
+        so callers (``discovery_analysis_service``, etc.) don't need to change.
+
+        ``response_format`` is currently ignored; Gemini structured output
+        uses ``response_schema`` on the request config, which doesn't map
+        cleanly to OpenAI's ``response_format`` here. Callers that need
+        structured output should use pydantic-ai's ``GoogleModel`` directly.
+        """
+        from google.genai import types as genai_types
+
+        client = self._get_gemini_client()
+        contents, system_instruction = _messages_to_genai_contents(messages)
+
+        config_kwargs: dict[str, Any] = {"temperature": temperature}
+        if max_tokens:
+            config_kwargs["max_output_tokens"] = max_tokens
+        if system_instruction:
+            config_kwargs["system_instruction"] = system_instruction
+
+        logger.info(
+            "Calling Gemini via ai-gateway endpoint=%s contents=%d",
+            endpoint_name,
+            len(contents),
+        )
+        response = client.models.generate_content(
+            model=endpoint_name,
+            contents=contents,
+            config=genai_types.GenerateContentConfig(**config_kwargs),
+        )
+        return _genai_response_to_chat_shape(response, endpoint_name)
+
     def call_chat_completion(
         self,
         endpoint_name: str,
@@ -499,18 +656,30 @@ class DatabricksService:
         max_tokens: int | None = None,
         model_parameters: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        """Call a Databricks serving endpoint using chat completion format with OpenAI client.
+        """Call a Databricks serving endpoint using chat completion format.
 
-        Args:
-            endpoint_name: Name of the serving endpoint
-            messages: List of message dictionaries with 'role' and 'content'
-            temperature: Temperature for generation (0.0 to 1.0)
-            max_tokens: Maximum number of tokens to generate
-            model_parameters: Additional model parameters
-
-        Returns:
-            Dictionary containing the response from the model
+        For Gemini-family endpoints, routes through Databricks' native
+        ai-gateway/gemini passthrough (using google-genai). Other models
+        continue through the OpenAI-compat shim. The Gemini routing avoids
+        502s the shim returns when Vertex AI emits response shapes it can't
+        translate (safety blocks, empty candidates, etc.).
         """
+        if _looks_like_gemini(endpoint_name):
+            try:
+                return self._call_gemini_chat_via_ai_gateway(
+                    endpoint_name=endpoint_name,
+                    messages=messages,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                )
+            except Exception as e:
+                logger.error(f"Error calling Gemini ai-gateway endpoint {endpoint_name}: {e}")
+                logger.error("Full traceback:", exc_info=True)
+                raise HTTPException(
+                    status_code=500,
+                    detail=f"Error calling serving endpoint: {e!s}",
+                ) from e
+
         try:
             # Prepare the request parameters
             request_params = {"messages": messages, "model": endpoint_name, "temperature": temperature}

--- a/server/services/discovery_dspy.py
+++ b/server/services/discovery_dspy.py
@@ -196,11 +196,37 @@ class DiscoverySummariesPayload(BaseModel):
     )
 
 
+_LITELLM_CONFIGURED = False
+
+
+def _configure_litellm_drop_params() -> None:
+    """Tell LiteLLM to drop provider-incompatible params instead of raising.
+
+    Without this, hardcoded sampling params (temperature=0.2/0.3) cause 400s on
+    reasoning models like gpt-5 (only temperature=1 supported) and on some
+    Gemini configurations. drop_params=True lets LiteLLM silently strip
+    unsupported params per-model so the same discovery/follow-up code path
+    works across Claude, gpt-5, gpt-5-codex, and Gemini Flash served by
+    Databricks. Idempotent; safe if litellm is not installed.
+    """
+    global _LITELLM_CONFIGURED
+    if _LITELLM_CONFIGURED:
+        return
+    try:
+        import litellm  # type: ignore
+
+        litellm.drop_params = True
+        _LITELLM_CONFIGURED = True
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.debug("Could not configure litellm.drop_params: %s", exc)
+
+
 def _import_dspy():
     # Local import so the rest of the server can still import if DSPy isn't available
     # in a minimal deployment environment.
     import dspy  # type: ignore
 
+    _configure_litellm_drop_params()
     return dspy
 
 

--- a/server/services/trace_summarization_service.py
+++ b/server/services/trace_summarization_service.py
@@ -17,6 +17,7 @@ import httpx
 from pydantic import BaseModel, Field
 from pydantic_ai import Agent, RunContext
 from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.profiles.openai import OpenAIModelProfile
 from pydantic_ai.providers.openai import OpenAIProvider
 
 logger = logging.getLogger(__name__)
@@ -345,7 +346,14 @@ class TraceSummarizationService:
         agent_run_timeout_s: float | None = None,
     ):
         provider = OpenAIProvider(base_url=endpoint_url, api_key=token)
-        model = OpenAIChatModel(model_name, provider=provider)
+        # Databricks model-serving's OpenAI-compat shim rejects the `strict`
+        # field on tool definitions ("tools.N.custom.strict: Extra inputs are
+        # not permitted") regardless of which backing model (Claude, gpt-5,
+        # Gemini) is selected. pydantic-ai's default OpenAI profile emits
+        # `strict: true|false` on tools and structured-output schemas, so we
+        # must disable it explicitly for cross-provider interop.
+        profile = OpenAIModelProfile(openai_supports_strict_tool_definition=False)
+        model = OpenAIChatModel(model_name, provider=provider, profile=profile)
 
         use_case_section = ""
         if use_case_description:

--- a/server/services/trace_summarization_service.py
+++ b/server/services/trace_summarization_service.py
@@ -16,6 +16,7 @@ from typing import Any, Literal
 import httpx
 from pydantic import BaseModel, Field
 from pydantic_ai import Agent, RunContext
+from pydantic_ai.models import Model
 from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.profiles.openai import OpenAIModelProfile
 from pydantic_ai.providers.openai import OpenAIProvider
@@ -324,6 +325,147 @@ def _make_pydantic_ai_tools() -> list:
     ]
 
 
+# --- Model construction ---
+
+
+def _looks_like_gemini(model_name: str) -> bool:
+    """Detect Gemini-family endpoint names. Databricks names them ``databricks-gemini-*``."""
+    return "gemini" in (model_name or "").lower()
+
+
+async def _strip_function_call_id_from_gemini_request(request: Any) -> None:
+    """Strip ``id`` from ``functionCall``/``functionResponse`` parts on outgoing
+    requests to Databricks' Gemini ai-gateway.
+
+    Vertex AI's ``FunctionCall`` proto defines only ``name`` and ``args`` — no
+    ``id`` field. The google-genai SDK adds ``id`` when echoing the model's
+    previous function call back in multi-turn conversations (per Google's
+    hosted Gemini API spec), and Databricks' ai-gateway/gemini path is a
+    pure passthrough that doesn't translate it away. The result is a 400
+    "Unknown name 'id' at 'contents[N].parts[*].function_call'" that breaks
+    multi-turn tool-using agents.
+
+    Installed as an httpx request hook via ``HttpOptions.async_client_args``.
+    """
+    if not request.content:
+        return
+    try:
+        body = json.loads(request.content)
+    except Exception:
+        return
+    contents = body.get("contents")
+    if not isinstance(contents, list):
+        return
+    mutated = False
+    for c in contents:
+        if not isinstance(c, dict):
+            continue
+        for part in c.get("parts") or []:
+            if not isinstance(part, dict):
+                continue
+            for key in ("functionCall", "function_call", "functionResponse", "function_response"):
+                fc = part.get(key)
+                if isinstance(fc, dict) and "id" in fc:
+                    fc.pop("id", None)
+                    mutated = True
+    if mutated:
+        new_body = json.dumps(body).encode()
+        # httpx Request's wire transport reads from self.stream, NOT
+        # self._content. Updating only _content leaves the original body
+        # in the stream and triggers a "Too much data for declared
+        # Content-Length" error. Rebuild both.
+        from httpx._content import ByteStream
+
+        request.stream = ByteStream(new_body)
+        request._content = new_body
+        request.headers["content-length"] = str(len(new_body))
+
+
+def _build_gemini_model_via_ai_gateway(
+    *, workspace_url: str, token: str, model_name: str
+) -> Model:
+    """Build a pydantic-ai ``GoogleModel`` pointed at Databricks' native
+    Gemini passthrough (``/ai-gateway/gemini``).
+
+    The OpenAI-compat Chat Completions shim can't carry Gemini's
+    ``thought_signature`` between turns (OpenAI wire format has no slot
+    for it), so multi-turn tool-using agents on Gemini have to go through
+    this native path. pydantic-ai's ``GoogleModel`` already handles
+    ``thought_signature`` round-tripping correctly; we just need to
+    install an httpx request hook to strip ``function_call.id`` (see
+    ``_strip_function_call_id_from_gemini_request`` for why).
+    """
+    # Local imports so this module still loads if the google extras
+    # aren't installed in a minimal environment.
+    import httpx as _httpx
+    from google import genai
+    from google.genai import types as genai_types
+    from pydantic_ai.models.google import GoogleModel
+    from pydantic_ai.providers.google import GoogleProvider
+
+    gateway_url = f"{workspace_url.rstrip('/')}/ai-gateway/gemini"
+
+    # google-genai defaults to aiohttp when it's installed and no explicit
+    # httpx client is passed (see ``_api_client._use_aiohttp``). Passing
+    # ``httpx_async_client`` here forces the httpx transport so our
+    # request hook actually fires. Without this, the function_call.id
+    # strip is silently skipped and multi-turn calls 400.
+    httpx_async_client = _httpx.AsyncClient(
+        event_hooks={"request": [_strip_function_call_id_from_gemini_request]},
+    )
+
+    client = genai.Client(
+        # api_key is ignored on Databricks (Authorization header is used)
+        # but must be non-empty to satisfy the SDK's validator.
+        api_key="databricks",
+        http_options=genai_types.HttpOptions(
+            base_url=gateway_url,
+            headers={"Authorization": f"Bearer {token}"},
+            httpx_async_client=httpx_async_client,
+        ),
+    )
+    provider = GoogleProvider(client=client)
+    logger.info(
+        "Gemini summarization routing via native ai-gateway: %s (model=%s)",
+        gateway_url,
+        model_name,
+    )
+    return GoogleModel(model_name, provider=provider)
+
+
+def _build_openai_compat_model(
+    *, endpoint_url: str, token: str, model_name: str
+) -> Model:
+    """Build a pydantic-ai model against the Databricks OpenAI-compat shim
+    at ``/serving-endpoints``. Used for Claude, gpt-5, and other non-Gemini
+    foundation models. Disables strict tool definitions because the shim
+    rejects the ``strict`` field on tool functions.
+    """
+    provider = OpenAIProvider(base_url=endpoint_url, api_key=token)
+    profile = OpenAIModelProfile(openai_supports_strict_tool_definition=False)
+    return OpenAIChatModel(model_name, provider=provider, profile=profile)
+
+
+def _build_summarization_model(
+    *, endpoint_url: str, token: str, model_name: str
+) -> Model:
+    """Pick the right pydantic-ai model class for the configured backing model.
+
+    Gemini multi-turn tool calling requires ``thought_signature`` roundtripping
+    that the OpenAI-compat shim doesn't carry, so Gemini endpoints route
+    through the native ai-gateway/gemini path. Everything else stays on
+    OpenAI Chat Completions.
+    """
+    if _looks_like_gemini(model_name):
+        workspace_url = endpoint_url.split("/serving-endpoints", 1)[0]
+        return _build_gemini_model_via_ai_gateway(
+            workspace_url=workspace_url, token=token, model_name=model_name
+        )
+    return _build_openai_compat_model(
+        endpoint_url=endpoint_url, token=token, model_name=model_name
+    )
+
+
 # --- Service ---
 
 
@@ -345,15 +487,13 @@ class TraceSummarizationService:
         max_concurrency: int = 3,
         agent_run_timeout_s: float | None = None,
     ):
-        provider = OpenAIProvider(base_url=endpoint_url, api_key=token)
-        # Databricks model-serving's OpenAI-compat shim rejects the `strict`
-        # field on tool definitions ("tools.N.custom.strict: Extra inputs are
-        # not permitted") regardless of which backing model (Claude, gpt-5,
-        # Gemini) is selected. pydantic-ai's default OpenAI profile emits
-        # `strict: true|false` on tools and structured-output schemas, so we
-        # must disable it explicitly for cross-provider interop.
-        profile = OpenAIModelProfile(openai_supports_strict_tool_definition=False)
-        model = OpenAIChatModel(model_name, provider=provider, profile=profile)
+        # Pick the right pydantic-ai model for the configured backing model.
+        # Gemini multi-turn tool calling needs ``thought_signature`` roundtripping
+        # via the native ai-gateway/gemini path; everything else goes through
+        # the OpenAI-compat shim. See _build_summarization_model for details.
+        model = _build_summarization_model(
+            endpoint_url=endpoint_url, token=token, model_name=model_name
+        )
 
         use_case_section = ""
         if use_case_description:

--- a/tests/integration/test_connection_resilience.py
+++ b/tests/integration/test_connection_resilience.py
@@ -171,3 +171,35 @@ class TestGetDbRetry:
             with pytest.raises(ValueError):
                 next(gen)
             assert call_count == 1  # No retry
+
+
+@pytest.mark.spec("AUTHENTICATION_SPEC")
+class TestStreamingEndpointsDoNotHoldSessions:
+    """Streaming/SSE endpoints must not bind a DB Session via FastAPI
+    dependency injection — doing so holds one pool connection per
+    subscriber for the entire stream lifetime and saturates the pool.
+    See gh#163 (production cascade traced to /discovery-comments/stream).
+    """
+
+    def _signature_params(self, fn):
+        import inspect
+
+        return inspect.signature(fn).parameters
+
+    def test_stream_discovery_comments_has_no_db_dependency(self):
+        from server.routers.discovery import stream_discovery_comments
+
+        params = self._signature_params(stream_discovery_comments)
+        assert "db" not in params, (
+            "Streaming endpoint must not bind a Session via Depends(get_db) — "
+            "acquire SessionLocal() per poll iteration instead. See gh#163."
+        )
+
+    def test_stream_discovery_agent_run_has_no_db_dependency(self):
+        from server.routers.discovery import stream_discovery_agent_run
+
+        params = self._signature_params(stream_discovery_agent_run)
+        assert "db" not in params, (
+            "Streaming endpoint must not bind a Session via Depends(get_db) — "
+            "acquire SessionLocal() per poll iteration instead. See gh#163."
+        )

--- a/tests/integration/test_connection_resilience.py
+++ b/tests/integration/test_connection_resilience.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from sqlalchemy.exc import DisconnectionError, OperationalError
+from sqlalchemy.exc import TimeoutError as SATimeoutError
 
 pytestmark = [
     pytest.mark.integration,
@@ -50,7 +51,6 @@ class TestIsConnectionError:
         "ssl connection has been closed unexpectedly",
         "could not connect to server",
         "connection refused",
-        "connection timed out",
         "invalid authorization",
         "database is locked",
     ])
@@ -59,6 +59,24 @@ class TestIsConnectionError:
 
         exc = Exception(message)
         assert _is_connection_error(exc) is True
+
+    @pytest.mark.spec("AUTHENTICATION_SPEC")
+    def test_pool_exhaustion_timeout_is_not_connection_error(self):
+        """SQLAlchemy QueuePool TimeoutError must NOT be classified as a
+        transient connection error.  Treating saturation as such triggers
+        engine.dispose() during the retry path, which drops in-flight
+        connections held by other concurrent requests and amplifies the
+        outage.  See gh#163.
+        """
+        from server.database import _is_connection_error
+
+        exc = SATimeoutError(
+            "QueuePool limit of size 5 overflow 5 reached, "
+            "connection timed out, timeout 30.00",
+            None,
+            None,
+        )
+        assert _is_connection_error(exc) is False
 
 
 class TestResetConnectionPool:

--- a/tests/integration/test_databricks_model_apis.py
+++ b/tests/integration/test_databricks_model_apis.py
@@ -141,6 +141,76 @@ def test_responses_api_passthrough_support(databricks_service, model):
         pytest.xfail(f"{model}: Responses API is OpenAI-only by design (expected)")
 
 
+@pytest.mark.spec("TRACE_SUMMARIZATION_SPEC")
+@pytest.mark.req(
+    "Facilitator can select a model for summarization from available Databricks endpoints"
+)
+@pytest.mark.asyncio
+async def test_gemini_multi_turn_summarization_via_ai_gateway():
+    """End-to-end: multi-turn pydantic-ai agent summarization on Gemini
+    through the Databricks ai-gateway path. This exercises:
+
+    - ``TraceSummarizationService``'s Gemini routing decision.
+    - The forced httpx transport (google-genai would otherwise pick aiohttp
+      and bypass our request hook).
+    - The ``function_call.id`` strip hook (without it, the second turn
+      400s because Vertex AI's FunctionCall proto has no ``id`` field).
+    - Pydantic-AI's native ``thought_signature`` round-tripping in
+      ``GoogleModel``.
+
+    Skipped automatically when Databricks credentials aren't configured.
+    """
+    from databricks.sdk import WorkspaceClient
+
+    from server.services.trace_summarization_service import TraceSummarizationService
+
+    w = WorkspaceClient()
+    token = w.config.authenticate()["Authorization"].removeprefix("Bearer ")
+    host = w.config.host.rstrip("/")
+
+    svc = TraceSummarizationService(
+        endpoint_url=f"{host}/serving-endpoints",
+        token=token,
+        model_name="databricks-gemini-3-5-flash",
+        agent_run_timeout_s=60.0,
+    )
+
+    result = await svc.summarize_trace(
+        {
+            "spans": [
+                {
+                    "name": "root_agent",
+                    "span_type": "AGENT",
+                    "status": "OK",
+                    "inputs": {"task": "find top issuers by spend"},
+                    "outputs": {"answer": "ICA-1, ICA-2, ICA-3"},
+                    "start_time_ns": 0,
+                    "end_time_ns": 4_000_000_000,
+                    "parent_span_id": None,
+                },
+                {
+                    "name": "sql",
+                    "span_type": "TOOL",
+                    "status": "OK",
+                    "inputs": {"q": "SELECT * FROM issuers"},
+                    "outputs": {"rows": 240},
+                    "start_time_ns": 1_000_000_000,
+                    "end_time_ns": 3_000_000_000,
+                    "parent_span_id": "span-1",
+                },
+            ],
+            "execution_time_ms": 4000,
+            "status": "OK",
+            "tags": {},
+        },
+        trace_id="integration-gemini-multi-turn",
+    )
+
+    assert result is not None, "Gemini multi-turn summarization should not return None"
+    assert result.executive_summary, "Executive summary should be populated"
+    assert len(result.milestones) >= 1, "At least one milestone expected"
+
+
 @pytest.mark.spec("DISCOVERY_SPEC")
 @pytest.mark.req(
     "Facilitator can select LLM model for follow-up question generation in Discovery dashboard"

--- a/tests/integration/test_databricks_model_apis.py
+++ b/tests/integration/test_databricks_model_apis.py
@@ -215,15 +215,13 @@ async def test_gemini_multi_turn_summarization_via_ai_gateway():
 @pytest.mark.req(
     "Facilitator can select LLM model for follow-up question generation in Discovery dashboard"
 )
-def test_gemini_chat_completion_returns_usable_content(databricks_service):
-    """Gemini via Chat Completions returns content as an array of parts dicts
-    (``[{type:"text", text:..., thoughtSignature:...}]``) and ``id: null``,
-    which trip OpenAI SDK 2.x's strict validators.
-
-    This test pins the behavior so a future Databricks shim fix is detected
-    immediately — if Gemini starts returning a plain-string content and a
-    real id, this test should be updated to require that shape and we can
-    delete any client-side normalization."""
+def test_gemini_chat_completion_returns_string_content(databricks_service):
+    """Discovery analysis and rubric generation both consume
+    ``response["choices"][0]["message"]["content"]`` as a ``str``. Now that
+    Gemini chat completions route through the native ai-gateway (the
+    OpenAI-compat shim was returning 502s on certain Vertex AI response
+    shapes), the content adapter must always produce a plain string.
+    Regression here would resurface the prod 502 we just fixed."""
     result = databricks_service.call_chat_completion(
         endpoint_name="databricks-gemini-3-5-flash",
         messages=[
@@ -234,16 +232,8 @@ def test_gemini_chat_completion_returns_usable_content(databricks_service):
         max_tokens=2000,
     )
     content = result["choices"][0]["message"]["content"]
-    # We accept either shape — the assertion just verifies we got something
-    # parseable. The migration that normalizes content is tested separately
-    # in unit tests.
-    assert content is not None
-    if isinstance(content, list):
-        joined = "".join(
-            part.get("text", "")
-            for part in content
-            if isinstance(part, dict) and part.get("type") == "text"
-        )
-        assert joined.strip(), "Gemini parts contained no text"
-    else:
-        assert isinstance(content, str) and content.strip(), "Gemini returned empty content"
+    assert isinstance(content, str), (
+        f"Gemini chat completion must return a string after ai-gateway adapter, "
+        f"got {type(content).__name__}"
+    )
+    assert content.strip(), "Gemini returned empty content"

--- a/tests/integration/test_databricks_model_apis.py
+++ b/tests/integration/test_databricks_model_apis.py
@@ -1,0 +1,179 @@
+"""Integration tests probing which Databricks-served LLM endpoints accept
+which OpenAI API surfaces.
+
+This is a live diagnostic that exercises the configured Databricks workspace.
+It's skipped automatically when credentials are unavailable (so CI never
+fails on it), but runnable on demand to verify and document the support
+matrix:
+
+    just test-integration tests/integration/test_databricks_model_apis.py
+
+Design note: per Databricks docs, the **Responses API passthrough is
+OpenAI-only by design** — it only accepts ``databricks-gpt-*`` model
+endpoints. Claude, Gemini, and Llama serve Chat Completions only. So
+unifying everything on a single OpenAI API surface isn't possible at
+this layer; we stay on Chat Completions for cross-provider calls and
+patch the Chat Completions quirks (Gemini's ``id: null`` and content
+shape) client-side.
+
+These tests pin that contract:
+- Every model exposed in the workshop's picker must accept a minimal
+  Chat Completions request.
+- Responses API support is checked separately, expected only for the
+  gpt-5 family. Other models ``xfail`` cleanly with the
+  "Responses API passthrough is not supported" message.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+# The serving endpoints we care about for the workshop feature set.
+# Kept as a parameter list so future additions just append.
+_PROBE_MODELS = [
+    "databricks-claude-opus-4-7",
+    "databricks-claude-sonnet-4",
+    "databricks-gpt-5",
+    "databricks-gemini-3-5-flash",
+    "databricks-meta-llama-3-3-70b-instruct",
+]
+
+
+def _databricks_available() -> bool:
+    """Return True iff we can resolve a Databricks host + auth locally.
+
+    Used to skip these tests cleanly in CI / minimal envs.
+    """
+    try:
+        from server.services.databricks_service import (  # noqa: WPS433
+            get_databricks_host,
+            resolve_databricks_token,
+        )
+
+        get_databricks_host()
+        resolve_databricks_token()
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not _databricks_available(),
+        reason="No Databricks credentials configured (set DATABRICKS_HOST + auth)",
+    ),
+]
+
+
+@pytest.fixture(scope="module")
+def databricks_service():
+    """Lazy import to avoid importing the service module when we're skipping."""
+    from server.services.databricks_service import DatabricksService
+
+    return DatabricksService()
+
+
+@pytest.mark.spec("TRACE_SUMMARIZATION_SPEC")
+@pytest.mark.req(
+    "Facilitator can select a model for summarization from available Databricks endpoints"
+)
+@pytest.mark.parametrize("model", _PROBE_MODELS)
+def test_chat_completions_works_for_model(databricks_service, model):
+    """Every model exposed in the workshop's model picker must accept a
+    minimal Chat Completions request. Failure here means the endpoint is
+    misconfigured or removed from the workspace."""
+    result = databricks_service.call_chat_completion(
+        endpoint_name=model,
+        messages=[{"role": "user", "content": "Reply with the word ok."}],
+        # gpt-5 family only accepts temperature=1; use the default-friendly
+        # value, expect drop_params/litellm to handle it elsewhere.
+        temperature=1.0,
+        max_tokens=2000,
+    )
+    content = result["choices"][0]["message"]["content"]
+    assert isinstance(content, (str, list)), (
+        f"{model}: chat completion returned unexpected content type {type(content)!r}"
+    )
+
+
+@pytest.mark.parametrize("model", _PROBE_MODELS)
+def test_responses_api_passthrough_support(databricks_service, model):
+    """Per Databricks docs the Responses API is OpenAI-only; gpt-5 endpoints
+    accept it, every other foundation model rejects with "Responses API
+    passthrough is not supported".
+
+    This test pins that contract. If a non-gpt model ever starts accepting
+    Responses, an xpass shows up and we can revisit our design. If gpt-5
+    stops accepting, we get a real failure to investigate.
+    """
+    is_openai_model = model.startswith("databricks-gpt")
+    try:
+        databricks_service.client.responses.create(
+            model=model,
+            input=[{"role": "user", "content": "Reply with the word ok."}],
+            max_output_tokens=2000,
+        )
+        accepted = True
+        error_msg = ""
+    except Exception as exc:
+        accepted = False
+        error_msg = str(exc)
+
+    if is_openai_model:
+        # gpt-5 family is allowed to reject our minimal request for reasons
+        # other than passthrough support (e.g. temperature/reasoning quirks).
+        # We only assert the passthrough isn't outright disabled.
+        assert "Responses API passthrough is not supported" not in error_msg, (
+            f"Regression: {model} stopped accepting Responses API passthrough"
+        )
+    else:
+        # Non-OpenAI models must keep rejecting passthrough — that's our
+        # design assumption. If they start accepting, this xfail flips to
+        # xpass and we should revisit.
+        if accepted or "Responses API passthrough is not supported" not in error_msg:
+            pytest.fail(
+                f"{model}: expected Responses API rejection, but got "
+                f"{'success' if accepted else error_msg[:200]}"
+            )
+        pytest.xfail(f"{model}: Responses API is OpenAI-only by design (expected)")
+
+
+@pytest.mark.spec("DISCOVERY_SPEC")
+@pytest.mark.req(
+    "Facilitator can select LLM model for follow-up question generation in Discovery dashboard"
+)
+def test_gemini_chat_completion_returns_usable_content(databricks_service):
+    """Gemini via Chat Completions returns content as an array of parts dicts
+    (``[{type:"text", text:..., thoughtSignature:...}]``) and ``id: null``,
+    which trip OpenAI SDK 2.x's strict validators.
+
+    This test pins the behavior so a future Databricks shim fix is detected
+    immediately — if Gemini starts returning a plain-string content and a
+    real id, this test should be updated to require that shape and we can
+    delete any client-side normalization."""
+    result = databricks_service.call_chat_completion(
+        endpoint_name="databricks-gemini-3-5-flash",
+        messages=[
+            {"role": "system", "content": "You analyze feedback briefly."},
+            {"role": "user", "content": 'List 3 themes from: "agent was helpful and accurate"'},
+        ],
+        temperature=0.3,
+        max_tokens=2000,
+    )
+    content = result["choices"][0]["message"]["content"]
+    # We accept either shape — the assertion just verifies we got something
+    # parseable. The migration that normalizes content is tested separately
+    # in unit tests.
+    assert content is not None
+    if isinstance(content, list):
+        joined = "".join(
+            part.get("text", "")
+            for part in content
+            if isinstance(part, dict) and part.get("type") == "text"
+        )
+        assert joined.strip(), "Gemini parts contained no text"
+    else:
+        assert isinstance(content, str) and content.strip(), "Gemini returned empty content"

--- a/tests/unit/services/test_databricks_service.py
+++ b/tests/unit/services/test_databricks_service.py
@@ -1,10 +1,15 @@
+import json
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
+import httpx
 import pytest
 
 import server.services.databricks_service as databricks_module
 from server.services.databricks_service import (
     DatabricksService,
+    _fix_databricks_shim_response,
+    _normalize_shim_content,
     clear_serving_endpoints_cache,
     get_databricks_host,
     get_experiment_id,
@@ -178,3 +183,151 @@ async def test_serving_endpoints_cache_dedupes_concurrent_requests(reset_endpoin
     assert all(r == [{"name": "endpoint-1", "state": "READY"}] for r in results)
     # No assertion on call_count here because slow_fetch isn't a Mock, but the
     # event/release pattern guarantees only one path ran the fetch body.
+
+
+# ---------------------------------------------------------------------------
+# Gemini-on-Databricks Chat Completions shim quirks
+# ---------------------------------------------------------------------------
+#
+# OpenAI's Responses API is gpt-only by design, so we stay on Chat Completions
+# for all cross-provider calls. The Databricks shim leaks two Gemini-native
+# quirks through Chat Completions that callers can't reasonably handle:
+#  1. ``id: null`` on the response object (OpenAI SDK 2.x's Pydantic
+#     validator rejects null id).
+#  2. ``content`` as an array of part dicts
+#     ``[{"type": "text", "text": "...", "thoughtSignature": "..."}]``
+#     instead of a plain string, breaking parsers that read
+#     ``response.choices[0].message.content`` as ``str``.
+# We patch both client-side so callers (discovery_analysis_service,
+# rubric_generation_service, etc.) work uniformly across providers.
+
+
+def _make_response(body: dict, content_type: str = "application/json") -> httpx.Response:
+    raw = json.dumps(body).encode()
+    return httpx.Response(
+        status_code=200,
+        headers={"content-type": content_type, "content-length": str(len(raw))},
+        content=raw,
+    )
+
+
+@pytest.mark.spec("DISCOVERY_SPEC")
+@pytest.mark.req(
+    "Facilitator can select LLM model for follow-up question generation in Discovery dashboard"
+)
+@pytest.mark.unit
+def test_fix_databricks_shim_response_replaces_null_id():
+    resp = _make_response({"id": None, "choices": [{"index": 0, "message": {}}]})
+    _fix_databricks_shim_response(resp)
+    parsed = json.loads(resp.content)
+    assert parsed["id"], "id must be filled in"
+    assert parsed["id"].startswith("databricks-shim-")
+
+
+@pytest.mark.spec("DISCOVERY_SPEC")
+@pytest.mark.req(
+    "Facilitator can select LLM model for follow-up question generation in Discovery dashboard"
+)
+@pytest.mark.unit
+def test_fix_databricks_shim_response_leaves_valid_id_alone():
+    """Other backing models (Claude, gpt-5) return real ids; the hook must
+    not overwrite them."""
+    resp = _make_response({"id": "chatcmpl-abc123", "choices": [{"index": 0, "message": {}}]})
+    _fix_databricks_shim_response(resp)
+    parsed = json.loads(resp.content)
+    assert parsed["id"] == "chatcmpl-abc123"
+
+
+@pytest.mark.spec("DISCOVERY_SPEC")
+@pytest.mark.req(
+    "Facilitator can select LLM model for follow-up question generation in Discovery dashboard"
+)
+@pytest.mark.unit
+def test_fix_databricks_shim_response_ignores_non_chat_payloads():
+    """The hook is installed on the shared OpenAI client, so it sees every
+    response. It must only mutate chat completion shapes (id+choices), not
+    arbitrary JSON like endpoint listings or error envelopes."""
+    resp = _make_response({"endpoints": [{"name": "foo"}]})
+    _fix_databricks_shim_response(resp)
+    parsed = json.loads(resp.content)
+    assert parsed == {"endpoints": [{"name": "foo"}]}
+
+
+@pytest.mark.spec("DISCOVERY_SPEC")
+@pytest.mark.req(
+    "Facilitator can select LLM model for follow-up question generation in Discovery dashboard"
+)
+@pytest.mark.unit
+def test_normalize_shim_content_joins_gemini_parts():
+    parts = [
+        {"type": "text", "text": "Hello, ", "thoughtSignature": "abc=="},
+        {"type": "text", "text": "world!", "thoughtSignature": "def=="},
+    ]
+    assert _normalize_shim_content(parts) == "Hello, world!"
+
+
+@pytest.mark.spec("DISCOVERY_SPEC")
+@pytest.mark.req(
+    "Facilitator can select LLM model for follow-up question generation in Discovery dashboard"
+)
+@pytest.mark.unit
+def test_normalize_shim_content_passes_string_through():
+    assert _normalize_shim_content("already a string") == "already a string"
+    assert _normalize_shim_content(None) is None
+
+
+@pytest.mark.spec("DISCOVERY_SPEC")
+@pytest.mark.req(
+    "Facilitator can select LLM model for follow-up question generation in Discovery dashboard"
+)
+@pytest.mark.unit
+def test_normalize_shim_content_ignores_non_text_parts():
+    parts = [
+        {"type": "text", "text": "Hello"},
+        {"type": "function_call", "name": "noop"},
+    ]
+    assert _normalize_shim_content(parts) == "Hello"
+
+
+@pytest.mark.spec("DISCOVERY_SPEC")
+@pytest.mark.req(
+    "Facilitator can select LLM model for follow-up question generation in Discovery dashboard"
+)
+@pytest.mark.unit
+def test_call_chat_completion_normalizes_gemini_content():
+    """End-to-end: when the OpenAI SDK returns a chat completion whose
+    message.content is the Gemini parts array, call_chat_completion must
+    return a result whose message.content is a plain string. Otherwise
+    discovery_analysis_service's parser breaks on Gemini."""
+    svc = DatabricksService.__new__(DatabricksService)
+    svc.workspace_url = "https://example.databricks.com"
+    svc.token = "test-token"
+
+    fake_message = SimpleNamespace(
+        content=[{"type": "text", "text": "Themes: A, B, C"}],
+        role="assistant",
+        model_dump=lambda: {
+            "role": "assistant",
+            "content": [{"type": "text", "text": "Themes: A, B, C"}],
+        },
+    )
+    fake_choice = SimpleNamespace(message=fake_message, index=0, finish_reason="stop")
+    fake_usage = SimpleNamespace(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+    fake_response = SimpleNamespace(
+        choices=[fake_choice],
+        model="databricks-gemini-3-5-flash",
+        usage=fake_usage,
+    )
+
+    fake_client = SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(create=lambda **_: fake_response)
+        )
+    )
+    svc.client = fake_client
+
+    result = svc.call_chat_completion(
+        endpoint_name="databricks-gemini-3-5-flash",
+        messages=[{"role": "user", "content": "Give me 3 themes"}],
+    )
+    assert result["choices"][0]["message"]["content"] == "Themes: A, B, C"

--- a/tests/unit/services/test_databricks_service.py
+++ b/tests/unit/services/test_databricks_service.py
@@ -294,11 +294,12 @@ def test_normalize_shim_content_ignores_non_text_parts():
     "Facilitator can select LLM model for follow-up question generation in Discovery dashboard"
 )
 @pytest.mark.unit
-def test_call_chat_completion_normalizes_gemini_content():
-    """End-to-end: when the OpenAI SDK returns a chat completion whose
-    message.content is the Gemini parts array, call_chat_completion must
-    return a result whose message.content is a plain string. Otherwise
-    discovery_analysis_service's parser breaks on Gemini."""
+def test_call_chat_completion_normalizes_array_content_on_shim_path():
+    """The OpenAI-compat shim has been observed to return ``message.content``
+    as an array of part dicts for certain backings. Even though Gemini now
+    bypasses this code path (it routes through the ai-gateway), the safety
+    net stays in place so any other model leaking array content gets
+    normalized to a string."""
     svc = DatabricksService.__new__(DatabricksService)
     svc.workspace_url = "https://example.databricks.com"
     svc.token = "test-token"
@@ -315,7 +316,7 @@ def test_call_chat_completion_normalizes_gemini_content():
     fake_usage = SimpleNamespace(prompt_tokens=10, completion_tokens=5, total_tokens=15)
     fake_response = SimpleNamespace(
         choices=[fake_choice],
-        model="databricks-gemini-3-5-flash",
+        model="databricks-claude-opus-4-7",
         usage=fake_usage,
     )
 
@@ -327,7 +328,169 @@ def test_call_chat_completion_normalizes_gemini_content():
     svc.client = fake_client
 
     result = svc.call_chat_completion(
-        endpoint_name="databricks-gemini-3-5-flash",
+        endpoint_name="databricks-claude-opus-4-7",
         messages=[{"role": "user", "content": "Give me 3 themes"}],
     )
     assert result["choices"][0]["message"]["content"] == "Themes: A, B, C"
+
+
+# ---------------------------------------------------------------------------
+# Gemini chat completion routes through the ai-gateway
+# ---------------------------------------------------------------------------
+#
+# Gemini chat completion through the OpenAI-compat shim is unreliable
+# (Vertex AI sometimes returns response shapes that the shim's translator
+# can't round-trip → 502 "invalid response from upstream"). We detect
+# Gemini endpoint names and route through the native ai-gateway/gemini
+# passthrough using google-genai. The adapter returns the chat-completions
+# dict shape so existing callers (discovery_analysis_service, etc.) don't
+# need to change.
+
+
+@pytest.mark.spec("DISCOVERY_SPEC")
+@pytest.mark.req(
+    "Facilitator can select LLM model for follow-up question generation in Discovery dashboard"
+)
+@pytest.mark.unit
+def test_call_chat_completion_routes_gemini_to_ai_gateway(monkeypatch):
+    """call_chat_completion must NOT touch the OpenAI client when the endpoint
+    is Gemini-family — it must dispatch to the ai-gateway helper. Otherwise
+    we re-introduce the shim 502s discovery analysis hit in production."""
+    svc = DatabricksService.__new__(DatabricksService)
+    svc.workspace_url = "https://example.databricks.com"
+    svc.token = "test-token"
+
+    # If anything reaches the OpenAI client it's a routing bug.
+    sentinel_client = SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(
+                create=lambda **_: pytest.fail("OpenAI client must not be used for Gemini")
+            )
+        )
+    )
+    svc.client = sentinel_client
+
+    captured: dict[str, Any] = {}
+
+    def fake_gateway(self, endpoint_name, messages, temperature=0.5, max_tokens=None, response_format=None):
+        captured["endpoint_name"] = endpoint_name
+        captured["messages"] = messages
+        captured["temperature"] = temperature
+        captured["max_tokens"] = max_tokens
+        return {
+            "choices": [
+                {"message": {"role": "assistant", "content": "OK"}, "index": 0, "finish_reason": "stop"}
+            ],
+            "model": endpoint_name,
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        }
+
+    monkeypatch.setattr(DatabricksService, "_call_gemini_chat_via_ai_gateway", fake_gateway)
+
+    result = svc.call_chat_completion(
+        endpoint_name="databricks-gemini-3-5-flash",
+        messages=[{"role": "user", "content": "hi"}],
+        temperature=0.7,
+        max_tokens=1024,
+    )
+    assert captured["endpoint_name"] == "databricks-gemini-3-5-flash"
+    assert captured["temperature"] == 0.7
+    assert captured["max_tokens"] == 1024
+    assert result["choices"][0]["message"]["content"] == "OK"
+
+
+@pytest.mark.spec("DISCOVERY_SPEC")
+@pytest.mark.req(
+    "Facilitator can select LLM model for follow-up question generation in Discovery dashboard"
+)
+@pytest.mark.unit
+def test_call_chat_completion_non_gemini_uses_openai_client(monkeypatch):
+    """Non-Gemini endpoints continue to use the OpenAI-compat shim, since
+    Claude/gpt-5/Llama don't have the response-shape issues Gemini has."""
+    svc = DatabricksService.__new__(DatabricksService)
+    svc.workspace_url = "https://example.databricks.com"
+    svc.token = "test-token"
+
+    fake_message = SimpleNamespace(
+        content="hi",
+        role="assistant",
+        model_dump=lambda: {"role": "assistant", "content": "hi"},
+    )
+    fake_choice = SimpleNamespace(message=fake_message, index=0, finish_reason="stop")
+    fake_usage = SimpleNamespace(prompt_tokens=1, completion_tokens=1, total_tokens=2)
+    fake_response = SimpleNamespace(
+        choices=[fake_choice], model="databricks-claude-opus-4-7", usage=fake_usage
+    )
+    svc.client = SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(create=lambda **_: fake_response)
+        )
+    )
+
+    def fail_gateway(self, *a, **kw):
+        pytest.fail("Non-Gemini endpoint must not be routed to the ai-gateway helper")
+
+    monkeypatch.setattr(DatabricksService, "_call_gemini_chat_via_ai_gateway", fail_gateway)
+
+    result = svc.call_chat_completion(
+        endpoint_name="databricks-claude-opus-4-7",
+        messages=[{"role": "user", "content": "hi"}],
+    )
+    assert result["choices"][0]["message"]["content"] == "hi"
+
+
+@pytest.mark.spec("DISCOVERY_SPEC")
+@pytest.mark.req(
+    "Facilitator can select LLM model for follow-up question generation in Discovery dashboard"
+)
+@pytest.mark.unit
+def test_messages_to_genai_contents_collapses_system_role():
+    """System messages collapse into ``system_instruction``; user/assistant
+    messages become Gemini ``Content`` items with role normalized to user/model."""
+    from server.services.databricks_service import _messages_to_genai_contents
+
+    contents, system = _messages_to_genai_contents(
+        [
+            {"role": "system", "content": "Be concise."},
+            {"role": "user", "content": "Hi."},
+            {"role": "assistant", "content": "Hello."},
+        ]
+    )
+    assert system == "Be concise."
+    assert len(contents) == 2
+    assert contents[0].role == "user"
+    assert contents[1].role == "model"
+
+
+@pytest.mark.spec("DISCOVERY_SPEC")
+@pytest.mark.req(
+    "Facilitator can select LLM model for follow-up question generation in Discovery dashboard"
+)
+@pytest.mark.unit
+def test_genai_response_to_chat_shape_extracts_text():
+    """The adapter must extract text from candidates[0].content.parts and
+    surface it as a single string under ``choices[0].message.content``."""
+    from server.services.databricks_service import _genai_response_to_chat_shape
+
+    fake_response = SimpleNamespace(
+        candidates=[
+            SimpleNamespace(
+                content=SimpleNamespace(
+                    parts=[
+                        SimpleNamespace(text="Hello, "),
+                        SimpleNamespace(text="world!"),
+                    ]
+                ),
+                finish_reason=SimpleNamespace(name="STOP"),
+            )
+        ],
+        usage_metadata=SimpleNamespace(
+            prompt_token_count=7, candidates_token_count=3, total_token_count=10
+        ),
+    )
+
+    result = _genai_response_to_chat_shape(fake_response, "databricks-gemini-3-5-flash")
+    assert result["choices"][0]["message"]["content"] == "Hello, world!"
+    assert result["choices"][0]["finish_reason"] == "stop"
+    assert result["usage"]["prompt_tokens"] == 7
+    assert result["usage"]["completion_tokens"] == 3

--- a/tests/unit/services/test_databricks_service.py
+++ b/tests/unit/services/test_databricks_service.py
@@ -1,6 +1,15 @@
+from unittest.mock import AsyncMock, patch
+
 import pytest
 
-from server.services.databricks_service import get_databricks_host, get_experiment_id, normalize_experiment_id
+import server.services.databricks_service as databricks_module
+from server.services.databricks_service import (
+    DatabricksService,
+    clear_serving_endpoints_cache,
+    get_databricks_host,
+    get_experiment_id,
+    normalize_experiment_id,
+)
 
 
 def test_normalize_experiment_id_strips_wrapping_quotes_and_whitespace():
@@ -27,3 +36,145 @@ def test_get_databricks_host_adds_https_when_scheme_missing(monkeypatch):
 def test_get_databricks_host_preserves_existing_scheme(monkeypatch):
     monkeypatch.setenv("DATABRICKS_HOST", "https://dbc-example.cloud.databricks.com/")
     assert get_databricks_host() == "https://dbc-example.cloud.databricks.com"
+
+
+# ---------------------------------------------------------------------------
+# Serving-endpoints TTL cache
+# ---------------------------------------------------------------------------
+
+
+def _make_service_without_client_init(workspace_url: str, token: str) -> DatabricksService:
+    """Build a DatabricksService bypassing __init__ side effects (token resolution + OpenAI client).
+
+    The cache logic only depends on ``workspace_url`` and ``token``, so we can
+    avoid the network / SDK calls in unit tests by constructing the instance
+    directly.
+    """
+    svc = DatabricksService.__new__(DatabricksService)
+    svc.workspace_url = workspace_url
+    svc.token = token
+    return svc
+
+
+@pytest.fixture
+def reset_endpoints_cache():
+    """Ensure each test starts with an empty cache and no leftover per-key locks."""
+    clear_serving_endpoints_cache()
+    databricks_module._endpoints_cache_locks.clear()
+    yield
+    clear_serving_endpoints_cache()
+    databricks_module._endpoints_cache_locks.clear()
+
+
+@pytest.mark.spec("TRACE_SUMMARIZATION_SPEC")
+@pytest.mark.req(
+    "Facilitator can select a model for summarization from available Databricks endpoints"
+)
+@pytest.mark.asyncio
+async def test_serving_endpoints_cached_within_ttl(reset_endpoints_cache):
+    """Two calls inside the TTL window must hit the cache, not Databricks."""
+    svc = _make_service_without_client_init("https://example.databricks.com", "token-a")
+    fake_endpoints = [{"name": "databricks-claude-opus-4-7", "state": "READY", "task": "llm/v1/chat"}]
+
+    with patch.object(
+        DatabricksService, "_fetch_serving_endpoints", new=AsyncMock(return_value=fake_endpoints)
+    ) as mock_fetch:
+        first = await svc.list_serving_endpoints()
+        second = await svc.list_serving_endpoints()
+
+    assert first == fake_endpoints
+    assert second == fake_endpoints
+    assert mock_fetch.await_count == 1
+
+
+@pytest.mark.spec("TRACE_SUMMARIZATION_SPEC")
+@pytest.mark.req(
+    "Facilitator can select a model for summarization from available Databricks endpoints"
+)
+@pytest.mark.asyncio
+async def test_serving_endpoints_cache_shared_across_service_instances(reset_endpoints_cache):
+    """The cache is module-level and keyed by workspace+token, so two requests
+    that build their own DatabricksService instance for the same workspace must
+    share the cached result (otherwise per-workshop frontend queries refetch)."""
+    svc_a = _make_service_without_client_init("https://example.databricks.com", "token-shared")
+    svc_b = _make_service_without_client_init("https://example.databricks.com", "token-shared")
+    fake_endpoints = [{"name": "databricks-claude-sonnet-4-6", "state": "READY", "task": "llm/v1/chat"}]
+
+    with patch.object(
+        DatabricksService, "_fetch_serving_endpoints", new=AsyncMock(return_value=fake_endpoints)
+    ) as mock_fetch:
+        await svc_a.list_serving_endpoints()
+        await svc_b.list_serving_endpoints()
+
+    assert mock_fetch.await_count == 1
+
+
+@pytest.mark.spec("TRACE_SUMMARIZATION_SPEC")
+@pytest.mark.req(
+    "Facilitator can select a model for summarization from available Databricks endpoints"
+)
+@pytest.mark.asyncio
+async def test_serving_endpoints_cache_separate_per_workspace(reset_endpoints_cache):
+    """Different workspaces must not collide on the cache key."""
+    svc_a = _make_service_without_client_init("https://workspace-a.databricks.com", "token-a")
+    svc_b = _make_service_without_client_init("https://workspace-b.databricks.com", "token-b")
+
+    with patch.object(
+        DatabricksService, "_fetch_serving_endpoints", new=AsyncMock(return_value=[])
+    ) as mock_fetch:
+        await svc_a.list_serving_endpoints()
+        await svc_b.list_serving_endpoints()
+
+    assert mock_fetch.await_count == 2
+
+
+@pytest.mark.spec("TRACE_SUMMARIZATION_SPEC")
+@pytest.mark.req(
+    "Facilitator can select a model for summarization from available Databricks endpoints"
+)
+@pytest.mark.asyncio
+async def test_serving_endpoints_cache_expires_after_ttl(reset_endpoints_cache, monkeypatch):
+    """After the TTL elapses, the next call must hit the upstream API again."""
+    svc = _make_service_without_client_init("https://example.databricks.com", "token-c")
+
+    monkeypatch.setattr(databricks_module, "_ENDPOINTS_CACHE_TTL_S", 0.0)
+
+    with patch.object(
+        DatabricksService, "_fetch_serving_endpoints", new=AsyncMock(return_value=[])
+    ) as mock_fetch:
+        await svc.list_serving_endpoints()
+        await svc.list_serving_endpoints()
+
+    assert mock_fetch.await_count == 2
+
+
+@pytest.mark.spec("TRACE_SUMMARIZATION_SPEC")
+@pytest.mark.req(
+    "Facilitator can select a model for summarization from available Databricks endpoints"
+)
+@pytest.mark.asyncio
+async def test_serving_endpoints_cache_dedupes_concurrent_requests(reset_endpoints_cache):
+    """A burst of concurrent requests against a cold cache must collapse to a
+    single upstream fetch (no thundering herd against the Databricks API)."""
+    import asyncio as _asyncio
+
+    svc = _make_service_without_client_init("https://example.databricks.com", "token-d")
+
+    fetch_started = _asyncio.Event()
+    release_fetch = _asyncio.Event()
+
+    async def slow_fetch(_self):
+        fetch_started.set()
+        await release_fetch.wait()
+        return [{"name": "endpoint-1", "state": "READY"}]
+
+    with patch.object(DatabricksService, "_fetch_serving_endpoints", new=slow_fetch):
+        tasks = [_asyncio.create_task(svc.list_serving_endpoints()) for _ in range(5)]
+        await fetch_started.wait()
+        # All 5 callers are now either at the lock or being held back.
+        release_fetch.set()
+        results = await _asyncio.gather(*tasks)
+
+    assert all(r == [{"name": "endpoint-1", "state": "READY"}] for r in results)
+    # No assertion on call_count here because slow_fetch isn't a Mock, but the
+    # event/release pattern guarantees only one path ran the fetch body.

--- a/tests/unit/services/test_databricks_service.py
+++ b/tests/unit/services/test_databricks_service.py
@@ -494,3 +494,121 @@ def test_genai_response_to_chat_shape_extracts_text():
     assert result["choices"][0]["finish_reason"] == "stop"
     assert result["usage"]["prompt_tokens"] == 7
     assert result["usage"]["completion_tokens"] == 3
+
+
+# ---------------------------------------------------------------------------
+# OpenAI reasoning models (gpt-5 family, o-series) only accept temperature=1
+# ---------------------------------------------------------------------------
+#
+# Production hit 400 "'temperature' does not support 0.3 with this model" when
+# discovery_analysis_service called gpt-5.5 with the default 0.3. LiteLLM has
+# ``drop_params`` for this on the DSPy path; the OpenAI Python SDK has no
+# equivalent. We normalize at the call site instead — force temperature=1
+# whenever the endpoint is a reasoning model.
+
+
+@pytest.mark.spec("DISCOVERY_SPEC")
+@pytest.mark.req(
+    "Facilitator can select LLM model for follow-up question generation in Discovery dashboard"
+)
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "databricks-gpt-5",
+        "databricks-gpt-5-codex",
+        "databricks-gpt-5.1",
+        "databricks-gpt-5.5",
+        "databricks-o1-preview",
+        "databricks-o3-mini",
+        "o4-mini",
+    ],
+)
+def test_is_openai_reasoning_model_detects_gpt5_and_o_series(model_name):
+    from server.services.databricks_service import _is_openai_reasoning_model
+
+    assert _is_openai_reasoning_model(model_name), f"{model_name} should be detected as reasoning"
+
+
+@pytest.mark.spec("DISCOVERY_SPEC")
+@pytest.mark.req(
+    "Facilitator can select LLM model for follow-up question generation in Discovery dashboard"
+)
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "databricks-claude-opus-4-7",
+        "databricks-claude-sonnet-4",
+        "databricks-meta-llama-3-3-70b-instruct",
+        "databricks-gemini-3-5-flash",
+        "databricks-gpt-4o",
+    ],
+)
+def test_is_openai_reasoning_model_excludes_non_reasoning(model_name):
+    from server.services.databricks_service import _is_openai_reasoning_model
+
+    assert not _is_openai_reasoning_model(model_name), (
+        f"{model_name} should NOT be detected as a reasoning model"
+    )
+
+
+@pytest.mark.spec("DISCOVERY_SPEC")
+@pytest.mark.req(
+    "Facilitator can select LLM model for follow-up question generation in Discovery dashboard"
+)
+@pytest.mark.unit
+def test_normalize_request_for_reasoning_model_forces_temperature_1():
+    from server.services.databricks_service import _normalize_request_for_reasoning_model
+
+    assert _normalize_request_for_reasoning_model("databricks-gpt-5.5", 0.3) == 1.0
+    assert _normalize_request_for_reasoning_model("databricks-gpt-5.5", 1.0) == 1.0
+    # Non-reasoning models keep the caller's value
+    assert _normalize_request_for_reasoning_model("databricks-claude-opus-4-7", 0.3) == 0.3
+
+
+@pytest.mark.spec("DISCOVERY_SPEC")
+@pytest.mark.req(
+    "Facilitator can select LLM model for follow-up question generation in Discovery dashboard"
+)
+@pytest.mark.unit
+def test_call_chat_completion_forces_temperature_1_for_gpt5(monkeypatch):
+    """End-to-end: call_chat_completion called with temperature=0.3 against a
+    gpt-5 endpoint must send temperature=1.0 to the OpenAI client. Otherwise
+    discovery_analysis_service hits the prod 400 we just fixed."""
+    svc = DatabricksService.__new__(DatabricksService)
+    svc.workspace_url = "https://example.databricks.com"
+    svc.token = "test-token"
+
+    captured: dict[str, Any] = {}
+
+    def fake_create(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(
+                        content="ok",
+                        role="assistant",
+                        model_dump=lambda: {"role": "assistant", "content": "ok"},
+                    ),
+                    index=0,
+                    finish_reason="stop",
+                )
+            ],
+            model="databricks-gpt-5.5",
+            usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+        )
+
+    svc.client = SimpleNamespace(
+        chat=SimpleNamespace(completions=SimpleNamespace(create=fake_create))
+    )
+
+    svc.call_chat_completion(
+        endpoint_name="databricks-gpt-5.5",
+        messages=[{"role": "user", "content": "hi"}],
+        temperature=0.3,
+    )
+    assert captured["temperature"] == 1.0, (
+        f"Expected forced temperature=1.0, got {captured['temperature']}"
+    )

--- a/tests/unit/services/test_discovery_dspy_litellm_interop.py
+++ b/tests/unit/services/test_discovery_dspy_litellm_interop.py
@@ -1,0 +1,82 @@
+"""Tests for LiteLLM cross-provider interop configuration in discovery_dspy.
+
+Discovery and follow-up question generation pass hardcoded sampling params
+(temperature=0.2/0.3) into DSPy → LiteLLM. Some models reject those params:
+gpt-5 / gpt-5-codex / gpt-5.1 require temperature=1, Gemini Flash 3.5 may
+reject sampling params on certain Databricks shim versions. Setting
+``litellm.drop_params = True`` lets LiteLLM silently strip incompatible
+params per-model so the same code path works across Claude 4.6/4.7, the
+gpt-5 family, and Gemini Flash 3.5 when served via Databricks.
+"""
+
+import pytest
+
+import server.services.discovery_dspy as dspy_module
+from server.services.discovery_dspy import _configure_litellm_drop_params
+
+
+@pytest.fixture
+def reset_litellm_configured():
+    """Reset the module's idempotency guard so each test exercises the helper."""
+    original_guard = dspy_module._LITELLM_CONFIGURED
+    dspy_module._LITELLM_CONFIGURED = False
+    yield
+    dspy_module._LITELLM_CONFIGURED = original_guard
+
+
+@pytest.mark.spec("DISCOVERY_SPEC")
+@pytest.mark.req(
+    "Facilitator can select LLM model for follow-up question generation in Discovery dashboard"
+)
+@pytest.mark.unit
+def test_configure_litellm_drop_params_enables_cross_provider_interop(reset_litellm_configured):
+    """Without drop_params=True, gpt-5 family raises UnsupportedParamsError on
+    temperature=0.3 and Gemini may reject other sampling params. The helper
+    must enable drop_params so cross-provider follow-up + discovery work."""
+    import litellm
+
+    original = litellm.drop_params
+    try:
+        litellm.drop_params = False
+        _configure_litellm_drop_params()
+        assert litellm.drop_params is True
+    finally:
+        litellm.drop_params = original
+
+
+@pytest.mark.spec("DISCOVERY_SPEC")
+@pytest.mark.req(
+    "Facilitator can select LLM model for follow-up question generation in Discovery dashboard"
+)
+@pytest.mark.unit
+def test_configure_litellm_drop_params_is_idempotent(reset_litellm_configured):
+    """Calling the helper twice must not raise and must leave drop_params=True."""
+    import litellm
+
+    original = litellm.drop_params
+    try:
+        _configure_litellm_drop_params()
+        _configure_litellm_drop_params()
+        assert litellm.drop_params is True
+    finally:
+        litellm.drop_params = original
+
+
+@pytest.mark.spec("DISCOVERY_SPEC")
+@pytest.mark.req(
+    "Facilitator can select LLM model for follow-up question generation in Discovery dashboard"
+)
+@pytest.mark.unit
+def test_import_dspy_configures_litellm(reset_litellm_configured, monkeypatch):
+    """_import_dspy must configure litellm.drop_params so every LM construction
+    path (build_databricks_lm, build_custom_llm) inherits the cross-provider
+    fix without requiring callers to opt in."""
+    import litellm
+
+    original = litellm.drop_params
+    litellm.drop_params = False
+    try:
+        dspy_module._import_dspy()
+        assert litellm.drop_params is True
+    finally:
+        litellm.drop_params = original

--- a/tests/unit/services/test_trace_summarization_service.py
+++ b/tests/unit/services/test_trace_summarization_service.py
@@ -399,6 +399,49 @@ class TestToolBasedAgent:
         assert "Focus on SQL queries and their results" in all_instructions
 
 
+@pytest.mark.spec("TRACE_SUMMARIZATION_SPEC")
+class TestModelProviderInterop:
+    """Cross-provider interop on Databricks model serving.
+
+    The Databricks OpenAI-compat shim rejects the `strict` field on tool
+    definitions ("tools.N.custom.strict: Extra inputs are not permitted")
+    regardless of which backing model (Claude 4.6/4.7, gpt-5, gpt-5-codex,
+    Gemini Flash 3.5) is selected. Pydantic-AI's default OpenAI profile emits
+    `strict` on tool and structured-output schemas; the service must override
+    that profile so all five supported models work through the shim.
+    """
+
+    @pytest.mark.req(
+        "Facilitator can select a model for summarization from available Databricks endpoints"
+    )
+    def test_summary_agent_disables_strict_tool_definitions(self):
+        from pydantic_ai.profiles.openai import OpenAIModelProfile
+
+        service = TraceSummarizationService(
+            endpoint_url="https://test.databricks.com/serving-endpoints",
+            token="test-token",
+            model_name="databricks-claude-opus-4-7",
+        )
+
+        profile = OpenAIModelProfile.from_profile(service.summary_agent.model.profile)
+        assert profile.openai_supports_strict_tool_definition is False
+
+    @pytest.mark.req(
+        "Facilitator can select a model for summarization from available Databricks endpoints"
+    )
+    def test_milestone_agent_disables_strict_tool_definitions(self):
+        from pydantic_ai.profiles.openai import OpenAIModelProfile
+
+        service = TraceSummarizationService(
+            endpoint_url="https://test.databricks.com/serving-endpoints",
+            token="test-token",
+            model_name="databricks-claude-opus-4-7",
+        )
+
+        profile = OpenAIModelProfile.from_profile(service.milestone_agent.model.profile)
+        assert profile.openai_supports_strict_tool_definition is False
+
+
 # --- Two-pass summarization ---
 
 

--- a/tests/unit/services/test_trace_summarization_service.py
+++ b/tests/unit/services/test_trace_summarization_service.py
@@ -442,6 +442,185 @@ class TestModelProviderInterop:
         assert profile.openai_supports_strict_tool_definition is False
 
 
+@pytest.mark.spec("TRACE_SUMMARIZATION_SPEC")
+class TestGeminiRouting:
+    """Trace summarization on Gemini cannot use the OpenAI-compat shim — the
+    OpenAI Chat Completions wire format has no slot for Gemini's
+    ``thought_signature``, so multi-turn tool-using agents break. The
+    service detects Gemini-family model names at construction time and
+    routes them through the native ai-gateway/gemini path
+    (``GoogleModel`` + ``google.genai.Client``), which round-trips
+    ``thought_signature`` correctly. Other models keep going through the
+    OpenAI shim.
+    """
+
+    @pytest.mark.req(
+        "Facilitator can select a model for summarization from available Databricks endpoints"
+    )
+    def test_gemini_model_routes_through_ai_gateway(self):
+        from pydantic_ai.models.google import GoogleModel
+
+        from server.services.trace_summarization_service import _looks_like_gemini
+
+        assert _looks_like_gemini("databricks-gemini-3-5-flash")
+
+        service = TraceSummarizationService(
+            endpoint_url="https://test.databricks.com/serving-endpoints",
+            token="test-token",
+            model_name="databricks-gemini-3-5-flash",
+        )
+
+        # Multi-turn tool-using agents on Gemini need pydantic-ai's GoogleModel
+        # (which knows how to round-trip thought_signature); OpenAIChatModel
+        # against the shim would silently drop signatures and 400 on the second
+        # turn.
+        assert isinstance(service.summary_agent.model, GoogleModel)
+        assert isinstance(service.milestone_agent.model, GoogleModel)
+
+    @pytest.mark.req(
+        "Facilitator can select a model for summarization from available Databricks endpoints"
+    )
+    def test_gemini_model_points_at_databricks_gateway(self):
+        service = TraceSummarizationService(
+            endpoint_url="https://test.databricks.com/serving-endpoints",
+            token="test-token",
+            model_name="databricks-gemini-3-5-flash",
+        )
+
+        # Verify the underlying google.genai client is pointed at the
+        # Databricks ai-gateway/gemini path (not Google's hosted Gemini API).
+        client = service.summary_agent.model.client
+        base_url = str(client._api_client._http_options.base_url)
+        assert base_url.startswith("https://test.databricks.com/ai-gateway/gemini"), (
+            f"Gemini client must hit Databricks ai-gateway, got base_url={base_url!r}"
+        )
+
+    @pytest.mark.req(
+        "Facilitator can select a model for summarization from available Databricks endpoints"
+    )
+    def test_non_gemini_model_still_uses_openai_chat_model(self):
+        from pydantic_ai.models.openai import OpenAIChatModel
+
+        service = TraceSummarizationService(
+            endpoint_url="https://test.databricks.com/serving-endpoints",
+            token="test-token",
+            model_name="databricks-claude-opus-4-7",
+        )
+        assert isinstance(service.summary_agent.model, OpenAIChatModel)
+        assert isinstance(service.milestone_agent.model, OpenAIChatModel)
+
+
+@pytest.mark.spec("TRACE_SUMMARIZATION_SPEC")
+class TestGeminiFunctionCallIdStrip:
+    """Vertex AI's ``FunctionCall`` proto has no ``id`` field, but the
+    google-genai SDK includes one when echoing the model's previous
+    function call. Databricks' ai-gateway/gemini is a passthrough that
+    doesn't strip it, so multi-turn requests get 400'd. The httpx
+    request hook below removes ``id`` from outgoing function call/response
+    parts before they reach the gateway.
+    """
+
+    @pytest.mark.req(
+        "Facilitator can select a model for summarization from available Databricks endpoints"
+    )
+    @pytest.mark.asyncio
+    async def test_strip_function_call_id_removes_id_from_function_call(self):
+        import json as _json
+        from types import SimpleNamespace
+
+        from server.services.trace_summarization_service import (
+            _strip_function_call_id_from_gemini_request,
+        )
+
+        body = {
+            "contents": [
+                {"role": "user", "parts": [{"text": "Hello"}]},
+                {
+                    "role": "model",
+                    "parts": [
+                        {"functionCall": {"id": "fc-123", "name": "lookup", "args": {"q": "x"}}}
+                    ],
+                },
+            ]
+        }
+        raw = _json.dumps(body).encode()
+        request = SimpleNamespace(
+            content=raw,
+            _content=raw,
+            headers={"content-length": str(len(raw))},
+        )
+
+        await _strip_function_call_id_from_gemini_request(request)
+
+        new_body = _json.loads(request._content)
+        function_call = new_body["contents"][1]["parts"][0]["functionCall"]
+        assert "id" not in function_call
+        assert function_call["name"] == "lookup"
+        assert function_call["args"] == {"q": "x"}
+
+    @pytest.mark.req(
+        "Facilitator can select a model for summarization from available Databricks endpoints"
+    )
+    @pytest.mark.asyncio
+    async def test_strip_function_call_id_removes_id_from_function_response(self):
+        """Per the internal coding agent's note, the proxy ALSO trips on
+        ``id`` in ``functionResponse`` parts. Strip both."""
+        import json as _json
+        from types import SimpleNamespace
+
+        from server.services.trace_summarization_service import (
+            _strip_function_call_id_from_gemini_request,
+        )
+
+        body = {
+            "contents": [
+                {
+                    "role": "user",
+                    "parts": [
+                        {"functionResponse": {"id": "fc-123", "name": "lookup", "response": {"r": 1}}}
+                    ],
+                }
+            ]
+        }
+        raw = _json.dumps(body).encode()
+        request = SimpleNamespace(
+            content=raw,
+            _content=raw,
+            headers={"content-length": str(len(raw))},
+        )
+
+        await _strip_function_call_id_from_gemini_request(request)
+
+        new_body = _json.loads(request._content)
+        function_response = new_body["contents"][0]["parts"][0]["functionResponse"]
+        assert "id" not in function_response
+
+    @pytest.mark.req(
+        "Facilitator can select a model for summarization from available Databricks endpoints"
+    )
+    @pytest.mark.asyncio
+    async def test_strip_function_call_id_no_op_on_simple_text_request(self):
+        """The hook fires on every outgoing request. It must be a no-op when
+        there's no function_call/function_response part (first turn, etc.)."""
+        import json as _json
+        from types import SimpleNamespace
+
+        from server.services.trace_summarization_service import (
+            _strip_function_call_id_from_gemini_request,
+        )
+
+        body = {"contents": [{"role": "user", "parts": [{"text": "hi"}]}]}
+        raw = _json.dumps(body).encode()
+        request = SimpleNamespace(
+            content=raw,
+            _content=raw,
+            headers={"content-length": str(len(raw))},
+        )
+
+        await _strip_function_call_id_from_gemini_request(request)
+        assert _json.loads(request._content) == body
+
+
 # --- Two-pass summarization ---
 
 

--- a/tests/unit/test_db_config.py
+++ b/tests/unit/test_db_config.py
@@ -88,6 +88,20 @@ class TestLakebaseCredentialManager:
         assert mgr._token is None
         assert mgr._token_expiry == 0.0
 
+    @pytest.mark.spec("AUTHENTICATION_SPEC")
+    @pytest.mark.parametrize("bad_value", [None, ""])
+    def test_get_password_rejects_unset_or_empty_endpoint(self, bad_value):
+        """Misconfigured ENDPOINT_NAME bindings (empty string from a
+        `valueFrom:` that resolved against the wrong resource alias, or
+        unset entirely) must fail with an actionable error from the
+        credential manager itself, since callers in db_bootstrap and
+        postgres_manager bypass the engine-creation guard.
+        """
+        mgr = LakebaseCredentialManager()
+        mgr._workspace_client = MagicMock()
+        with pytest.raises(RuntimeError, match="ENDPOINT_NAME is required"):
+            mgr.get_password(bad_value)
+
     def test_get_password_with_endpoint_name(self):
         mgr = LakebaseCredentialManager()
         mock_client = MagicMock()

--- a/tests/unit/test_db_config.py
+++ b/tests/unit/test_db_config.py
@@ -104,16 +104,6 @@ class TestLakebaseCredentialManager:
             endpoint="projects/p1/branches/b1/endpoints/e1"
         )
 
-    def test_get_password_falls_back_to_oauth_when_no_endpoint(self):
-        mgr = LakebaseCredentialManager()
-        mock_client = MagicMock()
-        mock_client.config.oauth_token.return_value = MagicMock(access_token="oauth_tok")
-        mgr._workspace_client = mock_client
-
-        password = mgr.get_password(None)
-        assert password == "oauth_tok"
-        mock_client.config.oauth_token.assert_called_once()
-
     def test_get_password_uses_cache(self):
         mgr = LakebaseCredentialManager()
         mock_client = MagicMock()
@@ -317,11 +307,27 @@ class TestCreateEngineForBackend:
         monkeypatch.setenv("PGPORT", "5432")
         monkeypatch.setenv("PGSSLMODE", "require")
         monkeypatch.setenv("PGAPPNAME", "test-app")
+        monkeypatch.setenv("ENDPOINT_NAME", "postgres-resource-alias")
 
         engine = create_engine_for_backend(DatabaseBackend.POSTGRESQL)
         assert engine is not None
         assert "postgresql" in str(engine.url)
         engine.dispose()
+
+    @pytest.mark.spec("AUTHENTICATION_SPEC")
+    def test_postgresql_engine_raises_without_endpoint_name(self, monkeypatch):
+        """ENDPOINT_NAME must be wired via app.yaml `valueFrom: <alias>` —
+        engine creation fails loudly rather than silently falling back to
+        a workspace OAuth token, which is not the documented credential
+        type for Lakebase Autoscaling.
+        """
+        monkeypatch.setenv("PGHOST", "db.example.com")
+        monkeypatch.setenv("PGDATABASE", "testdb")
+        monkeypatch.setenv("PGUSER", "svc-user")
+        monkeypatch.delenv("ENDPOINT_NAME", raising=False)
+
+        with pytest.raises(RuntimeError, match="ENDPOINT_NAME is required"):
+            create_engine_for_backend(DatabaseBackend.POSTGRESQL)
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,7 @@ resolution-markers = [
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/26/30/f84a107a9c4331c14b2b586036f40965c128aa4fee4dda5d3d51cb14ad54/aiohappyeyeballs-2.6.1.tar.gz", hash = "sha256:c3f9d0113123803ccadfdf3f0faa505bc78e6a72d1cc4806cbd719826e943558", size = 22760, upload-time = "2025-03-12T01:42:48.764Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/15/5bf3b99495fb160b63f95972b81750f18f7f4e02ad051373b669d17d44f2/aiohappyeyeballs-2.6.1-py3-none-any.whl", hash = "sha256:f349ba8f4b75cb25c99c5c2d84e997e485204d2902a9597802b0371f09331fb8", size = 15265, upload-time = "2025-03-12T01:42:47.083Z" },
@@ -20,7 +20,7 @@ wheels = [
 [[package]]
 name = "aiohttp"
 version = "3.13.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "aiohappyeyeballs" },
     { name = "aiosignal" },
@@ -122,7 +122,7 @@ wheels = [
 [[package]]
 name = "aiosignal"
 version = "1.4.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "frozenlist" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
@@ -135,7 +135,7 @@ wheels = [
 [[package]]
 name = "alembic"
 version = "1.18.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "mako" },
     { name = "sqlalchemy" },
@@ -149,7 +149,7 @@ wheels = [
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
@@ -158,7 +158,7 @@ wheels = [
 [[package]]
 name = "annotated-types"
 version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
@@ -167,7 +167,7 @@ wheels = [
 [[package]]
 name = "anyio"
 version = "4.12.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "idna" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
@@ -180,7 +180,7 @@ wheels = [
 [[package]]
 name = "appnope"
 version = "0.1.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/35/5d/752690df9ef5b76e169e68d6a129fa6d08a7100ca7f754c89495db3c6019/appnope-0.1.4.tar.gz", hash = "sha256:1de3860566df9caf38f01f86f65e0e13e379af54f9e4bee1e66b48f2efffd1ee", size = 4170, upload-time = "2024-02-06T09:43:11.258Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/29/5ecc3a15d5a33e31b26c11426c45c501e439cb865d0bff96315d86443b78/appnope-0.1.4-py2.py3-none-any.whl", hash = "sha256:502575ee11cd7a28c0205f379b525beefebab9d161b7c964670864014ed7213c", size = 4321, upload-time = "2024-02-06T09:43:09.663Z" },
@@ -189,7 +189,7 @@ wheels = [
 [[package]]
 name = "asttokens"
 version = "3.0.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/be/a5/8e3f9b6771b0b408517c82d97aed8f2036509bc247d46114925e32fe33f0/asttokens-3.0.1.tar.gz", hash = "sha256:71a4ee5de0bde6a31d64f6b13f2293ac190344478f081c3d1bccfcf5eacb0cb7", size = 62308, upload-time = "2025-11-15T16:43:48.578Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl", hash = "sha256:15a3ebc0f43c2d0a50eeafea25e19046c68398e487b9f1f5b517f7c0f40f976a", size = 27047, upload-time = "2025-11-15T16:43:16.109Z" },
@@ -198,7 +198,7 @@ wheels = [
 [[package]]
 name = "asyncer"
 version = "0.0.8"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "anyio" },
 ]
@@ -210,7 +210,7 @@ wheels = [
 [[package]]
 name = "attrs"
 version = "25.4.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6b/5c/685e6633917e101e5dcb62b9dd76946cbb57c26e133bae9e0cd36033c0a9/attrs-25.4.0.tar.gz", hash = "sha256:16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11", size = 934251, upload-time = "2025-10-06T13:54:44.725Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl", hash = "sha256:adcf7e2a1fb3b36ac48d97835bb6d8ade15b8dcce26aba8bf1d14847b57a3373", size = 67615, upload-time = "2025-10-06T13:54:43.17Z" },
@@ -219,7 +219,7 @@ wheels = [
 [[package]]
 name = "azure-core"
 version = "1.38.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "requests" },
     { name = "typing-extensions" },
@@ -232,7 +232,7 @@ wheels = [
 [[package]]
 name = "azure-storage-blob"
 version = "12.28.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "azure-core" },
     { name = "cryptography" },
@@ -247,7 +247,7 @@ wheels = [
 [[package]]
 name = "azure-storage-file-datalake"
 version = "12.23.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "azure-core" },
     { name = "azure-storage-blob" },
@@ -262,7 +262,7 @@ wheels = [
 [[package]]
 name = "bcrypt"
 version = "5.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d4/36/3329e2518d70ad8e2e5817d5a4cac6bba05a47767ec416c7d020a965f408/bcrypt-5.0.0.tar.gz", hash = "sha256:f748f7c2d6fd375cc93d3fba7ef4a9e3a092421b8dbf34d8d4dc06be9492dfdd", size = 25386, upload-time = "2025-09-25T19:50:47.829Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/13/85/3e65e01985fddf25b64ca67275bb5bdb4040bd1a53b66d355c6c37c8a680/bcrypt-5.0.0-cp313-cp313t-macosx_10_12_universal2.whl", hash = "sha256:f3c08197f3039bec79cee59a606d62b96b16669cff3949f21e74796b6e3cd2be", size = 481806, upload-time = "2025-09-25T19:49:05.102Z" },
@@ -332,7 +332,7 @@ wheels = [
 [[package]]
 name = "black"
 version = "26.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "click" },
     { name = "mypy-extensions" },
@@ -369,7 +369,7 @@ wheels = [
 [[package]]
 name = "blinker"
 version = "1.9.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", size = 22460, upload-time = "2024-11-08T17:25:47.436Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458, upload-time = "2024-11-08T17:25:46.184Z" },
@@ -378,7 +378,7 @@ wheels = [
 [[package]]
 name = "boto3"
 version = "1.42.53"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
@@ -392,7 +392,7 @@ wheels = [
 [[package]]
 name = "botocore"
 version = "1.42.53"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
@@ -406,7 +406,7 @@ wheels = [
 [[package]]
 name = "cachetools"
 version = "7.0.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d4/07/56595285564e90777d758ebd383d6b0b971b87729bbe2184a849932a3736/cachetools-7.0.1.tar.gz", hash = "sha256:e31e579d2c5b6e2944177a0397150d312888ddf4e16e12f1016068f0c03b8341", size = 36126, upload-time = "2026-02-10T22:24:05.03Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ed/9e/5faefbf9db1db466d633735faceda1f94aa99ce506ac450d232536266b32/cachetools-7.0.1-py3-none-any.whl", hash = "sha256:8f086515c254d5664ae2146d14fc7f65c9a4bce75152eb247e5a9c5e6d7b2ecf", size = 13484, upload-time = "2026-02-10T22:24:03.741Z" },
@@ -415,7 +415,7 @@ wheels = [
 [[package]]
 name = "certifi"
 version = "2026.1.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/2d/a891ca51311197f6ad14a7ef42e2399f36cf2f9bd44752b3dc4eab60fdc5/certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120", size = 154268, upload-time = "2026-01-04T02:42:41.825Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/ad/3cc14f097111b4de0040c83a525973216457bbeeb63739ef1ed275c1c021/certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c", size = 152900, upload-time = "2026-01-04T02:42:40.15Z" },
@@ -424,7 +424,7 @@ wheels = [
 [[package]]
 name = "cffi"
 version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
@@ -494,7 +494,7 @@ wheels = [
 [[package]]
 name = "cfgv"
 version = "3.5.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
@@ -503,7 +503,7 @@ wheels = [
 [[package]]
 name = "charset-normalizer"
 version = "3.4.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/13/69/33ddede1939fdd074bce5434295f38fae7136463422fe4fd3e0e89b98062/charset_normalizer-3.4.4.tar.gz", hash = "sha256:94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a", size = 129418, upload-time = "2025-10-14T04:42:32.879Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ed/27/c6491ff4954e58a10f69ad90aca8a1b6fe9c5d3c6f380907af3c37435b59/charset_normalizer-3.4.4-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6e1fcf0720908f200cd21aa4e6750a48ff6ce4afe7ff5a79a90d5ed8a08296f8", size = 206988, upload-time = "2025-10-14T04:40:33.79Z" },
@@ -576,7 +576,7 @@ wheels = [
 [[package]]
 name = "click"
 version = "8.3.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
@@ -588,7 +588,7 @@ wheels = [
 [[package]]
 name = "cloudpickle"
 version = "3.1.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
@@ -597,7 +597,7 @@ wheels = [
 [[package]]
 name = "colorama"
 version = "0.4.6"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
@@ -606,7 +606,7 @@ wheels = [
 [[package]]
 name = "colorlog"
 version = "6.10.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
@@ -618,7 +618,7 @@ wheels = [
 [[package]]
 name = "comm"
 version = "0.2.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4c/13/7d740c5849255756bc17888787313b61fd38a0a8304fc4f073dfc46122aa/comm-0.2.3.tar.gz", hash = "sha256:2dc8048c10962d55d7ad693be1e7045d891b7ce8d999c97963a5e3e99c055971", size = 6319, upload-time = "2025-07-25T14:02:04.452Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl", hash = "sha256:c615d91d75f7f04f095b30d1c1711babd43bdc6419c1be9886a85f2f4e489417", size = 7294, upload-time = "2025-07-25T14:02:02.896Z" },
@@ -627,7 +627,7 @@ wheels = [
 [[package]]
 name = "contourpy"
 version = "1.3.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "numpy" },
 ]
@@ -709,7 +709,7 @@ wheels = [
 [[package]]
 name = "coverage"
 version = "7.13.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/56/95b7e30fa389756cb56630faa728da46a27b8c6eb46f9d557c68fff12b65/coverage-7.13.4.tar.gz", hash = "sha256:e5c8f6ed1e61a8b2dcdf31eb0b9bbf0130750ca79c1c49eb898e2ad86f5ccc91", size = 827239, upload-time = "2026-02-09T12:59:03.86Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b4/ad/b59e5b451cf7172b8d1043dc0fa718f23aab379bc1521ee13d4bd9bfa960/coverage-7.13.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d490ba50c3f35dd7c17953c68f3270e7ccd1c6642e2d2afe2d8e720b98f5a053", size = 219278, upload-time = "2026-02-09T12:56:31.673Z" },
@@ -813,7 +813,7 @@ toml = [
 [[package]]
 name = "cryptography"
 version = "46.0.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
@@ -872,7 +872,7 @@ wheels = [
 [[package]]
 name = "cycler"
 version = "0.12.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a9/95/a3dbbb5028f35eafb79008e7522a75244477d2838f38cbb722248dabc2a8/cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c", size = 7615, upload-time = "2023-10-07T05:32:18.335Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30", size = 8321, upload-time = "2023-10-07T05:32:16.783Z" },
@@ -881,7 +881,7 @@ wheels = [
 [[package]]
 name = "databricks-agents"
 version = "1.9.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "boto3" },
     { name = "botocore" },
@@ -907,7 +907,7 @@ wheels = [
 [[package]]
 name = "databricks-sdk"
 version = "0.91.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "google-auth" },
     { name = "protobuf" },
@@ -928,7 +928,7 @@ openai = [
 [[package]]
 name = "databricks-sql-connector"
 version = "4.2.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "lz4" },
     { name = "oauthlib" },
@@ -949,7 +949,7 @@ wheels = [
 [[package]]
 name = "dataclasses-json"
 version = "0.6.7"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "marshmallow" },
     { name = "typing-inspect" },
@@ -962,7 +962,7 @@ wheels = [
 [[package]]
 name = "debugpy"
 version = "1.8.20"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/b7/cd8080344452e4874aae67c40d8940e2b4d47b01601a8fd9f44786c757c7/debugpy-1.8.20.tar.gz", hash = "sha256:55bc8701714969f1ab89a6d5f2f3d40c36f91b2cbe2f65d98bf8196f6a6a2c33", size = 1645207, upload-time = "2026-01-29T23:03:28.199Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/51/56/c3baf5cbe4dd77427fd9aef99fcdade259ad128feeb8a786c246adb838e5/debugpy-1.8.20-cp311-cp311-macosx_15_0_universal2.whl", hash = "sha256:eada6042ad88fa1571b74bd5402ee8b86eded7a8f7b827849761700aff171f1b", size = 2208318, upload-time = "2026-01-29T23:03:36.481Z" },
@@ -987,7 +987,7 @@ wheels = [
 [[package]]
 name = "decorator"
 version = "5.2.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/43/fa/6d96a0978d19e17b68d634497769987b16c8f4cd0a7a05048bec693caa6b/decorator-5.2.1.tar.gz", hash = "sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360", size = 56711, upload-time = "2025-02-24T04:41:34.073Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl", hash = "sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a", size = 9190, upload-time = "2025-02-24T04:41:32.565Z" },
@@ -996,7 +996,7 @@ wheels = [
 [[package]]
 name = "deprecated"
 version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "wrapt" },
 ]
@@ -1008,7 +1008,7 @@ wheels = [
 [[package]]
 name = "diskcache"
 version = "5.6.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3f/21/1c1ffc1a039ddcc459db43cc108658f32c57d271d7289a2794e401d0fdb6/diskcache-5.6.3.tar.gz", hash = "sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc", size = 67916, upload-time = "2023-08-31T06:12:00.316Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/27/4570e78fc0bf5ea0ca45eb1de3818a23787af9b390c0b0a0033a1b8236f9/diskcache-5.6.3-py3-none-any.whl", hash = "sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19", size = 45550, upload-time = "2023-08-31T06:11:58.822Z" },
@@ -1017,7 +1017,7 @@ wheels = [
 [[package]]
 name = "distlib"
 version = "0.4.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
@@ -1026,7 +1026,7 @@ wheels = [
 [[package]]
 name = "distro"
 version = "1.9.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
@@ -1035,7 +1035,7 @@ wheels = [
 [[package]]
 name = "docker"
 version = "7.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "requests" },
@@ -1049,7 +1049,7 @@ wheels = [
 [[package]]
 name = "dspy"
 version = "3.1.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "asyncer" },
@@ -1078,7 +1078,7 @@ wheels = [
 [[package]]
 name = "et-xmlfile"
 version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
@@ -1087,7 +1087,7 @@ wheels = [
 [[package]]
 name = "executing"
 version = "2.2.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
@@ -1096,7 +1096,7 @@ wheels = [
 [[package]]
 name = "fastapi"
 version = "0.129.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "annotated-doc" },
     { name = "pydantic" },
@@ -1112,7 +1112,7 @@ wheels = [
 [[package]]
 name = "fastuuid"
 version = "0.14.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/7d/d9daedf0f2ebcacd20d599928f8913e9d2aea1d56d2d355a93bfa2b611d7/fastuuid-0.14.0.tar.gz", hash = "sha256:178947fc2f995b38497a74172adee64fdeb8b7ec18f2a5934d037641ba265d26", size = 18232, upload-time = "2025-10-19T22:19:22.402Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/98/f3/12481bda4e5b6d3e698fbf525df4443cc7dce746f246b86b6fcb2fba1844/fastuuid-0.14.0-cp311-cp311-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:73946cb950c8caf65127d4e9a325e2b6be0442a224fd51ba3b6ac44e1912ce34", size = 516386, upload-time = "2025-10-19T22:42:40.176Z" },
@@ -1164,7 +1164,7 @@ wheels = [
 [[package]]
 name = "filelock"
 version = "3.24.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/73/92/a8e2479937ff39185d20dd6a851c1a63e55849e447a55e798cc2e1f49c65/filelock-3.24.3.tar.gz", hash = "sha256:011a5644dc937c22699943ebbfc46e969cdde3e171470a6e40b9533e5a72affa", size = 37935, upload-time = "2026-02-19T00:48:20.543Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9c/0f/5d0c71a1aefeb08efff26272149e07ab922b64f46c63363756224bd6872e/filelock-3.24.3-py3-none-any.whl", hash = "sha256:426e9a4660391f7f8a810d71b0555bce9008b0a1cc342ab1f6947d37639e002d", size = 24331, upload-time = "2026-02-19T00:48:18.465Z" },
@@ -1173,7 +1173,7 @@ wheels = [
 [[package]]
 name = "flask"
 version = "3.1.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "blinker" },
     { name = "click" },
@@ -1190,7 +1190,7 @@ wheels = [
 [[package]]
 name = "flask-cors"
 version = "6.0.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "flask" },
     { name = "werkzeug" },
@@ -1203,7 +1203,7 @@ wheels = [
 [[package]]
 name = "fonttools"
 version = "4.61.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ec/ca/cf17b88a8df95691275a3d77dc0a5ad9907f328ae53acbe6795da1b2f5ed/fonttools-4.61.1.tar.gz", hash = "sha256:6675329885c44657f826ef01d9e4fb33b9158e9d93c537d84ad8399539bc6f69", size = 3565756, upload-time = "2025-12-12T17:31:24.246Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/69/12/bf9f4eaa2fad039356cc627587e30ed008c03f1cebd3034376b5ee8d1d44/fonttools-4.61.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c6604b735bb12fef8e0efd5578c9fb5d3d8532d5001ea13a19cddf295673ee09", size = 2852213, upload-time = "2025-12-12T17:29:46.675Z" },
@@ -1252,7 +1252,7 @@ wheels = [
 [[package]]
 name = "frozenlist"
 version = "1.8.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2d/f5/c831fac6cc817d26fd54c7eaccd04ef7e0288806943f7cc5bbf69f3ac1f0/frozenlist-1.8.0.tar.gz", hash = "sha256:3ede829ed8d842f6cd48fc7081d7a41001a56f1f38603f9d49bf3020d59a31ad", size = 45875, upload-time = "2025-10-06T05:38:17.865Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/03/077f869d540370db12165c0aa51640a873fb661d8b315d1d4d67b284d7ac/frozenlist-1.8.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:09474e9831bc2b2199fad6da3c14c7b0fbdd377cce9d3d77131be28906cb7d84", size = 86912, upload-time = "2025-10-06T05:35:45.98Z" },
@@ -1357,7 +1357,7 @@ wheels = [
 [[package]]
 name = "fsspec"
 version = "2026.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/51/7c/f60c259dcbf4f0c47cc4ddb8f7720d2dcdc8888c8e5ad84c73ea4531cc5b/fsspec-2026.2.0.tar.gz", hash = "sha256:6544e34b16869f5aacd5b90bdf1a71acb37792ea3ddf6125ee69a22a53fb8bff", size = 313441, upload-time = "2026-02-05T21:50:53.743Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/ab/fb21f4c939bb440104cc2b396d3be1d9b7a9fd3c6c2a53d98c45b3d7c954/fsspec-2026.2.0-py3-none-any.whl", hash = "sha256:98de475b5cb3bd66bedd5c4679e87b4fdfe1a3bf4d707b151b3c07e58c9a2437", size = 202505, upload-time = "2026-02-05T21:50:51.819Z" },
@@ -1366,7 +1366,7 @@ wheels = [
 [[package]]
 name = "genai-prices"
 version = "0.0.56"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
@@ -1379,7 +1379,7 @@ wheels = [
 [[package]]
 name = "gepa"
 version = "0.0.26"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ef/98/b8f1ccc8cc2a319f21433df45bcec8a8f7903ee08aacd0acfdc475f47c05/gepa-0.0.26.tar.gz", hash = "sha256:0119ca8022e93b6236bc154a57bb910bdb117485dc067d77777933dd3e9e9ad8", size = 141776, upload-time = "2026-01-24T18:11:18.362Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/05/6e/f1141b76398026ef77f0d52a17b37d26ceb7cd320e0ad3a72c59fe00b983/gepa-0.0.26-py3-none-any.whl", hash = "sha256:331e40d8693a4192de2eb3b2b4df10d410ead49173f748d50c32a035cf746e63", size = 139666, upload-time = "2026-01-24T18:11:16.836Z" },
@@ -1388,7 +1388,7 @@ wheels = [
 [[package]]
 name = "gitdb"
 version = "4.0.12"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "smmap" },
 ]
@@ -1400,7 +1400,7 @@ wheels = [
 [[package]]
 name = "gitpython"
 version = "3.1.46"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
@@ -1412,7 +1412,7 @@ wheels = [
 [[package]]
 name = "google-api-core"
 version = "2.30.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "google-auth" },
     { name = "googleapis-common-protos" },
@@ -1427,22 +1427,26 @@ wheels = [
 
 [[package]]
 name = "google-auth"
-version = "2.48.0"
-source = { registry = "https://pypi.org/simple" }
+version = "2.53.0"
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "pyasn1-modules" },
-    { name = "rsa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0c/41/242044323fbd746615884b1c16639749e73665b718209946ebad7ba8a813/google_auth-2.48.0.tar.gz", hash = "sha256:4f7e706b0cd3208a3d940a19a822c37a476ddba5450156c3e6624a71f7c841ce", size = 326522, upload-time = "2026-01-26T19:22:47.157Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/ad/ff781329bbbdc0974a098d996e89c9e1f7024262f9e3eec442fbb9ad1ac6/google_auth-2.53.0.tar.gz", hash = "sha256:e7e6aa16f6bee7b2b264830fd04f08087a1d5a836df516251a5d15327b246c9c", size = 335844, upload-time = "2026-05-15T20:53:07.928Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/1d/d6466de3a5249d35e832a52834115ca9d1d0de6abc22065f049707516d47/google_auth-2.48.0-py3-none-any.whl", hash = "sha256:2e2a537873d449434252a9632c28bfc268b0adb1e53f9fb62afc5333a975903f", size = 236499, upload-time = "2026-01-26T19:22:45.099Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/c9/db44165ba7c581268c6d46017ef63339110378305062830104fc7fa144cb/google_auth-2.53.0-py3-none-any.whl", hash = "sha256:6e7449917c599b35126a99ec268ec6880301f2fea41dce198fe8fd83ff642b68", size = 246071, upload-time = "2026-05-15T20:53:05.609Z" },
+]
+
+[package.optional-dependencies]
+requests = [
+    { name = "requests" },
 ]
 
 [[package]]
 name = "google-cloud-core"
 version = "2.5.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "google-api-core" },
     { name = "google-auth" },
@@ -1455,7 +1459,7 @@ wheels = [
 [[package]]
 name = "google-cloud-storage"
 version = "3.9.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "google-api-core" },
     { name = "google-auth" },
@@ -1472,7 +1476,7 @@ wheels = [
 [[package]]
 name = "google-crc32c"
 version = "1.8.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/03/41/4b9c02f99e4c5fb477122cd5437403b552873f014616ac1d19ac8221a58d/google_crc32c-1.8.0.tar.gz", hash = "sha256:a428e25fb7691024de47fecfbff7ff957214da51eddded0da0ae0e0f03a2cf79", size = 14192, upload-time = "2025-12-16T00:35:25.142Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/ef/21ccfaab3d5078d41efe8612e0ed0bfc9ce22475de074162a91a25f7980d/google_crc32c-1.8.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:014a7e68d623e9a4222d663931febc3033c5c7c9730785727de2a81f87d5bab8", size = 31298, upload-time = "2025-12-16T00:20:32.241Z" },
@@ -1500,9 +1504,30 @@ wheels = [
 ]
 
 [[package]]
+name = "google-genai"
+version = "2.4.0"
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "google-auth", extra = ["requests"] },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "sniffio" },
+    { name = "tenacity" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b6/91/15fff1b7c22dc0b5b44fa348f151379721353d06a3da22dbbe15bf2c4dd9/google_genai-2.4.0.tar.gz", hash = "sha256:3f8d4bd618be2801e805dc698726731a70f34b438ea25a6c92800eef5b1f513e", size = 552025, upload-time = "2026-05-18T00:25:14.556Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/c8/1b49f6bb69dc7e291ba5d14926937bec4dffcc09ee875822636bd5ef3cf4/google_genai-2.4.0-py3-none-any.whl", hash = "sha256:48df1c44190b05b834fee9cffd360af6d6fd7f68164588e7ebd670fa34f71ee1", size = 818207, upload-time = "2026-05-18T00:25:12.426Z" },
+]
+
+[[package]]
 name = "google-resumable-media"
 version = "2.8.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "google-crc32c" },
 ]
@@ -1514,7 +1539,7 @@ wheels = [
 [[package]]
 name = "googleapis-common-protos"
 version = "1.72.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "protobuf" },
 ]
@@ -1526,7 +1551,7 @@ wheels = [
 [[package]]
 name = "graphene"
 version = "3.4.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "graphql-core" },
     { name = "graphql-relay" },
@@ -1541,7 +1566,7 @@ wheels = [
 [[package]]
 name = "graphql-core"
 version = "3.2.7"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ac/9b/037a640a2983b09aed4a823f9cf1729e6d780b0671f854efa4727a7affbe/graphql_core-3.2.7.tar.gz", hash = "sha256:27b6904bdd3b43f2a0556dad5d579bdfdeab1f38e8e8788e555bdcb586a6f62c", size = 513484, upload-time = "2025-11-01T22:30:40.436Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0a/14/933037032608787fb92e365883ad6a741c235e0ff992865ec5d904a38f1e/graphql_core-3.2.7-py3-none-any.whl", hash = "sha256:17fc8f3ca4a42913d8e24d9ac9f08deddf0a0b2483076575757f6c412ead2ec0", size = 207262, upload-time = "2025-11-01T22:30:38.912Z" },
@@ -1550,7 +1575,7 @@ wheels = [
 [[package]]
 name = "graphql-relay"
 version = "3.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "graphql-core" },
 ]
@@ -1562,7 +1587,7 @@ wheels = [
 [[package]]
 name = "greenlet"
 version = "3.3.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8a/99/1cd3411c56a410994669062bd73dd58270c00cc074cac15f385a1fd91f8a/greenlet-3.3.1.tar.gz", hash = "sha256:41848f3230b58c08bb43dee542e74a2a2e34d3c59dc3076cec9151aeeedcae98", size = 184690, upload-time = "2026-01-23T15:31:02.076Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/e8/2e1462c8fdbe0f210feb5ac7ad2d9029af8be3bf45bd9fa39765f821642f/greenlet-3.3.1-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:5fd23b9bc6d37b563211c6abbb1b3cab27db385a4449af5c32e932f93017080c", size = 274974, upload-time = "2026-01-23T15:31:02.891Z" },
@@ -1609,7 +1634,7 @@ wheels = [
 [[package]]
 name = "griffelib"
 version = "2.0.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9d/82/74f4a3310cdabfbb10da554c3a672847f1ed33c6f61dd472681ce7f1fe67/griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e", size = 166461, upload-time = "2026-03-27T11:34:51.091Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/11/8c/c9138d881c79aa0ea9ed83cbd58d5ca75624378b38cee225dcf5c42cc91f/griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1", size = 142357, upload-time = "2026-03-27T11:34:46.275Z" },
@@ -1618,7 +1643,7 @@ wheels = [
 [[package]]
 name = "gunicorn"
 version = "25.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "packaging" },
 ]
@@ -1630,7 +1655,7 @@ wheels = [
 [[package]]
 name = "h11"
 version = "0.16.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
@@ -1639,7 +1664,7 @@ wheels = [
 [[package]]
 name = "hf-xet"
 version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5e/6e/0f11bacf08a67f7fb5ee09740f2ca54163863b07b70d579356e9222ce5d8/hf_xet-1.2.0.tar.gz", hash = "sha256:a8c27070ca547293b6890c4bf389f713f80e8c478631432962bb7f4bc0bd7d7f", size = 506020, upload-time = "2025-10-24T19:04:32.129Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/a5/85ef910a0aa034a2abcfadc360ab5ac6f6bc4e9112349bd40ca97551cff0/hf_xet-1.2.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:ceeefcd1b7aed4956ae8499e2199607765fbd1c60510752003b6cc0b8413b649", size = 2861870, upload-time = "2025-10-24T19:04:11.422Z" },
@@ -1668,7 +1693,7 @@ wheels = [
 [[package]]
 name = "httpcore"
 version = "1.0.9"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "h11" },
@@ -1681,7 +1706,7 @@ wheels = [
 [[package]]
 name = "httptools"
 version = "0.7.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b5/46/120a669232c7bdedb9d52d4aeae7e6c7dfe151e99dc70802e2fc7a5e1993/httptools-0.7.1.tar.gz", hash = "sha256:abd72556974f8e7c74a259655924a717a2365b236c882c3f6f8a45fe94703ac9", size = 258961, upload-time = "2025-10-10T03:55:08.559Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9c/08/17e07e8d89ab8f343c134616d72eebfe03798835058e2ab579dcc8353c06/httptools-0.7.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:474d3b7ab469fefcca3697a10d11a32ee2b9573250206ba1e50d5980910da657", size = 206521, upload-time = "2025-10-10T03:54:31.002Z" },
@@ -1717,7 +1742,7 @@ wheels = [
 [[package]]
 name = "httpx"
 version = "0.28.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "certifi" },
@@ -1732,7 +1757,7 @@ wheels = [
 [[package]]
 name = "huey"
 version = "2.6.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fe/29/3428d52eb8e85025e264a291641a9f9d6407cc1e51d1b630f6ac5815999a/huey-2.6.0.tar.gz", hash = "sha256:8d11f8688999d65266af1425b831f6e3773e99415027177b8734b0ffd5e251f6", size = 221068, upload-time = "2026-01-06T03:01:02.055Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/34/fae9ac8f1c3a552fd3f7ff652b94c78d219dedc5fce0c0a4232457760a00/huey-2.6.0-py3-none-any.whl", hash = "sha256:1b9df9d370b49c6d5721ba8a01ac9a787cf86b3bdc584e4679de27b920395c3f", size = 76951, upload-time = "2026-01-06T03:01:00.808Z" },
@@ -1741,7 +1766,7 @@ wheels = [
 [[package]]
 name = "huggingface-hub"
 version = "1.4.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "fsspec" },
@@ -1779,7 +1804,7 @@ dependencies = [
     { name = "psycopg-binary" },
     { name = "psycopg-pool" },
     { name = "pydantic" },
-    { name = "pydantic-ai-slim", extra = ["openai"] },
+    { name = "pydantic-ai-slim", extra = ["google", "openai"] },
     { name = "python-dotenv" },
     { name = "python-multipart" },
     { name = "pyyaml" },
@@ -1845,7 +1870,7 @@ requires-dist = [
     { name = "psycopg-binary", specifier = ">=3.1.0" },
     { name = "psycopg-pool", specifier = ">=3.1.0" },
     { name = "pydantic", specifier = ">=2.5.0" },
-    { name = "pydantic-ai-slim", extras = ["openai"], specifier = ">=0.2" },
+    { name = "pydantic-ai-slim", extras = ["openai", "google"], specifier = ">=0.2" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=7.4.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
@@ -1880,7 +1905,7 @@ dev = [
 [[package]]
 name = "identify"
 version = "2.6.16"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5b/8d/e8b97e6bd3fb6fb271346f7981362f1e04d6a7463abd0de79e1fda17c067/identify-2.6.16.tar.gz", hash = "sha256:846857203b5511bbe94d5a352a48ef2359532bc8f6727b5544077a0dcfb24980", size = 99360, upload-time = "2026-01-12T18:58:58.201Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b8/58/40fbbcefeda82364720eba5cf2270f98496bdfa19ea75b4cccae79c698e6/identify-2.6.16-py2.py3-none-any.whl", hash = "sha256:391ee4d77741d994189522896270b787aed8670389bfd60f326d677d64a6dfb0", size = 99202, upload-time = "2026-01-12T18:58:56.627Z" },
@@ -1889,7 +1914,7 @@ wheels = [
 [[package]]
 name = "idna"
 version = "3.11"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
@@ -1898,7 +1923,7 @@ wheels = [
 [[package]]
 name = "importlib-metadata"
 version = "8.7.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "zipp" },
 ]
@@ -1910,7 +1935,7 @@ wheels = [
 [[package]]
 name = "iniconfig"
 version = "2.3.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
@@ -1919,7 +1944,7 @@ wheels = [
 [[package]]
 name = "ipykernel"
 version = "7.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "appnope", marker = "sys_platform == 'darwin'" },
     { name = "comm" },
@@ -1943,7 +1968,7 @@ wheels = [
 [[package]]
 name = "ipython"
 version = "9.10.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "decorator" },
@@ -1965,7 +1990,7 @@ wheels = [
 [[package]]
 name = "ipython-pygments-lexers"
 version = "1.1.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "pygments" },
 ]
@@ -1977,7 +2002,7 @@ wheels = [
 [[package]]
 name = "isodate"
 version = "0.7.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz", hash = "sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6", size = 29705, upload-time = "2024-10-08T23:04:11.5Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/15/aa/0aca39a37d3c7eb941ba736ede56d689e7be91cab5d9ca846bde3999eba6/isodate-0.7.2-py3-none-any.whl", hash = "sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15", size = 22320, upload-time = "2024-10-08T23:04:09.501Z" },
@@ -1986,7 +2011,7 @@ wheels = [
 [[package]]
 name = "itsdangerous"
 version = "2.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
@@ -1995,7 +2020,7 @@ wheels = [
 [[package]]
 name = "jedi"
 version = "0.19.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "parso" },
 ]
@@ -2007,7 +2032,7 @@ wheels = [
 [[package]]
 name = "jinja2"
 version = "3.1.6"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
@@ -2019,7 +2044,7 @@ wheels = [
 [[package]]
 name = "jiter"
 version = "0.13.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0d/5e/4ec91646aee381d01cdb9974e30882c9cd3b8c5d1079d6b5ff4af522439a/jiter-0.13.0.tar.gz", hash = "sha256:f2839f9c2c7e2dffc1bc5929a510e14ce0a946be9365fd1219e7ef342dae14f4", size = 164847, upload-time = "2026-02-02T12:37:56.441Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/71/29/499f8c9eaa8a16751b1c0e45e6f5f1761d180da873d417996cc7bddc8eef/jiter-0.13.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:ea026e70a9a28ebbdddcbcf0f1323128a8db66898a06eaad3a4e62d2f554d096", size = 311157, upload-time = "2026-02-02T12:35:37.758Z" },
@@ -2104,7 +2129,7 @@ wheels = [
 [[package]]
 name = "jmespath"
 version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
@@ -2113,7 +2138,7 @@ wheels = [
 [[package]]
 name = "joblib"
 version = "1.5.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
@@ -2122,7 +2147,7 @@ wheels = [
 [[package]]
 name = "json-repair"
 version = "0.58.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0c/9b/2a1500e587fd7c33f10dc90d4e26a6ad421bdfbc7ab84c244279b2515e42/json_repair-0.58.0.tar.gz", hash = "sha256:8465fe2f8b7515d1cbf262a2608630e73d9498598bd42330c89f59923c50d0e4", size = 57425, upload-time = "2026-02-17T12:30:29.797Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/35/006b1625a645556f0d18247694c3f278eb122526fca2766ab2e8fba997e7/json_repair-0.58.0-py3-none-any.whl", hash = "sha256:54c31d22a47d5d4a52c4b022604d73f64bc5b01211f3422f0a671b1cc4ccfe3c", size = 40024, upload-time = "2026-02-17T12:30:28.601Z" },
@@ -2131,7 +2156,7 @@ wheels = [
 [[package]]
 name = "jsonpatch"
 version = "1.33"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "jsonpointer" },
 ]
@@ -2143,7 +2168,7 @@ wheels = [
 [[package]]
 name = "jsonpath-ng"
 version = "1.7.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "ply" },
 ]
@@ -2155,7 +2180,7 @@ wheels = [
 [[package]]
 name = "jsonpointer"
 version = "3.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6a/0a/eebeb1fa92507ea94016a2a790b93c2ae41a7e18778f85471dc54475ed25/jsonpointer-3.0.0.tar.gz", hash = "sha256:2b2d729f2091522d61c3b31f82e11870f60b68f43fbc705cb76bf4b832af59ef", size = 9114, upload-time = "2024-06-10T19:24:42.462Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/71/92/5e77f98553e9e75130c78900d000368476aed74276eb8ae8796f65f00918/jsonpointer-3.0.0-py2.py3-none-any.whl", hash = "sha256:13e088adc14fca8b6aa8177c044e12701e6ad4b28ff10e65f2267a90109c9942", size = 7595, upload-time = "2024-06-10T19:24:40.698Z" },
@@ -2164,7 +2189,7 @@ wheels = [
 [[package]]
 name = "jsonschema"
 version = "4.26.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "jsonschema-specifications" },
@@ -2179,7 +2204,7 @@ wheels = [
 [[package]]
 name = "jsonschema-specifications"
 version = "2025.9.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "referencing" },
 ]
@@ -2191,7 +2216,7 @@ wheels = [
 [[package]]
 name = "jupyter-client"
 version = "8.8.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "jupyter-core" },
     { name = "python-dateutil" },
@@ -2207,7 +2232,7 @@ wheels = [
 [[package]]
 name = "jupyter-core"
 version = "5.9.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "platformdirs" },
     { name = "traitlets" },
@@ -2220,7 +2245,7 @@ wheels = [
 [[package]]
 name = "kiwisolver"
 version = "1.4.9"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5c/3c/85844f1b0feb11ee581ac23fe5fce65cd049a200c1446708cc1b7f922875/kiwisolver-1.4.9.tar.gz", hash = "sha256:c3b22c26c6fd6811b0ae8363b95ca8ce4ea3c202d3d0975b2914310ceb1bcc4d", size = 97564, upload-time = "2025-08-10T21:27:49.279Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6f/ab/c80b0d5a9d8a1a65f4f815f2afff9798b12c3b9f31f1d304dd233dd920e2/kiwisolver-1.4.9-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:eb14a5da6dc7642b0f3a18f13654847cd8b7a2550e2645a5bda677862b03ba16", size = 124167, upload-time = "2025-08-10T21:25:53.403Z" },
@@ -2310,7 +2335,7 @@ wheels = [
 [[package]]
 name = "langchain-core"
 version = "1.2.14"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "jsonpatch" },
     { name = "langsmith" },
@@ -2329,7 +2354,7 @@ wheels = [
 [[package]]
 name = "langchain-openai"
 version = "1.1.10"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "openai" },
@@ -2343,7 +2368,7 @@ wheels = [
 [[package]]
 name = "langsmith"
 version = "0.7.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "orjson", marker = "platform_python_implementation != 'PyPy'" },
@@ -2363,7 +2388,7 @@ wheels = [
 [[package]]
 name = "librt"
 version = "0.8.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/56/9c/b4b0c54d84da4a94b37bd44151e46d5e583c9534c7e02250b961b1b6d8a8/librt-0.8.1.tar.gz", hash = "sha256:be46a14693955b3bd96014ccbdb8339ee8c9346fbe11c1b78901b55125f14c73", size = 177471, upload-time = "2026-02-17T16:13:06.101Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1d/01/0e748af5e4fee180cf7cd12bd12b0513ad23b045dccb2a83191bde82d168/librt-0.8.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:681dc2451d6d846794a828c16c22dc452d924e9f700a485b7ecb887a30aad1fd", size = 65315, upload-time = "2026-02-17T16:11:25.152Z" },
@@ -2436,7 +2461,7 @@ wheels = [
 [[package]]
 name = "limits"
 version = "5.8.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "deprecated" },
     { name = "packaging" },
@@ -2450,7 +2475,7 @@ wheels = [
 [[package]]
 name = "litellm"
 version = "1.81.13"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "click" },
@@ -2473,7 +2498,7 @@ wheels = [
 [[package]]
 name = "logfire-api"
 version = "4.31.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/08/a2/8d5a3c1c282d5f2bd9f5e9ddd5288d1414a53301ce389af9016b6d82bd50/logfire_api-4.31.0.tar.gz", hash = "sha256:fc4b01257ebd4ce297ad374ed201eb1a9213b999f6ae6df45cfca5bd0ef378f8", size = 77838, upload-time = "2026-03-27T19:00:47.545Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/26/27/9372b7492b3e146908d520f8599909311cd930175801ad219171fafc6f3e/logfire_api-4.31.0-py3-none-any.whl", hash = "sha256:3c1f502fd4eb8ef0996427a5cf275fd8f327f38600650a1f53071a8171c812db", size = 123402, upload-time = "2026-03-27T19:00:44.952Z" },
@@ -2482,7 +2507,7 @@ wheels = [
 [[package]]
 name = "lz4"
 version = "4.4.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/57/51/f1b86d93029f418033dddf9b9f79c8d2641e7454080478ee2aab5123173e/lz4-4.4.5.tar.gz", hash = "sha256:5f0b9e53c1e82e88c10d7c180069363980136b9d7a8306c4dca4f760d60c39f0", size = 172886, upload-time = "2025-11-03T13:02:36.061Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/93/5b/6edcd23319d9e28b1bedf32768c3d1fd56eed8223960a2c47dacd2cec2af/lz4-4.4.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d6da84a26b3aa5da13a62e4b89ab36a396e9327de8cd48b436a3467077f8ccd4", size = 207391, upload-time = "2025-11-03T13:01:36.644Z" },
@@ -2530,7 +2555,7 @@ wheels = [
 [[package]]
 name = "mako"
 version = "1.3.10"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
@@ -2542,7 +2567,7 @@ wheels = [
 [[package]]
 name = "markdown-it-py"
 version = "4.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "mdurl" },
 ]
@@ -2554,7 +2579,7 @@ wheels = [
 [[package]]
 name = "markupsafe"
 version = "3.0.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631, upload-time = "2025-09-27T18:36:18.185Z" },
@@ -2628,7 +2653,7 @@ wheels = [
 [[package]]
 name = "marshmallow"
 version = "3.26.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "packaging" },
 ]
@@ -2640,7 +2665,7 @@ wheels = [
 [[package]]
 name = "matplotlib"
 version = "3.10.8"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "contourpy" },
     { name = "cycler" },
@@ -2704,7 +2729,7 @@ wheels = [
 [[package]]
 name = "matplotlib-inline"
 version = "0.2.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "traitlets" },
 ]
@@ -2716,7 +2741,7 @@ wheels = [
 [[package]]
 name = "mdurl"
 version = "0.1.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
@@ -2725,7 +2750,7 @@ wheels = [
 [[package]]
 name = "mlflow"
 version = "3.10.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "alembic" },
     { name = "cryptography" },
@@ -2775,7 +2800,7 @@ genai = [
 [[package]]
 name = "mlflow-skinny"
 version = "3.10.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "cachetools" },
     { name = "click" },
@@ -2805,7 +2830,7 @@ wheels = [
 [[package]]
 name = "mlflow-tracing"
 version = "3.10.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "cachetools" },
     { name = "databricks-sdk" },
@@ -2824,7 +2849,7 @@ wheels = [
 [[package]]
 name = "multidict"
 version = "6.7.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1a/c2/c2d94cbe6ac1753f3fc980da97b3d930efe1da3af3c9f5125354436c073d/multidict-6.7.1.tar.gz", hash = "sha256:ec6652a1bee61c53a3e5776b6049172c53b6aaba34f18c9ad04f82712bac623d", size = 102010, upload-time = "2026-01-26T02:46:45.979Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/f1/a90635c4f88fb913fbf4ce660b83b7445b7a02615bda034b2f8eb38fd597/multidict-6.7.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7ff981b266af91d7b4b3793ca3382e53229088d193a85dfad6f5f4c27fc73e5d", size = 76626, upload-time = "2026-01-26T02:43:26.485Z" },
@@ -2941,7 +2966,7 @@ wheels = [
 [[package]]
 name = "mypy"
 version = "1.19.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
     { name = "mypy-extensions" },
@@ -2980,7 +3005,7 @@ wheels = [
 [[package]]
 name = "mypy-extensions"
 version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
@@ -2989,7 +3014,7 @@ wheels = [
 [[package]]
 name = "nest-asyncio"
 version = "1.6.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
@@ -2998,7 +3023,7 @@ wheels = [
 [[package]]
 name = "nodeenv"
 version = "1.10.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
@@ -3007,7 +3032,7 @@ wheels = [
 [[package]]
 name = "numpy"
 version = "2.4.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/57/fd/0005efbd0af48e55eb3c7208af93f2862d4b1a56cd78e84309a2d959208d/numpy-2.4.2.tar.gz", hash = "sha256:659a6107e31a83c4e33f763942275fd278b21d095094044eb35569e86a21ddae", size = 20723651, upload-time = "2026-01-31T23:13:10.135Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d3/44/71852273146957899753e69986246d6a176061ea183407e95418c2aa4d9a/numpy-2.4.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e7e88598032542bd49af7c4747541422884219056c268823ef6e5e89851c8825", size = 16955478, upload-time = "2026-01-31T23:10:25.623Z" },
@@ -3086,7 +3111,7 @@ wheels = [
 [[package]]
 name = "oauthlib"
 version = "3.3.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
@@ -3095,7 +3120,7 @@ wheels = [
 [[package]]
 name = "openai"
 version = "2.30.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "distro" },
@@ -3114,7 +3139,7 @@ wheels = [
 [[package]]
 name = "openpyxl"
 version = "3.1.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "et-xmlfile" },
 ]
@@ -3126,7 +3151,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-api"
 version = "1.39.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "importlib-metadata" },
     { name = "typing-extensions" },
@@ -3139,7 +3164,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-proto"
 version = "1.39.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "protobuf" },
 ]
@@ -3151,7 +3176,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-sdk"
 version = "1.39.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-semantic-conventions" },
@@ -3165,7 +3190,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-semantic-conventions"
 version = "0.60b1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "typing-extensions" },
@@ -3178,7 +3203,7 @@ wheels = [
 [[package]]
 name = "optuna"
 version = "4.7.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "alembic" },
     { name = "colorlog" },
@@ -3196,7 +3221,7 @@ wheels = [
 [[package]]
 name = "orjson"
 version = "3.11.7"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/45/b268004f745ede84e5798b48ee12b05129d19235d0e15267aa57dcdb400b/orjson-3.11.7.tar.gz", hash = "sha256:9b1a67243945819ce55d24a30b59d6a168e86220452d2c96f4d1f093e71c0c49", size = 6144992, upload-time = "2026-02-02T15:38:49.29Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/37/02/da6cb01fc6087048d7f61522c327edf4250f1683a58a839fdcc435746dd5/orjson-3.11.7-cp311-cp311-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:9487abc2c2086e7c8eb9a211d2ce8855bae0e92586279d0d27b341d5ad76c85c", size = 228664, upload-time = "2026-02-02T15:37:25.542Z" },
@@ -3264,7 +3289,7 @@ wheels = [
 [[package]]
 name = "packaging"
 version = "26.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
@@ -3273,7 +3298,7 @@ wheels = [
 [[package]]
 name = "pandas"
 version = "2.3.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "python-dateutil" },
@@ -3327,7 +3352,7 @@ wheels = [
 [[package]]
 name = "parso"
 version = "0.8.6"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/81/76/a1e769043c0c0c9fe391b702539d594731a4362334cdf4dc25d0c09761e7/parso-0.8.6.tar.gz", hash = "sha256:2b9a0332696df97d454fa67b81618fd69c35a7b90327cbe6ba5c92d2c68a7bfd", size = 401621, upload-time = "2026-02-09T15:45:24.425Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b6/61/fae042894f4296ec49e3f193aff5d7c18440da9e48102c3315e1bc4519a7/parso-0.8.6-py2.py3-none-any.whl", hash = "sha256:2c549f800b70a5c4952197248825584cb00f033b29c692671d3bf08bf380baff", size = 106894, upload-time = "2026-02-09T15:45:21.391Z" },
@@ -3336,7 +3361,7 @@ wheels = [
 [[package]]
 name = "pathspec"
 version = "1.0.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
@@ -3345,7 +3370,7 @@ wheels = [
 [[package]]
 name = "pexpect"
 version = "4.9.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "ptyprocess" },
 ]
@@ -3357,7 +3382,7 @@ wheels = [
 [[package]]
 name = "pillow"
 version = "12.1.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1f/42/5c74462b4fd957fcd7b13b04fb3205ff8349236ea74c7c375766d6c82288/pillow-12.1.1.tar.gz", hash = "sha256:9ad8fa5937ab05218e2b6a4cff30295ad35afd2f83ac592e68c0d871bb0fdbc4", size = 46980264, upload-time = "2026-02-11T04:23:07.146Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2b/46/5da1ec4a5171ee7bf1a0efa064aba70ba3d6e0788ce3f5acd1375d23c8c0/pillow-12.1.1-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:e879bb6cd5c73848ef3b2b48b8af9ff08c5b71ecda8048b7dd22d8a33f60be32", size = 5304084, upload-time = "2026-02-11T04:20:27.501Z" },
@@ -3444,7 +3469,7 @@ wheels = [
 [[package]]
 name = "platformdirs"
 version = "4.9.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1b/04/fea538adf7dbbd6d186f551d595961e564a3b6715bdf276b477460858672/platformdirs-4.9.2.tar.gz", hash = "sha256:9a33809944b9db043ad67ca0db94b14bf452cc6aeaac46a88ea55b26e2e9d291", size = 28394, upload-time = "2026-02-16T03:56:10.574Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/48/31/05e764397056194206169869b50cf2fee4dbbbc71b344705b9c0d878d4d8/platformdirs-4.9.2-py3-none-any.whl", hash = "sha256:9170634f126f8efdae22fb58ae8a0eaa86f38365bc57897a6c4f781d1f5875bd", size = 21168, upload-time = "2026-02-16T03:56:08.891Z" },
@@ -3453,7 +3478,7 @@ wheels = [
 [[package]]
 name = "pluggy"
 version = "1.6.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
@@ -3462,7 +3487,7 @@ wheels = [
 [[package]]
 name = "ply"
 version = "3.11"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e5/69/882ee5c9d017149285cab114ebeab373308ef0f874fcdac9beb90e0ac4da/ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3", size = 159130, upload-time = "2018-02-15T19:01:31.097Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/58/35da89ee790598a0700ea49b2a66594140f44dec458c07e8e3d4979137fc/ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce", size = 49567, upload-time = "2018-02-15T19:01:27.172Z" },
@@ -3471,7 +3496,7 @@ wheels = [
 [[package]]
 name = "pre-commit"
 version = "4.5.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "cfgv" },
     { name = "identify" },
@@ -3487,7 +3512,7 @@ wheels = [
 [[package]]
 name = "prettytable"
 version = "3.17.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "wcwidth" },
 ]
@@ -3499,7 +3524,7 @@ wheels = [
 [[package]]
 name = "prompt-toolkit"
 version = "3.0.52"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "wcwidth" },
 ]
@@ -3511,7 +3536,7 @@ wheels = [
 [[package]]
 name = "propcache"
 version = "0.4.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9e/da/e9fc233cf63743258bff22b3dfa7ea5baef7b5bc324af47a0ad89b8ffc6f/propcache-0.4.1.tar.gz", hash = "sha256:f48107a8c637e80362555f37ecf49abe20370e557cc4ab374f04ec4423c97c3d", size = 46442, upload-time = "2025-10-08T19:49:02.291Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8c/d4/4e2c9aaf7ac2242b9358f98dccd8f90f2605402f5afeff6c578682c2c491/propcache-0.4.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:60a8fda9644b7dfd5dece8c61d8a85e271cb958075bfc4e01083c148b61a7caf", size = 80208, upload-time = "2025-10-08T19:46:24.597Z" },
@@ -3610,7 +3635,7 @@ wheels = [
 [[package]]
 name = "proto-plus"
 version = "1.27.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "protobuf" },
 ]
@@ -3622,7 +3647,7 @@ wheels = [
 [[package]]
 name = "protobuf"
 version = "6.33.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ba/25/7c72c307aafc96fa87062aa6291d9f7c94836e43214d43722e86037aac02/protobuf-6.33.5.tar.gz", hash = "sha256:6ddcac2a081f8b7b9642c09406bc6a4290128fce5f471cddd165960bb9119e5c", size = 444465, upload-time = "2026-01-29T21:51:33.494Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b1/79/af92d0a8369732b027e6d6084251dd8e782c685c72da161bd4a2e00fbabb/protobuf-6.33.5-cp310-abi3-win32.whl", hash = "sha256:d71b040839446bac0f4d162e758bea99c8251161dae9d0983a3b88dee345153b", size = 425769, upload-time = "2026-01-29T21:51:21.751Z" },
@@ -3637,7 +3662,7 @@ wheels = [
 [[package]]
 name = "psutil"
 version = "7.2.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
@@ -3665,7 +3690,7 @@ wheels = [
 [[package]]
 name = "psycopg"
 version = "3.3.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
@@ -3678,7 +3703,7 @@ wheels = [
 [[package]]
 name = "psycopg-binary"
 version = "3.3.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/c0/b389119dd754483d316805260f3e73cdcad97925839107cc7a296f6132b1/psycopg_binary-3.3.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a89bb9ee11177b2995d87186b1d9fa892d8ea725e85eab28c6525e4cc14ee048", size = 4609740, upload-time = "2026-02-18T16:47:51.093Z" },
     { url = "https://files.pythonhosted.org/packages/cf/e3/9976eef20f61840285174d360da4c820a311ab39d6b82fa09fbb545be825/psycopg_binary-3.3.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9f7d0cf072c6fbac3795b08c98ef9ea013f11db609659dcfc6b1f6cc31f9e181", size = 4676837, upload-time = "2026-02-18T16:47:55.523Z" },
@@ -3729,7 +3754,7 @@ wheels = [
 [[package]]
 name = "psycopg-pool"
 version = "3.3.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
@@ -3741,7 +3766,7 @@ wheels = [
 [[package]]
 name = "ptyprocess"
 version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/20/e5/16ff212c1e452235a90aeb09066144d0c5a6a8c0834397e03f5224495c4e/ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220", size = 70762, upload-time = "2020-12-28T15:15:30.155Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35", size = 13993, upload-time = "2020-12-28T15:15:28.35Z" },
@@ -3750,7 +3775,7 @@ wheels = [
 [[package]]
 name = "pure-eval"
 version = "0.2.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42", size = 19752, upload-time = "2024-07-21T12:58:21.801Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0", size = 11842, upload-time = "2024-07-21T12:58:20.04Z" },
@@ -3759,7 +3784,7 @@ wheels = [
 [[package]]
 name = "pyarrow"
 version = "23.0.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/88/22/134986a4cc224d593c1afde5494d18ff629393d74cc2eddb176669f234a4/pyarrow-23.0.1.tar.gz", hash = "sha256:b8c5873e33440b2bc2f4a79d2b47017a89c5a24116c055625e6f2ee50523f019", size = 1167336, upload-time = "2026-02-16T10:14:12.39Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/41/8e6b6ef7e225d4ceead8459427a52afdc23379768f54dd3566014d7618c1/pyarrow-23.0.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:6f0147ee9e0386f519c952cc670eb4a8b05caa594eeffe01af0e25f699e4e9bb", size = 34302230, upload-time = "2026-02-16T10:09:03.859Z" },
@@ -3809,7 +3834,7 @@ wheels = [
 [[package]]
 name = "pyasn1"
 version = "0.6.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fe/b6/6e630dff89739fcd427e3f72b3d905ce0acb85a45d4ec3e2678718a3487f/pyasn1-0.6.2.tar.gz", hash = "sha256:9b59a2b25ba7e4f8197db7686c09fb33e658b98339fadb826e9512629017833b", size = 146586, upload-time = "2026-01-16T18:04:18.534Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/44/b5/a96872e5184f354da9c84ae119971a0a4c221fe9b27a4d94bd43f2596727/pyasn1-0.6.2-py3-none-any.whl", hash = "sha256:1eb26d860996a18e9b6ed05e7aae0e9fc21619fcee6af91cca9bad4fbea224bf", size = 83371, upload-time = "2026-01-16T18:04:17.174Z" },
@@ -3818,7 +3843,7 @@ wheels = [
 [[package]]
 name = "pyasn1-modules"
 version = "0.4.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "pyasn1" },
 ]
@@ -3830,7 +3855,7 @@ wheels = [
 [[package]]
 name = "pybreaker"
 version = "1.4.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f2/89/fbf98e383f1ec6d117af2cd983efdb3eb7018b63834c427025764194cac2/pybreaker-1.4.1.tar.gz", hash = "sha256:8df2d245c73ba40c8242c56ffb4f12138fbadc23e296224740c2028ea9dc1178", size = 15555, upload-time = "2025-09-21T15:12:04.499Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/44/75/e64d3d40a741e2be21d69154f4e5c43a66f0c603c5ef11f49e01429a5932/pybreaker-1.4.1-py3-none-any.whl", hash = "sha256:b4dab4a05195b7f2a64a6c1a6c4ba7a96534ef56ea7210e6bcb59f28897160e0", size = 12915, upload-time = "2025-09-21T15:12:02.284Z" },
@@ -3839,7 +3864,7 @@ wheels = [
 [[package]]
 name = "pycparser"
 version = "3.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
@@ -3848,7 +3873,7 @@ wheels = [
 [[package]]
 name = "pydantic"
 version = "2.12.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "annotated-types" },
     { name = "pydantic-core" },
@@ -3863,7 +3888,7 @@ wheels = [
 [[package]]
 name = "pydantic-ai-slim"
 version = "1.77.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "genai-prices" },
     { name = "griffelib" },
@@ -3879,6 +3904,9 @@ wheels = [
 ]
 
 [package.optional-dependencies]
+google = [
+    { name = "google-genai" },
+]
 openai = [
     { name = "openai" },
     { name = "tiktoken" },
@@ -3887,7 +3915,7 @@ openai = [
 [[package]]
 name = "pydantic-core"
 version = "2.41.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
@@ -3984,7 +4012,7 @@ wheels = [
 [[package]]
 name = "pydantic-graph"
 version = "1.77.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "logfire-api" },
@@ -3999,7 +4027,7 @@ wheels = [
 [[package]]
 name = "pygments"
 version = "2.19.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
@@ -4008,7 +4036,7 @@ wheels = [
 [[package]]
 name = "pyjwt"
 version = "2.11.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5c/5a/b46fa56bf322901eee5b0454a34343cdbdae202cd421775a8ee4e42fd519/pyjwt-2.11.0.tar.gz", hash = "sha256:35f95c1f0fbe5d5ba6e43f00271c275f7a1a4db1dab27bf708073b75318ea623", size = 98019, upload-time = "2026-01-30T19:59:55.694Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6f/01/c26ce75ba460d5cd503da9e13b21a33804d38c2165dec7b716d06b13010c/pyjwt-2.11.0-py3-none-any.whl", hash = "sha256:94a6bde30eb5c8e04fee991062b534071fd1439ef58d2adc9ccb823e7bcd0469", size = 28224, upload-time = "2026-01-30T19:59:54.539Z" },
@@ -4017,7 +4045,7 @@ wheels = [
 [[package]]
 name = "pyparsing"
 version = "3.3.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
@@ -4026,7 +4054,7 @@ wheels = [
 [[package]]
 name = "pytest"
 version = "9.0.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "iniconfig" },
@@ -4042,7 +4070,7 @@ wheels = [
 [[package]]
 name = "pytest-asyncio"
 version = "1.3.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "pytest" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
@@ -4055,7 +4083,7 @@ wheels = [
 [[package]]
 name = "pytest-cov"
 version = "7.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "coverage", extra = ["toml"] },
     { name = "pluggy" },
@@ -4069,7 +4097,7 @@ wheels = [
 [[package]]
 name = "pytest-json-report"
 version = "1.5.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "pytest" },
     { name = "pytest-metadata" },
@@ -4082,7 +4110,7 @@ wheels = [
 [[package]]
 name = "pytest-metadata"
 version = "3.1.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "pytest" },
 ]
@@ -4094,7 +4122,7 @@ wheels = [
 [[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "six" },
 ]
@@ -4106,7 +4134,7 @@ wheels = [
 [[package]]
 name = "python-dotenv"
 version = "1.2.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230, upload-time = "2025-10-26T15:12:09.109Z" },
@@ -4115,7 +4143,7 @@ wheels = [
 [[package]]
 name = "python-multipart"
 version = "0.0.22"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
@@ -4124,7 +4152,7 @@ wheels = [
 [[package]]
 name = "pytokens"
 version = "0.4.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b6/34/b4e015b99031667a7b960f888889c5bd34ef585c85e1cb56a594b92836ac/pytokens-0.4.1.tar.gz", hash = "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a", size = 23015, upload-time = "2026-01-30T01:03:45.924Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3d/92/790ebe03f07b57e53b10884c329b9a1a308648fc083a6d4a39a10a28c8fc/pytokens-0.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d70e77c55ae8380c91c0c18dea05951482e263982911fc7410b1ffd1dadd3440", size = 160864, upload-time = "2026-01-30T01:02:57.882Z" },
@@ -4158,7 +4186,7 @@ wheels = [
 [[package]]
 name = "pytz"
 version = "2025.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884, upload-time = "2025-03-25T02:25:00.538Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225, upload-time = "2025-03-25T02:24:58.468Z" },
@@ -4167,7 +4195,7 @@ wheels = [
 [[package]]
 name = "pywin32"
 version = "311"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7c/af/449a6a91e5d6db51420875c54f6aff7c97a86a3b13a0b4f1a5c13b988de3/pywin32-311-cp311-cp311-win32.whl", hash = "sha256:184eb5e436dea364dcd3d2316d577d625c0351bf237c4e9a5fabbcfa5a58b151", size = 8697031, upload-time = "2025-07-14T20:13:13.266Z" },
     { url = "https://files.pythonhosted.org/packages/51/8f/9bb81dd5bb77d22243d33c8397f09377056d5c687aa6d4042bea7fbf8364/pywin32-311-cp311-cp311-win_amd64.whl", hash = "sha256:3ce80b34b22b17ccbd937a6e78e7225d80c52f5ab9940fe0506a1a16f3dab503", size = 9508308, upload-time = "2025-07-14T20:13:15.147Z" },
@@ -4186,7 +4214,7 @@ wheels = [
 [[package]]
 name = "pyyaml"
 version = "6.0.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
@@ -4241,7 +4269,7 @@ wheels = [
 [[package]]
 name = "pyzmq"
 version = "27.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "cffi", marker = "implementation_name == 'pypy'" },
 ]
@@ -4299,7 +4327,7 @@ wheels = [
 [[package]]
 name = "referencing"
 version = "0.37.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "rpds-py" },
@@ -4313,7 +4341,7 @@ wheels = [
 [[package]]
 name = "regex"
 version = "2026.2.19"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ff/c0/d8079d4f6342e4cec5c3e7d7415b5cd3e633d5f4124f7a4626908dbe84c7/regex-2026.2.19.tar.gz", hash = "sha256:6fb8cb09b10e38f3ae17cc6dc04a1df77762bd0351b6ba9041438e7cc85ec310", size = 414973, upload-time = "2026-02-19T19:03:47.899Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6f/93/43f405a98f54cc59c786efb4fc0b644615ed2392fc89d57d30da11f35b5b/regex-2026.2.19-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:93b16a18cadb938f0f2306267161d57eb33081a861cee9ffcd71e60941eb5dfc", size = 488365, upload-time = "2026-02-19T19:00:17.857Z" },
@@ -4417,7 +4445,7 @@ wheels = [
 [[package]]
 name = "requests"
 version = "2.32.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "charset-normalizer" },
@@ -4432,7 +4460,7 @@ wheels = [
 [[package]]
 name = "requests-toolbelt"
 version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "requests" },
 ]
@@ -4444,7 +4472,7 @@ wheels = [
 [[package]]
 name = "rich"
 version = "14.3.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
@@ -4457,7 +4485,7 @@ wheels = [
 [[package]]
 name = "rpds-py"
 version = "0.30.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/6e/f964e88b3d2abee2a82c1ac8366da848fce1c6d834dc2132c3fda3970290/rpds_py-0.30.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a2bffea6a4ca9f01b3f8e548302470306689684e61602aa3d141e34da06cf425", size = 370157, upload-time = "2025-11-30T20:21:53.789Z" },
@@ -4563,21 +4591,9 @@ wheels = [
 ]
 
 [[package]]
-name = "rsa"
-version = "4.9.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyasn1" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
-]
-
-[[package]]
 name = "ruff"
 version = "0.15.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/06/04/eab13a954e763b0606f460443fcbf6bb5a0faf06890ea3754ff16523dce5/ruff-0.15.2.tar.gz", hash = "sha256:14b965afee0969e68bb871eba625343b8673375f457af4abe98553e8bbb98342", size = 4558148, upload-time = "2026-02-19T22:32:20.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2f/70/3a4dc6d09b13cb3e695f28307e5d889b2e1a66b7af9c5e257e796695b0e6/ruff-0.15.2-py3-none-linux_armv6l.whl", hash = "sha256:120691a6fdae2f16d65435648160f5b81a9625288f75544dc40637436b5d3c0d", size = 10430565, upload-time = "2026-02-19T22:32:41.824Z" },
@@ -4602,7 +4618,7 @@ wheels = [
 [[package]]
 name = "s3transfer"
 version = "0.16.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "botocore" },
 ]
@@ -4614,7 +4630,7 @@ wheels = [
 [[package]]
 name = "scikit-learn"
 version = "1.8.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "joblib" },
     { name = "numpy" },
@@ -4664,7 +4680,7 @@ wheels = [
 [[package]]
 name = "scipy"
 version = "1.17.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "numpy" },
 ]
@@ -4735,7 +4751,7 @@ wheels = [
 [[package]]
 name = "shellingham"
 version = "1.5.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
@@ -4744,7 +4760,7 @@ wheels = [
 [[package]]
 name = "six"
 version = "1.17.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
@@ -4753,7 +4769,7 @@ wheels = [
 [[package]]
 name = "skops"
 version = "0.13.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "packaging" },
@@ -4769,7 +4785,7 @@ wheels = [
 [[package]]
 name = "slowapi"
 version = "0.1.9"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "limits" },
 ]
@@ -4781,7 +4797,7 @@ wheels = [
 [[package]]
 name = "smmap"
 version = "5.0.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/44/cd/a040c4b3119bbe532e5b0732286f805445375489fceaec1f48306068ee3b/smmap-5.0.2.tar.gz", hash = "sha256:26ea65a03958fa0c8a1c7e8c7a58fdc77221b8910f6be2131affade476898ad5", size = 22329, upload-time = "2025-01-02T07:14:40.909Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/be/d09147ad1ec7934636ad912901c5fd7667e1c858e19d355237db0d0cd5e4/smmap-5.0.2-py3-none-any.whl", hash = "sha256:b30115f0def7d7531d22a0fb6502488d879e75b260a9db4d0819cfb25403af5e", size = 24303, upload-time = "2025-01-02T07:14:38.724Z" },
@@ -4790,7 +4806,7 @@ wheels = [
 [[package]]
 name = "sniffio"
 version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
@@ -4799,7 +4815,7 @@ wheels = [
 [[package]]
 name = "sqlalchemy"
 version = "2.0.46"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
     { name = "typing-extensions" },
@@ -4848,7 +4864,7 @@ wheels = [
 [[package]]
 name = "sqlparse"
 version = "0.5.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815, upload-time = "2025-12-19T07:17:45.073Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138, upload-time = "2025-12-19T07:17:46.573Z" },
@@ -4857,7 +4873,7 @@ wheels = [
 [[package]]
 name = "stack-data"
 version = "0.6.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "asttokens" },
     { name = "executing" },
@@ -4871,7 +4887,7 @@ wheels = [
 [[package]]
 name = "starlette"
 version = "0.52.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
@@ -4884,7 +4900,7 @@ wheels = [
 [[package]]
 name = "tenacity"
 version = "9.1.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
@@ -4893,7 +4909,7 @@ wheels = [
 [[package]]
 name = "testcontainers"
 version = "4.14.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "docker" },
     { name = "python-dotenv" },
@@ -4909,7 +4925,7 @@ wheels = [
 [[package]]
 name = "threadpoolctl"
 version = "3.6.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
@@ -4918,7 +4934,7 @@ wheels = [
 [[package]]
 name = "thrift"
 version = "0.20.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "six" },
 ]
@@ -4927,7 +4943,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/3c/2d/8946864f716ac82dc
 [[package]]
 name = "tiktoken"
 version = "0.12.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "regex" },
     { name = "requests" },
@@ -4981,7 +4997,7 @@ wheels = [
 [[package]]
 name = "tokenizers"
 version = "0.22.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "huggingface-hub" },
 ]
@@ -5007,7 +5023,7 @@ wheels = [
 [[package]]
 name = "tomli"
 version = "2.4.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/30/31573e9457673ab10aa432461bee537ce6cef177667deca369efb79df071/tomli-2.4.0.tar.gz", hash = "sha256:aa89c3f6c277dd275d8e243ad24f3b5e701491a860d5121f2cdd399fbb31fc9c", size = 17477, upload-time = "2026-01-11T11:22:38.165Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3c/d9/3dc2289e1f3b32eb19b9785b6a006b28ee99acb37d1d47f78d4c10e28bf8/tomli-2.4.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b5ef256a3fd497d4973c11bf142e9ed78b150d36f5773f1ca6088c230ffc5867", size = 153663, upload-time = "2026-01-11T11:21:45.27Z" },
@@ -5061,7 +5077,7 @@ wheels = [
 [[package]]
 name = "tornado"
 version = "6.5.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/37/1d/0a336abf618272d53f62ebe274f712e213f5a03c0b2339575430b8362ef2/tornado-6.5.4.tar.gz", hash = "sha256:a22fa9047405d03260b483980635f0b041989d8bcc9a313f8fe18b411d84b1d7", size = 513632, upload-time = "2025-12-15T19:21:03.836Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ab/a9/e94a9d5224107d7ce3cc1fab8d5dc97f5ea351ccc6322ee4fb661da94e35/tornado-6.5.4-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:d6241c1a16b1c9e4cc28148b1cda97dd1c6cb4fb7068ac1bedc610768dff0ba9", size = 443909, upload-time = "2025-12-15T19:20:48.382Z" },
@@ -5080,7 +5096,7 @@ wheels = [
 [[package]]
 name = "tqdm"
 version = "4.67.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
@@ -5092,7 +5108,7 @@ wheels = [
 [[package]]
 name = "traitlets"
 version = "5.14.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
@@ -5101,7 +5117,7 @@ wheels = [
 [[package]]
 name = "typer"
 version = "0.24.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "annotated-doc" },
     { name = "click" },
@@ -5116,7 +5132,7 @@ wheels = [
 [[package]]
 name = "typer-slim"
 version = "0.24.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "typer" },
 ]
@@ -5128,7 +5144,7 @@ wheels = [
 [[package]]
 name = "typing-extensions"
 version = "4.15.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
@@ -5137,7 +5153,7 @@ wheels = [
 [[package]]
 name = "typing-inspect"
 version = "0.9.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "mypy-extensions" },
     { name = "typing-extensions" },
@@ -5150,7 +5166,7 @@ wheels = [
 [[package]]
 name = "typing-inspection"
 version = "0.4.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
@@ -5162,7 +5178,7 @@ wheels = [
 [[package]]
 name = "tzdata"
 version = "2025.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
@@ -5171,7 +5187,7 @@ wheels = [
 [[package]]
 name = "urllib3"
 version = "2.6.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
@@ -5180,7 +5196,7 @@ wheels = [
 [[package]]
 name = "uuid-utils"
 version = "0.14.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/57/7c/3a926e847516e67bc6838634f2e54e24381105b4e80f9338dc35cca0086b/uuid_utils-0.14.0.tar.gz", hash = "sha256:fc5bac21e9933ea6c590433c11aa54aaca599f690c08069e364eb13a12f670b4", size = 22072, upload-time = "2026-01-20T20:37:15.729Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/42/42d003f4a99ddc901eef2fd41acb3694163835e037fb6dde79ad68a72342/uuid_utils-0.14.0-cp39-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:f6695c0bed8b18a904321e115afe73b34444bc8451d0ce3244a1ec3b84deb0e5", size = 601786, upload-time = "2026-01-20T20:37:09.843Z" },
@@ -5209,7 +5225,7 @@ wheels = [
 [[package]]
 name = "uvicorn"
 version = "0.41.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
@@ -5233,7 +5249,7 @@ standard = [
 [[package]]
 name = "uvloop"
 version = "0.22.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/06/f0/18d39dbd1971d6d62c4629cc7fa67f74821b0dc1f5a77af43719de7936a7/uvloop-0.22.1.tar.gz", hash = "sha256:6c84bae345b9147082b17371e3dd5d42775bddce91f885499017f4607fdaf39f", size = 2443250, upload-time = "2025-10-16T22:17:19.342Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/d5/69900f7883235562f1f50d8184bb7dd84a2fb61e9ec63f3782546fdbd057/uvloop-0.22.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c60ebcd36f7b240b30788554b6f0782454826a0ed765d8430652621b5de674b9", size = 1352420, upload-time = "2025-10-16T22:16:21.187Z" },
@@ -5271,7 +5287,7 @@ wheels = [
 [[package]]
 name = "virtualenv"
 version = "20.38.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "distlib" },
     { name = "filelock" },
@@ -5285,7 +5301,7 @@ wheels = [
 [[package]]
 name = "vulture"
 version = "2.14"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8e/25/925f35db758a0f9199113aaf61d703de891676b082bd7cf73ea01d6000f7/vulture-2.14.tar.gz", hash = "sha256:cb8277902a1138deeab796ec5bef7076a6e0248ca3607a3f3dee0b6d9e9b8415", size = 58823, upload-time = "2024-12-08T17:39:43.319Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/56/0cc15b8ff2613c1d5c3dc1f3f576ede1c43868c1bc2e5ccaa2d4bcd7974d/vulture-2.14-py2.py3-none-any.whl", hash = "sha256:d9a90dba89607489548a49d557f8bac8112bd25d3cbc8aeef23e860811bd5ed9", size = 28915, upload-time = "2024-12-08T17:39:40.573Z" },
@@ -5294,7 +5310,7 @@ wheels = [
 [[package]]
 name = "waitress"
 version = "3.0.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bf/cb/04ddb054f45faa306a230769e868c28b8065ea196891f09004ebace5b184/waitress-3.0.2.tar.gz", hash = "sha256:682aaaf2af0c44ada4abfb70ded36393f0e307f4ab9456a215ce0020baefc31f", size = 179901, upload-time = "2024-11-16T20:02:35.195Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8d/57/a27182528c90ef38d82b636a11f606b0cbb0e17588ed205435f8affe3368/waitress-3.0.2-py3-none-any.whl", hash = "sha256:c56d67fd6e87c2ee598b76abdd4e96cfad1f24cacdea5078d382b1f9d7b5ed2e", size = 56232, upload-time = "2024-11-16T20:02:33.858Z" },
@@ -5303,7 +5319,7 @@ wheels = [
 [[package]]
 name = "watchfiles"
 version = "1.1.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "anyio" },
 ]
@@ -5390,7 +5406,7 @@ wheels = [
 [[package]]
 name = "wcwidth"
 version = "0.6.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
@@ -5399,7 +5415,7 @@ wheels = [
 [[package]]
 name = "websockets"
 version = "16.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f2/db/de907251b4ff46ae804ad0409809504153b3f30984daf82a1d84a9875830/websockets-16.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:31a52addea25187bde0797a97d6fc3d2f92b6f72a9370792d65a6e84615ac8a8", size = 177340, upload-time = "2026-01-10T09:22:34.539Z" },
@@ -5458,7 +5474,7 @@ wheels = [
 [[package]]
 name = "werkzeug"
 version = "3.1.6"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
@@ -5470,7 +5486,7 @@ wheels = [
 [[package]]
 name = "whenever"
 version = "0.7.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
@@ -5523,7 +5539,7 @@ wheels = [
 [[package]]
 name = "wrapt"
 version = "2.1.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f7/37/ae31f40bec90de2f88d9597d0b5281e23ffe85b893a47ca5d9c05c63a4f6/wrapt-2.1.1.tar.gz", hash = "sha256:5fdcb09bf6db023d88f312bd0767594b414655d58090fc1c46b3414415f67fac", size = 81329, upload-time = "2026-02-03T02:12:13.786Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b8/a8/9254e4da74b30a105935197015b18b31b7a298bf046e67d8952ef74967bd/wrapt-2.1.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6c366434a7fb914c7a5de508ed735ef9c133367114e1a7cb91dfb5cd806a1549", size = 60554, upload-time = "2026-02-03T02:11:13.038Z" },
@@ -5586,7 +5602,7 @@ wheels = [
 [[package]]
 name = "xxhash"
 version = "3.6.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/02/84/30869e01909fb37a6cc7e18688ee8bf1e42d57e7e0777636bd47524c43c7/xxhash-3.6.0.tar.gz", hash = "sha256:f0162a78b13a0d7617b2845b90c763339d1f1d82bb04a4b07f4ab535cc5e05d6", size = 85160, upload-time = "2025-10-02T14:37:08.097Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/17/d4/cc2f0400e9154df4b9964249da78ebd72f318e35ccc425e9f403c392f22a/xxhash-3.6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b47bbd8cf2d72797f3c2772eaaac0ded3d3af26481a26d7d7d41dc2d3c46b04a", size = 32844, upload-time = "2025-10-02T14:34:14.037Z" },
@@ -5689,7 +5705,7 @@ wheels = [
 [[package]]
 name = "yarl"
 version = "1.22.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "idna" },
     { name = "multidict" },
@@ -5799,7 +5815,7 @@ wheels = [
 [[package]]
 name = "zipp"
 version = "3.23.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547, upload-time = "2025-06-08T17:06:39.4Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276, upload-time = "2025-06-08T17:06:38.034Z" },
@@ -5808,7 +5824,7 @@ wheels = [
 [[package]]
 name = "zstandard"
 version = "0.25.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fd/aa/3e0508d5a5dd96529cdc5a97011299056e14c6505b678fd58938792794b1/zstandard-0.25.0.tar.gz", hash = "sha256:7713e1179d162cf5c7906da876ec2ccb9c3a9dcbdffef0cc7f70c3667a205f0b", size = 711513, upload-time = "2025-09-14T22:15:54.002Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/83/c3ca27c363d104980f1c9cee1101cc8ba724ac8c28a033ede6aab89585b1/zstandard-0.25.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:933b65d7680ea337180733cf9e87293cc5500cc0eb3fc8769f4d3c88d724ec5c", size = 795254, upload-time = "2025-09-14T22:16:26.137Z" },


### PR DESCRIPTION
- Disable strict tool definitions on the trace summarization model profile so the Databricks OpenAI-compat shim accepts requests across Claude 4.6/4.7, gpt-5, gpt-5-codex, and Gemini Flash 3.5 (the shim rejects "tools.N.custom.strict" regardless of backing model).
- Set litellm.drop_params=True at DSPy LM construction so hardcoded sampling params (temperature=0.2/0.3 in discovery + followup) don't 400 on gpt-5 reasoning models that require temperature=1.
- Add a workspace-keyed TTL cache to DatabricksService.list_serving_endpoints with concurrent-request deduplication via per-key asyncio.Lock; the frontend's per-workshop React Query cache was triggering frequent upstream refetches of a workspace-global list. TTL configurable via DATABRICKS_ENDPOINTS_CACHE_TTL_S (default 300s).

Co-authored-by: Isaac

## Summary

<!-- Brief description of what this PR does -->

## Related Spec

<!-- Which spec(s) does this PR implement or affect? -->
- Spec: `SPEC_NAME` (from `/specs/`)

## Changes

<!-- List the key changes made -->
-

## Testing

<!-- How was this tested? -->
- [ ] Tests tagged with `@pytest.mark.spec("SPEC_NAME")` or equivalent
- [ ] `just test-server` passes
- [ ] `just ui-test-unit` passes
- [ ] `just ui-lint` passes
- [ ] E2E tests pass (if applicable)

## Checklist

- [ ] Read the relevant spec before implementing
- [ ] No changes to `/specs/` without approval
- [ ] No new database migrations without approval
- [ ] Coverage map updated if new tests added (`uv run spec-coverage-analyzer`)
