### PR TITLE
fix(auth): configure Databricks MLflow once per worker

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -21,6 +21,7 @@ from server.config import ServerConfig
 from server.db_bootstrap import maybe_bootstrap_db_on_startup
 from server.db_config import DatabaseBackend, detect_database_backend
 from server.routers import router
+from server.services.databricks_service import configure_databricks_mlflow_once
 from server.sqlite_rescue import (
     backup_to_volume,
     get_rescue_status,
@@ -119,6 +120,7 @@ async def lifespan(app: FastAPI):
     """Manage application lifespan with proper startup and shutdown."""
     print("🚀 Application startup - lifespan function called!")
     _configure_app_log_levels()
+    configure_databricks_mlflow_once()
 
     # Detect database backend
     db_backend = detect_database_backend()

--- a/server/routers/workshops.py
+++ b/server/routers/workshops.py
@@ -1856,8 +1856,6 @@ async def begin_annotation_phase(workshop_id: str, request: dict | None = None, 
                         try:
                             import mlflow as _mlflow
 
-                            _mlflow.set_tracking_uri("databricks")
-
                             filter_str = f"tags.eval = 'true' AND tags.workshop_id = '{workshop_id}'"
                             job.add_log(f"Polling MLflow for tagged traces: {filter_str}")
                             job.add_log(f"Experiment ID: {mlflow_config.experiment_id}")
@@ -3497,7 +3495,6 @@ async def upload_csv_and_log_to_mlflow(
     try:
         import mlflow
 
-        mlflow.set_tracking_uri("databricks")
         mlflow.set_experiment(experiment_id=exp_id)
 
         # Read file content

--- a/server/services/alignment_service.py
+++ b/server/services/alignment_service.py
@@ -558,9 +558,6 @@ class AlignmentService:
                     mlflow_to_workshop_trace_map[trace.mlflow_trace_id] = trace.id
             yield f"Built MLflow-to-workshop trace mapping ({len(mlflow_to_workshop_trace_map)} traces)"
 
-        # SDK handles auth (service principal on Apps, CLI profile locally)
-        mlflow.set_tracking_uri("databricks")
-
         # Prepare the evaluation data
         human_feedback_map: dict[str, dict[str, Any]] = {}
 
@@ -1129,9 +1126,6 @@ class AlignmentService:
             return
 
         try:
-            # SDK handles auth (service principal on Apps, CLI profile locally)
-            mlflow.set_tracking_uri("databricks")
-
             # Enable MemAlign debug logging
             logging.getLogger("mlflow.genai.judges.optimizers.memalign").setLevel(logging.DEBUG)
 

--- a/server/services/database_service.py
+++ b/server/services/database_service.py
@@ -2292,8 +2292,6 @@ Provide your rating as a single number (1-5) followed by a brief explanation."""
       result['error'] = 'mlflow not available'
       return result
 
-    mlflow.set_tracking_uri('databricks')
-
     try:
       mlflow.set_experiment(experiment_id=config.experiment_id)
     except Exception as exc:
@@ -2721,8 +2719,6 @@ Provide your rating as a single number (1-5) followed by a brief explanation."""
       logger.warning('MLflow is not available; cannot sync evaluation feedback.')
       return {'synced': 0, 'error': 'MLflow not available'}
 
-    mlflow.set_tracking_uri('databricks')
-
     try:
       mlflow.set_experiment(experiment_id=config.experiment_id)
     except Exception as exc:
@@ -2862,8 +2858,6 @@ Provide your rating as a single number (1-5) followed by a brief explanation."""
     except ImportError:
       logger.warning('MLflow is not available; cannot tag traces.')
       return {'tagged': 0, 'failed': trace_ids, 'error': 'MLflow not available'}
-
-    mlflow.set_tracking_uri('databricks')
 
     try:
       mlflow.set_experiment(experiment_id=config.experiment_id)

--- a/server/services/databricks_service.py
+++ b/server/services/databricks_service.py
@@ -235,6 +235,36 @@ def _normalize_databricks_host(host: str | None) -> str | None:
     return normalized
 
 
+def _get_workspace_client():
+    """Build a Databricks SDK client with a normalized host when available."""
+    from databricks.sdk import WorkspaceClient
+
+    host = _normalize_databricks_host(os.getenv("DATABRICKS_HOST"))
+    if host:
+        return WorkspaceClient(host=host)
+    return WorkspaceClient()
+
+
+def normalize_databricks_auth_env_once() -> None:
+    """Normalize Databricks auth env during worker startup.
+
+    Databricks Apps should already provide a fully-qualified ``DATABRICKS_HOST``.
+    This is a defensive local/dev normalization so SDK clients that construct
+    themselves from environment variables see a scheme-safe host.
+    """
+    host = _normalize_databricks_host(os.getenv("DATABRICKS_HOST"))
+    if host and host != os.getenv("DATABRICKS_HOST"):
+        os.environ["DATABRICKS_HOST"] = host
+
+
+def configure_databricks_mlflow_once() -> None:
+    """Configure MLflow Databricks tracking during worker startup."""
+    import mlflow
+
+    normalize_databricks_auth_env_once()
+    mlflow.set_tracking_uri("databricks")
+
+
 def normalize_experiment_id(experiment_id: str | None) -> str | None:
     """Normalize MLflow experiment IDs from env/form inputs.
 
@@ -261,9 +291,7 @@ def _get_sdk_token() -> str | None:
     Locally, the SDK uses CLI profile auth.
     """
     try:
-        from databricks.sdk import WorkspaceClient
-
-        w = WorkspaceClient()
+        w = _get_workspace_client()
         headers = w.config.authenticate()
         auth_header = headers.get("Authorization", "")
         if auth_header.startswith("Bearer "):
@@ -313,9 +341,7 @@ def get_databricks_host() -> str:
     if host:
         return host
     try:
-        from databricks.sdk import WorkspaceClient
-
-        w = WorkspaceClient()
+        w = _get_workspace_client()
         host = _normalize_databricks_host(w.config.host)
         if host:
             return host

--- a/server/services/discovery_dspy.py
+++ b/server/services/discovery_dspy.py
@@ -17,6 +17,8 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
+from server.services.databricks_service import _normalize_databricks_host
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -51,16 +53,6 @@ def _maybe_enable_mlflow_dspy_autolog() -> None:
 
         try:
             import mlflow
-
-            # If the user didn't explicitly set a tracking URI, default to Databricks for
-            # this dev-only experiment-id based tracing. This avoids accidentally creating
-            # a local SQLite-backed MLflow store (which would never write to a Databricks
-            # experiment id).
-            if not (os.getenv("MLFLOW_TRACKING_URI") or "").strip():
-                try:
-                    mlflow.set_tracking_uri("databricks")
-                except Exception as exc:
-                    logger.debug("Failed to set MLflow tracking URI to databricks: %s", exc)
 
             # Pin to the requested experiment id for these dev traces.
             # (If the tracking URI/credentials aren't configured, this will throw;
@@ -244,13 +236,14 @@ def _get_sdk_token(workspace_url: str | None = None) -> str | None:
         from databricks.sdk import WorkspaceClient
 
         # Try platform / default SDK credentials first (Databricks Apps + local CLI)
-        w = WorkspaceClient()
+        default_host = _normalize_databricks_host(os.getenv("DATABRICKS_HOST"))
+        w = WorkspaceClient(host=default_host) if default_host else WorkspaceClient()
         headers = w.config.authenticate()
         auth_header = headers.get("Authorization", "")
         if auth_header.startswith("Bearer "):
             # If a workspace_url was given, verify the SDK host matches
-            sdk_host = (w.config.host or "").rstrip("/")
-            target_host = (workspace_url or "").rstrip("/")
+            sdk_host = _normalize_databricks_host(w.config.host)
+            target_host = _normalize_databricks_host(workspace_url)
             if target_host and sdk_host and sdk_host.lower() != target_host.lower():
                 # Host mismatch — retry with explicit host
                 logger.debug(
@@ -258,7 +251,7 @@ def _get_sdk_token(workspace_url: str | None = None) -> str | None:
                     sdk_host,
                     target_host,
                 )
-                w2 = WorkspaceClient(host=workspace_url)
+                w2 = WorkspaceClient(host=target_host)
                 headers2 = w2.config.authenticate()
                 auth2 = headers2.get("Authorization", "")
                 if auth2.startswith("Bearer "):

--- a/server/services/judge_service.py
+++ b/server/services/judge_service.py
@@ -279,10 +279,6 @@ class JudgeService:
         """Evaluate using real MLflow LLM judge."""
         # Initialize MLflow with proper experiment context
         try:
-            # Use same method as intake service - "databricks" URI with environment variables
-            # This leverages databricks-sdk for authentication which works reliably
-            mlflow.set_tracking_uri("databricks")
-
             # Use existing experiment from MLflow config instead of creating new ones
             # NOTE: Default experiment ID '0' often requires special permissions in Databricks
             if hasattr(mlflow_config, "experiment_id") and mlflow_config.experiment_id:

--- a/server/services/mlflow_intake_service.py
+++ b/server/services/mlflow_intake_service.py
@@ -35,13 +35,8 @@ class MLflowIntakeService:
     self.db_service = db_service
 
   def configure_mlflow(self) -> None:
-    """Configure MLflow for Databricks.
-
-    Auth is handled by the Databricks SDK — service principal on Apps,
-    CLI profile locally.  DATABRICKS_HOST and auth credentials are
-    already in the environment.
-    """
-    mlflow.set_tracking_uri('databricks')
+    """MLflow is configured once during worker startup."""
+    return None
 
   def search_traces(self, config: MLflowIntakeConfig) -> List[MLflowTraceInfo]:
     """Search for traces in MLflow experiment with proper error handling."""

--- a/tests/unit/services/test_databricks_service.py
+++ b/tests/unit/services/test_databricks_service.py
@@ -1,5 +1,10 @@
 import json
+import os
+import inspect
+import sys
+import types
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import httpx
@@ -14,6 +19,8 @@ from server.services.databricks_service import (
     get_databricks_host,
     get_experiment_id,
     normalize_experiment_id,
+    configure_databricks_mlflow_once,
+    normalize_databricks_auth_env_once,
 )
 
 
@@ -41,6 +48,61 @@ def test_get_databricks_host_adds_https_when_scheme_missing(monkeypatch):
 def test_get_databricks_host_preserves_existing_scheme(monkeypatch):
     monkeypatch.setenv("DATABRICKS_HOST", "https://dbc-example.cloud.databricks.com/")
     assert get_databricks_host() == "https://dbc-example.cloud.databricks.com"
+
+
+def test_sdk_token_uses_normalized_host_for_m2m_auth(monkeypatch):
+    created_hosts = []
+
+    class FakeWorkspaceClient:
+        def __init__(self, host=None):
+            created_hosts.append(host)
+            self.config = SimpleNamespace(
+                host=host,
+                authenticate=lambda: {"Authorization": "Bearer sdk-token"},
+            )
+
+    sdk_module = types.ModuleType("databricks.sdk")
+    sdk_module.WorkspaceClient = FakeWorkspaceClient
+    monkeypatch.setitem(sys.modules, "databricks", types.ModuleType("databricks"))
+    monkeypatch.setitem(sys.modules, "databricks.sdk", sdk_module)
+    monkeypatch.setenv("DATABRICKS_HOST", "adb-1234567890123456.7.azuredatabricks.net/")
+
+    assert databricks_module._get_sdk_token() == "sdk-token"
+    assert created_hosts == ["https://adb-1234567890123456.7.azuredatabricks.net"]
+
+
+def test_normalize_databricks_auth_env_once_normalizes_host_without_token(monkeypatch):
+    monkeypatch.delenv("DATABRICKS_TOKEN", raising=False)
+    monkeypatch.setenv("DATABRICKS_HOST", "dbc-example.cloud.databricks.com/")
+
+    normalize_databricks_auth_env_once()
+
+    assert "DATABRICKS_TOKEN" not in os.environ
+    assert os.environ["DATABRICKS_HOST"] == "https://dbc-example.cloud.databricks.com"
+
+
+def test_configure_databricks_mlflow_once_normalizes_host_before_mlflow(monkeypatch):
+    calls = []
+
+    class FakeMlflow:
+        @staticmethod
+        def set_tracking_uri(uri):
+            calls.append((uri, os.environ.get("DATABRICKS_HOST")))
+
+    monkeypatch.setitem(sys.modules, "mlflow", FakeMlflow)
+    monkeypatch.setenv("DATABRICKS_HOST", "adb-1234567890123456.7.azuredatabricks.net/")
+
+    configure_databricks_mlflow_once()
+
+    assert calls == [("databricks", "https://adb-1234567890123456.7.azuredatabricks.net")]
+
+
+def test_databricks_auth_env_normalized_from_app_lifespan():
+    import server.app as app_module
+
+    source = inspect.getsource(app_module.lifespan)
+
+    assert "configure_databricks_mlflow_once()" in source
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/test_discovery_dspy_litellm_interop.py
+++ b/tests/unit/services/test_discovery_dspy_litellm_interop.py
@@ -9,6 +9,10 @@ params per-model so the same code path works across Claude 4.6/4.7, the
 gpt-5 family, and Gemini Flash 3.5 when served via Databricks.
 """
 
+import sys
+import types
+from types import SimpleNamespace
+
 import pytest
 
 import server.services.discovery_dspy as dspy_module
@@ -80,3 +84,29 @@ def test_import_dspy_configures_litellm(reset_litellm_configured, monkeypatch):
         assert litellm.drop_params is True
     finally:
         litellm.drop_params = original
+
+
+@pytest.mark.spec("JUDGE_EVALUATION_SPEC")
+@pytest.mark.req("Judge tuning can use Databricks M2M OAuth credentials")
+@pytest.mark.unit
+def test_get_sdk_token_normalizes_env_host_for_m2m_token_url(monkeypatch):
+    """The Databricks SDK builds the M2M token URL from host; env hosts
+    without a scheme must be normalized before SDK auth runs."""
+    created_hosts = []
+
+    class FakeWorkspaceClient:
+        def __init__(self, host=None):
+            created_hosts.append(host)
+            self.config = SimpleNamespace(
+                host=host,
+                authenticate=lambda: {"Authorization": "Bearer judge-token"},
+            )
+
+    sdk_module = types.ModuleType("databricks.sdk")
+    sdk_module.WorkspaceClient = FakeWorkspaceClient
+    monkeypatch.setitem(sys.modules, "databricks", types.ModuleType("databricks"))
+    monkeypatch.setitem(sys.modules, "databricks.sdk", sdk_module)
+    monkeypatch.setenv("DATABRICKS_HOST", "dbc-example.cloud.databricks.com/")
+
+    assert dspy_module._get_sdk_token("https://dbc-example.cloud.databricks.com") == "judge-token"
+    assert created_hosts == ["https://dbc-example.cloud.databricks.com"]


### PR DESCRIPTION
## Summary
- configure Databricks MLflow tracking once during worker startup
- centralize Databricks host normalization in databricks_service and reuse it from DSPy
- remove per-service mlflow.set_tracking_uri calls from judge/alignment/eval paths
- add regression coverage for normalized M2M auth host handling

## Tests
- .venv/bin/pytest tests/unit/services/test_databricks_service.py::test_sdk_token_uses_normalized_host_for_m2m_auth tests/unit/services/test_databricks_service.py::test_normalize_databricks_auth_env_once_normalizes_host_without_token tests/unit/services/test_databricks_service.py::test_configure_databricks_mlflow_once_normalizes_host_before_mlflow tests/unit/services/test_databricks_service.py::test_databricks_auth_env_normalized_from_app_lifespan tests/unit/services/test_discovery_dspy_litellm_interop.py::test_get_sdk_token_normalizes_env_host_for_m2m_token_url tests/unit/services/test_alignment_service.py -q --no-cov

Fixes #160